### PR TITLE
Improve draft recovery and timeline resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,10 @@ Service. It does not store them in the YAML config file. Run `xeet logout` to
 delete the saved session. This removes Xeet's copy but does not log your browser
 out of X. Run `xeet auth` again whenever you want to reconnect.
 
-X rotates the internal `CreateTweet` id periodically; xeet discovers the current
-one automatically and caches it. If discovery fails, Xeet explains how to set
-it manually from the `CreateTweet` request in browser developer tools.
+X rotates internal GraphQL operation ids periodically; xeet discovers and
+caches current ids for posting, timelines, likes, and unlikes. If CreateTweet
+discovery fails, Xeet explains how to set it manually from the `CreateTweet`
+request in browser developer tools.
 
 CreateTweet mutations are never retried after a transient or ambiguous outcome.
 (A request explicitly rejected as an unknown persisted-query id is refreshed
@@ -133,6 +134,11 @@ draft or session cookies.
 Up to four PNG, JPEG, GIF, or WebP images can be attached. The composer shows
 the real format, dimensions, and size before anything is uploaded.
 
+Unfinished composer drafts are autosaved and offered again the next time the
+composer opens. File attachments are restored from their original paths;
+clipboard images are copied into a private local draft directory so they can be
+restored too. A successful post or an explicit discard removes the saved draft.
+
 On Wayland, install `wl-clipboard` for clipboard image paste and link copying.
 X11 and XWayland use the system X11 clipboard. In SSH or headless sessions,
 clipboard operations degrade gracefully and `Ctrl+O` file attachment remains
@@ -149,7 +155,8 @@ xeet timeline         # explicit timeline command
 
 Use **j/k** or the arrow keys to move (**Ctrl+D/U** jumps five posts),
 **Enter** to read a truncated post in full, **i** to zoom the selected post's
-image to the whole terminal, **l** to like or unlike, **r** to reply in
+image to the whole terminal, **A** to read descriptions for all attached images
+(even when previews are off), **l** to like or unlike, **r** to reply in
 place, **o** to open the post in the browser, **y** to copy its link,
 and **P** to write a new post. **R** refreshes in place: new posts stack on
 top while you keep your position. More posts load automatically near the

--- a/TODO.md
+++ b/TODO.md
@@ -17,13 +17,14 @@
 - Lazy inline truecolor image previews in the timeline
 - multi-image timeline collages and optional native Kitty/iTerm2 previews
 - Bounded API retries, rate-limit errors, session-expiry detection, and cookie-leak tests
+- Draft autosave and restore across process exits, including clipboard images
+- Actionable offline, timeout, service outage, rate-limit, and expired-session recovery
+- Persistent operation-ID caching for posting, timelines, likes, and unlikes
+- Keyboard-accessible image descriptions, including text-only mode
 
 ## Next
 
-- Draft autosave and restore across process exits
 - `xeet whoami` session/account display
-- Graceful offline handling
-- Accessible image alt text
 - Following timeline option
 - Configurable theme without changing layout
 - Chunked upload for video and large media

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -61,10 +61,12 @@ func runAuth(cmd *cobra.Command, args []string) error {
 	candidate.SessionImported = time.Now()
 	ctx, cancel := context.WithTimeout(cmd.Context(), 45*time.Second)
 	defer cancel()
-	handle, err := api.NewWebClient(&candidate).Verify(ctx)
+	client := api.NewWebClient(&candidate)
+	handle, err := client.Verify(ctx)
 	if err != nil {
 		return fmt.Errorf("session found in %s but X rejected verification: %w", browser, err)
 	}
+	client.ApplyRefreshedQueryIDs(&candidate)
 	if err := configMgr.Save(&candidate); err != nil {
 		return err
 	}

--- a/cmd/post.go
+++ b/cmd/post.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -77,7 +76,7 @@ func runPost(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	ctx := context.Background()
+	ctx := cmd.Context()
 
 	if cfg.AuthToken == "" {
 		return fmt.Errorf("run 'xeet auth' first")
@@ -106,9 +105,8 @@ func runPost(cmd *cobra.Command, args []string) error {
 		}
 		return err
 	}
-	// Cache a freshly discovered query id so we don't rediscover next time.
-	if client.Refreshed() {
-		cfg.CreateTweetQID = client.QueryID()
+	// Cache freshly discovered operation ids so later commands avoid discovery.
+	if client.ApplyRefreshedQueryIDs(cfg) {
 		_ = configMgr.Save(cfg)
 	}
 	if id != "" {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 
 	"xeet/internal/tui"
@@ -24,6 +25,8 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() error { return rootCmd.Execute() }
+
+func ExecuteContext(ctx context.Context) error { return rootCmd.ExecuteContext(ctx) }
 
 func SetVersion(version, commit, buildTime string) {
 	appVersion = version
@@ -55,5 +58,5 @@ func runRoot(cmd *cobra.Command, args []string) error {
 	if barebones {
 		imageMode = "off"
 	}
-	return runTimeline(imageMode)
+	return runTimeline(cmd.Context(), imageMode)
 }

--- a/cmd/timeline.go
+++ b/cmd/timeline.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 
 	"xeet/internal/timeline"
@@ -15,7 +16,7 @@ var timelineCmd = &cobra.Command{
 	Use:   "timeline",
 	Short: "Browse your X home timeline",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runTimeline(timelineImageMode)
+		return runTimeline(cmd.Context(), timelineImageMode)
 	},
 }
 
@@ -24,7 +25,7 @@ func init() {
 	rootCmd.AddCommand(timelineCmd)
 }
 
-func runTimeline(imageMode string) error {
+func runTimeline(ctx context.Context, imageMode string) error {
 	switch imageMode {
 	case "auto", "native", "ansi", "off":
 	default:
@@ -35,11 +36,19 @@ func runTimeline(imageMode string) error {
 		if err != nil {
 			return err
 		}
-		if action.Kind != timeline.ActionCompose {
+		switch action.Kind {
+		case timeline.ActionCompose:
+			if err := tui.Run(); err != nil {
+				return err
+			}
+		case timeline.ActionAuthenticate:
+			authInvocation := &cobra.Command{}
+			authInvocation.SetContext(ctx)
+			if err := runAuth(authInvocation, nil); err != nil {
+				return err
+			}
+		default:
 			return nil
-		}
-		if err := tui.Run(); err != nil {
-			return err
 		}
 	}
 }

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -34,6 +34,7 @@ type ActionKind int
 const (
 	ActionQuit ActionKind = iota
 	ActionCompose
+	ActionAuthenticate
 )
 
 type Action struct{ Kind ActionKind }
@@ -58,6 +59,7 @@ type Model struct {
 	loadingMore   bool
 	refreshing    bool
 	help          bool
+	altText       bool
 	expanded      bool
 	zoom          bool
 	action        Action
@@ -199,7 +201,11 @@ func fetchPage(cursor string, more bool) tea.Cmd {
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
 		defer cancel()
-		page, err := api.NewWebClient(cfg).FetchHomeTimeline(ctx, cursor, 30)
+		client := api.NewWebClient(cfg)
+		page, err := client.FetchHomeTimeline(ctx, cursor, 30)
+		if client.ApplyRefreshedQueryIDs(cfg) {
+			_ = mgr.Save(cfg)
+		}
 		return pageMsg{page: page, err: err, more: more}
 	}
 }
@@ -216,7 +222,11 @@ func setLike(tweetID string, liked bool) tea.Cmd {
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		err = api.NewWebClient(cfg).SetTweetLiked(ctx, tweetID, liked)
+		client := api.NewWebClient(cfg)
+		err = client.SetTweetLiked(ctx, tweetID, liked)
+		if client.ApplyRefreshedQueryIDs(cfg) {
+			_ = mgr.Save(cfg)
+		}
 		return likeMsg{id: tweetID, liked: liked, err: err}
 	}
 }
@@ -235,8 +245,7 @@ func sendReply(tweetID, text string) tea.Cmd {
 		defer cancel()
 		client := api.NewWebClient(cfg)
 		id, err := client.PostTweet(ctx, text, tweetID, nil, nil)
-		if err == nil && client.Refreshed() {
-			cfg.CreateTweetQID = client.QueryID()
+		if client.ApplyRefreshedQueryIDs(cfg) {
 			_ = mgr.Save(cfg)
 		}
 		return replyResultMsg{id: id, err: err}
@@ -269,6 +278,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, tea.Quit
 			case "?", "esc", "enter":
 				m.help = false
+				return m, m.imageRepaint()
+			}
+		}
+		return m, nil
+	}
+	if m.altText {
+		if key, ok := msg.(tea.KeyMsg); ok {
+			switch key.String() {
+			case "q", "ctrl+c":
+				return m, tea.Quit
+			case "A", "esc", "enter":
+				m.altText = false
 				return m, m.imageRepaint()
 			}
 		}
@@ -439,6 +460,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.resize()
 			return m, m.imageRepaint(m.replyEditor.Focus())
 		}
+	case "a":
+		if errors.Is(m.err, api.ErrSessionExpired) {
+			m.action = Action{Kind: ActionAuthenticate}
+			return m, tea.Quit
+		}
 	case "P", "c":
 		m.action = Action{Kind: ActionCompose}
 		return m, tea.Quit
@@ -452,6 +478,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case "o":
 		if post, ok := m.currentPost(); ok {
 			return m, openURL(postURL(post))
+		}
+	case "A":
+		if post, ok := m.currentPost(); ok && len(post.Media) > 0 {
+			m.altText = true
+			return m, m.imageRepaint()
 		}
 	case "i":
 		if post, ok := m.currentPost(); ok && len(post.Media) > 0 {

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -60,6 +60,7 @@ type Model struct {
 	refreshing    bool
 	help          bool
 	altText       bool
+	altTextScroll int
 	expanded      bool
 	zoom          bool
 	action        Action
@@ -291,9 +292,24 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case "A", "esc", "enter":
 				m.altText = false
 				return m, m.imageRepaint()
+			case "j", "down":
+				m.moveAltText(1)
+			case "k", "up":
+				m.moveAltText(-1)
+			case "pgdown", "ctrl+d":
+				m.moveAltText(m.altTextVisibleRows())
+			case "pgup", "ctrl+u":
+				m.moveAltText(-m.altTextVisibleRows())
+			case "home", "g":
+				m.altTextScroll = 0
+			case "end", "G":
+				m.altTextScroll = m.altTextMaxScroll()
 			}
+			// Panel keys must not trigger actions in the feed underneath it.
+			return m, nil
 		}
-		return m, nil
+		// Background results (likes, pages, and previews) must still reach the
+		// normal handlers while the panel is open.
 	}
 	if m.zoom {
 		// Keys close the zoom view; everything else (preview arrivals,
@@ -482,6 +498,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case "A":
 		if post, ok := m.currentPost(); ok && len(post.Media) > 0 {
 			m.altText = true
+			m.altTextScroll = 0
 			return m, m.imageRepaint()
 		}
 	case "i":
@@ -516,6 +533,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 	return m, nil
+}
+
+func (m *Model) moveAltText(delta int) {
+	m.altTextScroll = max(0, min(m.altTextMaxScroll(), m.altTextScroll+delta))
 }
 
 func (m *Model) moveSelection(target int) {

--- a/internal/timeline/model_test.go
+++ b/internal/timeline/model_test.go
@@ -124,6 +124,40 @@ func TestAltTextPanelListsEveryImageWithoutRenderer(t *testing.T) {
 	}
 }
 
+func TestAltTextPanelScrollsLongDescriptions(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.loading = false
+	m.height = 12
+	m.posts = []api.TimelinePost{{ID: "1", Media: []api.TimelineMedia{{
+		AltText: strings.Repeat("a long accessible description ", 30),
+	}}}}
+	m.altText = true
+	before := m.View()
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyDown})
+	if m.altTextScroll != 1 {
+		t.Fatalf("scroll=%d, want 1", m.altTextScroll)
+	}
+	if after := m.View(); after == before || !strings.Contains(after, "↑/↓ scroll") {
+		t.Fatalf("long alt text did not scroll:\n%s", after)
+	}
+}
+
+func TestAltTextPanelProcessesBackgroundResults(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.loading = false
+	m.altText = true
+	m.posts = []api.TimelinePost{{ID: "1", Liked: true, LikeCount: 1, Media: []api.TimelineMedia{{}}}}
+	m.liking["1"] = true
+	next, _ := m.Update(likeMsg{id: "1", liked: true, err: errors.New("rejected")})
+	m = next.(Model)
+	if !m.altText {
+		t.Fatal("background result unexpectedly closed alt text")
+	}
+	if m.liking["1"] || m.posts[0].Liked || m.posts[0].LikeCount != 0 {
+		t.Fatalf("like result was dropped: liking=%v post=%+v", m.liking, m.posts[0])
+	}
+}
+
 func TestRefreshKey(t *testing.T) {
 	m := New()
 	m.loading = false

--- a/internal/timeline/model_test.go
+++ b/internal/timeline/model_test.go
@@ -76,6 +76,54 @@ func TestPostAction(t *testing.T) {
 	}
 }
 
+func TestExpiredSessionOffersReconnectAction(t *testing.T) {
+	m := New()
+	m.loading = false
+	m.err = api.ErrSessionExpired
+	if view := m.View(); !strings.Contains(view, "a reconnect") || !strings.Contains(view, "xeet auth") {
+		t.Fatalf("expired-session guidance missing: %s", view)
+	}
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	m = next.(Model)
+	if m.action.Kind != ActionAuthenticate || cmd == nil {
+		t.Fatal("a did not start reconnect flow")
+	}
+}
+
+func TestReconnectKeyIgnoredForOtherErrors(t *testing.T) {
+	m := New()
+	m.loading = false
+	m.err = &api.ConnectionError{Kind: "offline", Err: errors.New("offline")}
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	m = next.(Model)
+	if m.action.Kind == ActionAuthenticate || cmd != nil {
+		t.Fatal("a unexpectedly started reconnect flow for a network error")
+	}
+}
+
+func TestAltTextPanelListsEveryImageWithoutRenderer(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.loading = false
+	m.posts = []api.TimelinePost{{ID: "1", Text: "photos", AuthorName: "Alice", Handle: "alice", Media: []api.TimelineMedia{
+		{AltText: "a cat on a windowsill"}, {},
+	}}}
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'A'}})
+	m = next.(Model)
+	if !m.altText || cmd != nil {
+		t.Fatalf("alt panel did not open: altText=%v cmd=%v", m.altText, cmd)
+	}
+	view := m.View()
+	for _, want := range []string{"image 1 of 2", "a cat on a windowsill", "image 2 of 2", "No alt text was provided"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("alt panel missing %q: %s", want, view)
+		}
+	}
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyEsc})
+	if m.altText {
+		t.Fatal("alt panel did not close")
+	}
+}
+
 func TestRefreshKey(t *testing.T) {
 	m := New()
 	m.loading = false

--- a/internal/timeline/view.go
+++ b/internal/timeline/view.go
@@ -421,32 +421,70 @@ func (m Model) viewZoom() string {
 		lipgloss.JoinVertical(lipgloss.Center, parts...))
 }
 
-func (m Model) viewAltText() string {
+func (m Model) altTextPanelWidth() int {
+	return min(64, max(28, m.width-8))
+}
+
+func (m Model) altTextVisibleRows() int {
+	// Border, padding, title, account, spacer, and footer consume eight rows.
+	return max(1, m.height-8)
+}
+
+func (m Model) altTextRows() []string {
 	post, ok := m.currentPost()
-	if !ok || len(post.Media) == 0 {
-		return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center,
-			lipgloss.NewStyle().Foreground(muted).Render("this post has no images"))
+	if !ok {
+		return nil
 	}
-	w := min(64, max(28, m.width-8))
-	name := post.AuthorName
-	if name == "" {
-		name = "someone"
-	}
-	rows := []string{lipgloss.NewStyle().Foreground(pink).Bold(true).Render("image descriptions"),
-		lipgloss.NewStyle().Foreground(muted).Render(name + "  @" + post.Handle), ""}
+	width := m.altTextPanelWidth() - 6
+	var rows []string
 	for index, item := range post.Media {
 		description := strings.TrimSpace(item.AltText)
 		if description == "" {
 			description = "No alt text was provided."
 		}
 		label := fmt.Sprintf("image %d of %d", index+1, len(post.Media))
-		rows = append(rows,
-			lipgloss.NewStyle().Foreground(blue).Bold(true).Render(label),
-			lipgloss.NewStyle().Foreground(bright).Width(w-6).Render(description), "")
+		rows = append(rows, lipgloss.NewStyle().Foreground(blue).Bold(true).Render(label))
+		wrapped := lipgloss.NewStyle().Foreground(bright).Width(width).Render(description)
+		rows = append(rows, strings.Split(wrapped, "\n")...)
+		if index < len(post.Media)-1 {
+			rows = append(rows, "")
+		}
 	}
-	rows = append(rows, lipgloss.NewStyle().Foreground(muted).Render("A, enter, or esc close"))
+	return rows
+}
+
+func (m Model) altTextMaxScroll() int {
+	return max(0, len(m.altTextRows())-m.altTextVisibleRows())
+}
+
+func (m Model) viewAltText() string {
+	post, ok := m.currentPost()
+	if !ok || len(post.Media) == 0 {
+		return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center,
+			lipgloss.NewStyle().Foreground(muted).Render("this post has no images"))
+	}
+	w := m.altTextPanelWidth()
+	name := post.AuthorName
+	if name == "" {
+		name = "someone"
+	}
+	rows := m.altTextRows()
+	start := max(0, min(m.altTextMaxScroll(), m.altTextScroll))
+	end := min(len(rows), start+m.altTextVisibleRows())
+	visible := rows[start:end]
+
+	footer := "A/enter/esc close"
+	if len(rows) > m.altTextVisibleRows() {
+		footer = fmt.Sprintf("↑/↓ scroll  ·  %d-%d/%d  ·  %s", start+1, end, len(rows), footer)
+	}
+	content := []string{
+		lipgloss.NewStyle().Foreground(pink).Bold(true).Render("image descriptions"),
+		lipgloss.NewStyle().Foreground(muted).Render(name + "  @" + post.Handle), "",
+	}
+	content = append(content, visible...)
+	content = append(content, lipgloss.NewStyle().Foreground(muted).Render(footer))
 	box := lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lavender).
-		Padding(1, 2).Width(w).Render(lipgloss.JoinVertical(lipgloss.Left, rows...))
+		Padding(1, 2).Width(w).Render(lipgloss.JoinVertical(lipgloss.Left, content...))
 	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, box)
 }
 

--- a/internal/timeline/view.go
+++ b/internal/timeline/view.go
@@ -19,6 +19,9 @@ func (m Model) View() string {
 	if m.help {
 		return m.viewHelp()
 	}
+	if m.altText {
+		return m.viewAltText()
+	}
 	if m.zoom {
 		return m.viewZoom()
 	}
@@ -36,7 +39,7 @@ func (m Model) View() string {
 		center := lipgloss.Place(m.viewport.Width, m.viewport.Height, lipgloss.Center, lipgloss.Center,
 			lipgloss.NewStyle().Foreground(red).Width(max(20, m.viewport.Width-8)).Align(lipgloss.Center).
 				Render("the cat lost the timeline\n\n"+m.err.Error()))
-		return m.shell(center, "R retry  ·  q quit")
+		return m.shell(center, m.errorFooter(true))
 	}
 	return m.shell(m.viewport.View(), footer)
 }
@@ -85,7 +88,7 @@ func (m Model) footer() string {
 		return m.toast
 	}
 	if m.err != nil {
-		return "refresh failed  ·  R retry"
+		return m.errorFooter(false)
 	}
 	position := 0
 	if len(m.posts) > 0 {
@@ -98,6 +101,17 @@ func (m Model) footer() string {
 		return fmt.Sprintf("%d/%d · enter collapse · o browser · ? help", position, len(m.posts))
 	}
 	return fmt.Sprintf("%d/%d · enter read · l like · r reply · ? help", position, len(m.posts))
+}
+
+func (m Model) errorFooter(includeQuit bool) string {
+	parts := []string{"R retry"}
+	if errors.Is(m.err, api.ErrSessionExpired) {
+		parts = append([]string{"a reconnect"}, parts...)
+	}
+	if includeQuit {
+		parts = append(parts, "q quit")
+	}
+	return strings.Join(parts, "  ·  ")
 }
 
 func (m Model) renderFeedContent() (string, []int, []int) {
@@ -407,14 +421,43 @@ func (m Model) viewZoom() string {
 		lipgloss.JoinVertical(lipgloss.Center, parts...))
 }
 
+func (m Model) viewAltText() string {
+	post, ok := m.currentPost()
+	if !ok || len(post.Media) == 0 {
+		return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center,
+			lipgloss.NewStyle().Foreground(muted).Render("this post has no images"))
+	}
+	w := min(64, max(28, m.width-8))
+	name := post.AuthorName
+	if name == "" {
+		name = "someone"
+	}
+	rows := []string{lipgloss.NewStyle().Foreground(pink).Bold(true).Render("image descriptions"),
+		lipgloss.NewStyle().Foreground(muted).Render(name + "  @" + post.Handle), ""}
+	for index, item := range post.Media {
+		description := strings.TrimSpace(item.AltText)
+		if description == "" {
+			description = "No alt text was provided."
+		}
+		label := fmt.Sprintf("image %d of %d", index+1, len(post.Media))
+		rows = append(rows,
+			lipgloss.NewStyle().Foreground(blue).Bold(true).Render(label),
+			lipgloss.NewStyle().Foreground(bright).Width(w-6).Render(description), "")
+	}
+	rows = append(rows, lipgloss.NewStyle().Foreground(muted).Render("A, enter, or esc close"))
+	box := lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lavender).
+		Padding(1, 2).Width(w).Render(lipgloss.JoinVertical(lipgloss.Left, rows...))
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, box)
+}
+
 func (m Model) viewHelp() string {
 	w := m.contentWidth()
 	if w > 54 {
 		w = 54
 	}
-	keys := "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nl           like / unlike\nr           reply\nR           refresh\nenter       read full post\ni           zoom image\no           open in browser\ny           copy link\nP           new post\ng / G       top / bottom\nctrl+l      redraw screen\nq           quit"
+	keys := "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nl           like / unlike\nr           reply\nR           refresh\nenter       read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\nP           new post\ng / G       top / bottom\nctrl+l      redraw screen\nq           quit"
 	if m.height < 25 {
-		keys = "\n\nj/k move · g/G ends\nl like · r reply · y copy\nenter read · i zoom\nR refresh · o browser\nP compose · ctrl+l redraw\nq quit"
+		keys = "\n\nj/k move · g/G ends\nl like · r reply · y copy\nenter read · i zoom · A alt text\nR refresh · o browser\nP compose · ctrl+l redraw\nq quit"
 	}
 	images := "images: " + string(m.imageMode)
 	if m.imageNote != "" && m.height >= 28 {

--- a/internal/tui/draft.go
+++ b/internal/tui/draft.go
@@ -1,0 +1,262 @@
+package tui
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"xeet/internal/media"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+const draftVersion = 1
+
+type savedDraft struct {
+	Version     int               `json:"version"`
+	Text        string            `json:"text,omitempty"`
+	Attachments []savedAttachment `json:"attachments,omitempty"`
+}
+
+type savedAttachment struct {
+	Path string `json:"path"`
+}
+
+type draftStore interface {
+	Load() (string, []media.Attachment, error)
+	Save(string, []media.Attachment) error
+	Clear() error
+}
+
+type saveDraftMsg struct{ seq int }
+
+func (m *Model) scheduleDraftSave() tea.Cmd {
+	m.draftSeq++
+	seq := m.draftSeq
+	return tea.Tick(400*time.Millisecond, func(time.Time) tea.Msg { return saveDraftMsg{seq: seq} })
+}
+
+func (m *Model) saveDraft() error {
+	return m.drafts.Save(m.editor.Value(), append([]media.Attachment(nil), m.attachments...))
+}
+
+type memorylessDraftStore struct{}
+
+func (memorylessDraftStore) Load() (string, []media.Attachment, error) { return "", nil, nil }
+func (memorylessDraftStore) Save(string, []media.Attachment) error     { return nil }
+func (memorylessDraftStore) Clear() error                              { return nil }
+
+type fileDraftStore struct {
+	path     string
+	mediaDir string
+}
+
+func newFileDraftStore() (*fileDraftStore, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	return newFileDraftStoreAt(home), nil
+}
+
+func newFileDraftStoreAt(home string) *fileDraftStore {
+	return &fileDraftStore{
+		path:     filepath.Join(home, ".xeet-draft.json"),
+		mediaDir: filepath.Join(home, ".xeet-draft-media"),
+	}
+}
+
+func (s *fileDraftStore) Load() (string, []media.Attachment, error) {
+	data, err := readRegularFile(s.path)
+	if os.IsNotExist(err) {
+		return "", nil, nil
+	}
+	if err != nil {
+		return "", nil, fmt.Errorf("read saved draft: %w", err)
+	}
+	var draft savedDraft
+	if err := json.Unmarshal(data, &draft); err != nil {
+		return "", nil, fmt.Errorf("read saved draft: %w", err)
+	}
+	if draft.Version != draftVersion {
+		return "", nil, fmt.Errorf("saved draft has unsupported version %d", draft.Version)
+	}
+	attachments := make([]media.Attachment, 0, len(draft.Attachments))
+	var skipped int
+	for _, saved := range draft.Attachments {
+		if len(attachments) == media.MaxAttachments {
+			break
+		}
+		attachment, loadErr := media.FromPath(saved.Path)
+		if loadErr != nil {
+			skipped++
+			continue
+		}
+		attachments = append(attachments, attachment)
+	}
+	if skipped > 0 {
+		return draft.Text, attachments, fmt.Errorf("%d saved image attachment(s) are no longer available", skipped)
+	}
+	return draft.Text, attachments, nil
+}
+
+func (s *fileDraftStore) Save(text string, attachments []media.Attachment) error {
+	if strings.TrimSpace(text) == "" && len(attachments) == 0 {
+		return s.Clear()
+	}
+	if err := rejectSymlink(s.path); err != nil {
+		return err
+	}
+
+	draft := savedDraft{Version: draftVersion, Text: text}
+	keep := make(map[string]bool)
+	for _, attachment := range attachments {
+		path := attachment.Path
+		if attachment.Source == media.SourceClipboard || path == "" {
+			var err error
+			path, err = s.saveClipboardAttachment(attachment)
+			if err != nil {
+				return err
+			}
+		}
+		if filepath.Dir(path) == s.mediaDir {
+			keep[path] = true
+		}
+		draft.Attachments = append(draft.Attachments, savedAttachment{Path: path})
+	}
+	data, err := json.MarshalIndent(draft, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if err := atomicWrite0600(s.path, data); err != nil {
+		return fmt.Errorf("save draft: %w", err)
+	}
+	return s.cleanMedia(keep)
+}
+
+func (s *fileDraftStore) saveClipboardAttachment(attachment media.Attachment) (string, error) {
+	if len(attachment.Data) == 0 {
+		return "", fmt.Errorf("save clipboard attachment %q: image data is empty", attachment.Name)
+	}
+	if err := ensurePrivateDirectory(s.mediaDir); err != nil {
+		return "", fmt.Errorf("create draft media directory: %w", err)
+	}
+	ext := strings.ToLower(attachment.Format)
+	if ext == "jpeg" {
+		ext = "jpg"
+	}
+	if ext == "" {
+		ext = "image"
+	}
+	path := filepath.Join(s.mediaDir, attachment.ID+"."+ext)
+	if err := rejectSymlink(path); err != nil {
+		return "", err
+	}
+	if err := atomicWrite0600(path, attachment.Data); err != nil {
+		return "", fmt.Errorf("save clipboard attachment: %w", err)
+	}
+	return path, nil
+}
+
+func (s *fileDraftStore) Clear() error {
+	var result error
+	if err := os.Remove(s.path); err != nil && !os.IsNotExist(err) {
+		result = errors.Join(result, err)
+	}
+	if err := os.RemoveAll(s.mediaDir); err != nil {
+		result = errors.Join(result, err)
+	}
+	return result
+}
+
+func (s *fileDraftStore) cleanMedia(keep map[string]bool) error {
+	entries, err := os.ReadDir(s.mediaDir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		path := filepath.Join(s.mediaDir, entry.Name())
+		if !keep[path] {
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func ensurePrivateDirectory(path string) error {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return os.Mkdir(path, 0700)
+	}
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s is not a directory; refusing to use it", path)
+	}
+	return os.Chmod(path, 0700)
+}
+
+func readRegularFile(path string) ([]byte, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s is not a regular file", path)
+	}
+	return os.ReadFile(path)
+}
+
+func rejectSymlink(path string) error {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s is a symlink; refusing to replace it", path)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%s is not a regular file", path)
+	}
+	return nil
+}
+
+func atomicWrite0600(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".xeet-draft-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(0600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/internal/tui/draft_test.go
+++ b/internal/tui/draft_test.go
@@ -1,0 +1,204 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"xeet/internal/media"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func writeDraftPNG(t *testing.T, dir, name string, width int) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, pngBytes(t, width), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestFileDraftStoreRoundTrip(t *testing.T) {
+	home := t.TempDir()
+	imagePath := writeDraftPNG(t, home, "photo.png", 7)
+	attachment, err := media.FromPath(imagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := newFileDraftStoreAt(home)
+	if err := store.Save("unfinished words", []media.Attachment{attachment}); err != nil {
+		t.Fatal(err)
+	}
+
+	text, attachments, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if text != "unfinished words" || len(attachments) != 1 || attachments[0].Width != 7 {
+		t.Fatalf("restored text=%q attachments=%+v", text, attachments)
+	}
+	info, err := os.Stat(store.path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0600 {
+		t.Fatalf("draft permissions = %o, want 600", info.Mode().Perm())
+	}
+}
+
+func TestClipboardDraftAttachmentIsPersistedAndCleaned(t *testing.T) {
+	home := t.TempDir()
+	attachment, err := media.FromClipboard(pngBytes(t, 5))
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := newFileDraftStoreAt(home)
+	if err := store.Save("clipboard pic", []media.Attachment{attachment}); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(store.mediaDir)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("draft media entries=%v err=%v", entries, err)
+	}
+
+	text, attachments, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if text != "clipboard pic" || len(attachments) != 1 || attachments[0].Width != 5 {
+		t.Fatalf("restored text=%q attachments=%+v", text, attachments)
+	}
+	// Saving a restored clipboard sidecar must not delete the file referenced
+	// by the newly written draft.
+	if err := store.Save(text, attachments); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(attachments[0].Path); err != nil {
+		t.Fatalf("restored clipboard sidecar was removed: %v", err)
+	}
+	if err := store.Clear(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(store.path); !os.IsNotExist(err) {
+		t.Fatalf("draft file remains after clear: %v", err)
+	}
+	if _, err := os.Stat(store.mediaDir); !os.IsNotExist(err) {
+		t.Fatalf("draft media remains after clear: %v", err)
+	}
+}
+
+func TestDraftLoadPreservesTextWhenAttachmentDisappears(t *testing.T) {
+	home := t.TempDir()
+	path := writeDraftPNG(t, home, "temporary.png", 3)
+	attachment, err := media.FromPath(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := newFileDraftStoreAt(home)
+	if err := store.Save("keep the words", []media.Attachment{attachment}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	text, attachments, err := store.Load()
+	if text != "keep the words" || len(attachments) != 0 || err == nil || !strings.Contains(err.Error(), "no longer available") {
+		t.Fatalf("text=%q attachments=%d err=%v", text, len(attachments), err)
+	}
+}
+
+func TestDraftStoreRefusesSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink setup requires privileges on Windows")
+	}
+	home := t.TempDir()
+	target := filepath.Join(home, "target")
+	if err := os.WriteFile(target, []byte("do not replace"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	store := newFileDraftStoreAt(home)
+	if err := os.Symlink(target, store.path); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Save("secret draft", nil); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink refusal, got %v", err)
+	}
+	data, err := os.ReadFile(target)
+	if err != nil || string(data) != "do not replace" {
+		t.Fatalf("symlink target changed: %q, %v", data, err)
+	}
+}
+
+type recordingDraftStore struct {
+	text        string
+	attachments []media.Attachment
+	saves       int
+	clears      int
+}
+
+func (s *recordingDraftStore) Load() (string, []media.Attachment, error) {
+	return s.text, s.attachments, nil
+}
+func (s *recordingDraftStore) Save(text string, attachments []media.Attachment) error {
+	s.text = text
+	s.attachments = attachments
+	s.saves++
+	return nil
+}
+func (s *recordingDraftStore) Clear() error { s.clears++; return nil }
+
+func TestDraftAutosaveDebouncesAndSuccessClears(t *testing.T) {
+	store := &recordingDraftStore{}
+	m := newWithDraftStore(fakeClipboard{}, store)
+	m.editor.SetValue("first")
+	first := m.scheduleDraftSave()
+	m.editor.SetValue("latest")
+	second := m.scheduleDraftSave()
+
+	m = updateModel(t, m, first())
+	if store.saves != 0 {
+		t.Fatal("stale autosave was written")
+	}
+	m = updateModel(t, m, second())
+	if store.saves != 1 || store.text != "latest" {
+		t.Fatalf("saves=%d text=%q", store.saves, store.text)
+	}
+
+	m.screen = screenPosting
+	m = updateModel(t, m, postResultMsg{id: "123"})
+	if store.clears != 1 || m.screen != screenSuccess {
+		t.Fatalf("clears=%d screen=%v", store.clears, m.screen)
+	}
+}
+
+func TestEmptyComposerClearsAPreviouslySavedDraft(t *testing.T) {
+	store := &recordingDraftStore{text: "stale"}
+	m := newWithDraftStore(fakeClipboard{}, store)
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	_ = next.(Model)
+	if cmd == nil || store.clears != 1 {
+		t.Fatalf("quit command=%v clears=%d", cmd, store.clears)
+	}
+}
+
+func TestQuitDialogCanSaveOrDiscardDraft(t *testing.T) {
+	store := &recordingDraftStore{}
+	m := newWithDraftStore(fakeClipboard{}, store)
+	m.editor.SetValue("come back later")
+	m.dialog = dialogQuit
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if cmd == nil || store.saves != 1 || store.text != "come back later" {
+		t.Fatalf("save quit command=%v saves=%d text=%q", cmd, store.saves, store.text)
+	}
+
+	m.dialog = dialogQuit
+	next, cmd = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	_ = next.(Model)
+	if cmd == nil || store.clears != 1 {
+		t.Fatalf("discard quit command=%v clears=%d", cmd, store.clears)
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -79,11 +79,20 @@ type Model struct {
 	cancelling     bool
 	postID         string
 	clipboard      clipboardReader
+	drafts         draftStore
+	draftSeq       int
 }
 
 func New(clip clipboardReader) Model {
+	return newWithDraftStore(clip, memorylessDraftStore{})
+}
+
+func newWithDraftStore(clip clipboardReader, drafts draftStore) Model {
 	if clip == nil {
 		clip = systemClipboard{initErr: fmt.Errorf("clipboard unavailable")}
+	}
+	if drafts == nil {
+		drafts = memorylessDraftStore{}
 	}
 	editor := textarea.New()
 	editor.Placeholder = "what are you thinking?"
@@ -102,14 +111,28 @@ func New(clip clipboardReader) Model {
 	s := spinner.New()
 	s.Spinner = spinner.Dot
 
-	return Model{width: 72, height: 22, editor: editor, pathInput: path, spinner: s, clipboard: clip}
+	return Model{width: 72, height: 22, editor: editor, pathInput: path, spinner: s, clipboard: clip, drafts: drafts}
 }
 
 func (m Model) Init() tea.Cmd { return textarea.Blink }
 
 func Run() error {
-	m := New(systemClipboard{initErr: clip.Init()})
-	_, err := tea.NewProgram(m, tea.WithAltScreen()).Run()
+	store, err := newFileDraftStore()
+	if err != nil {
+		return fmt.Errorf("initialize draft recovery: %w", err)
+	}
+	m := newWithDraftStore(systemClipboard{initErr: clip.Init()}, store)
+	text, attachments, restoreErr := store.Load()
+	if text != "" || len(attachments) > 0 {
+		m.editor.SetValue(text)
+		m.attachments = attachments
+		m.toast = "Restored your saved draft"
+		m.resize()
+	}
+	if restoreErr != nil {
+		m.toast = restoreErr.Error()
+	}
+	_, err = tea.NewProgram(m, tea.WithAltScreen()).Run()
 	return err
 }
 
@@ -184,8 +207,7 @@ func beginPost(text string, attachments []media.Attachment) tea.Cmd {
 			id, err := client.PostTweet(ctx, text, "", uploads, func(event api.PostEvent) {
 				events <- postProgressMsg{event: event}
 			})
-			if err == nil && client.Refreshed() {
-				cfg.CreateTweetQID = client.QueryID()
+			if client.ApplyRefreshedQueryIDs(cfg) {
 				_ = mgr.Save(cfg)
 			}
 			events <- postResultMsg{id: id, err: err, diagnostic: client.LastDiagnostic()}

--- a/internal/tui/pty_test.go
+++ b/internal/tui/pty_test.go
@@ -98,7 +98,7 @@ func TestComposerPTYUnicodeResizeAndDraftDialog(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 	output := captured.String()
-	for _, want := range []string{"hello", "café", "leave this draft behind?"} {
+	for _, want := range []string{"hello", "café", "save this draft for later?"} {
 		if !strings.Contains(output, want) {
 			t.Errorf("composer PTY output missing %q; output:\n%s", want, output)
 		}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -21,6 +21,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width, m.height = msg.Width, msg.Height
 		m.resize()
 		return m, nil
+	case saveDraftMsg:
+		if msg.seq != m.draftSeq {
+			return m, nil
+		}
+		if err := m.saveDraft(); err != nil {
+			m.toast = "Couldn't autosave draft: " + err.Error()
+		}
+		return m, nil
 	case clipboardMsg:
 		if msg.err != nil {
 			m.lastErr = msg.err
@@ -33,7 +41,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.editor.InsertString(msg.text)
 			m.toast = "Pasted text"
 		}
-		return m, nil
+		return m, m.scheduleDraftSave()
 	case attachmentMsg:
 		if msg.err != nil {
 			m.lastErr = msg.err
@@ -41,7 +49,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.lastErr = nil
 		m.addAttachment(msg.attachment)
-		return m, nil
+		return m, m.scheduleDraftSave()
 	case postStartedMsg:
 		m.postEvents = msg.events
 		m.postCancel = msg.cancel
@@ -68,6 +76,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.postID = msg.id
 		m.postDiagnostic = ""
 		m.postEvents = nil
+		m.draftSeq++
+		if err := m.drafts.Clear(); err != nil {
+			m.toast = "Warning: couldn't clear the saved draft: " + err.Error()
+		} else {
+			m.toast = ""
+		}
 		return m, nil
 	case browserOpenedMsg:
 		if msg.err != nil {
@@ -107,21 +121,24 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if canOpenDraftInX(m.lastErr) && strings.TrimSpace(m.editor.Value()) != "" {
 				return m, openDraftInX(m.editor.Value())
 			}
-		case "ctrl+c":
+		case "ctrl+c", "esc":
 			if m.hasDraft() {
 				m.dialog = dialogQuit
 				return m, nil
 			}
-			return m, tea.Quit
-		case "esc":
-			if m.hasDraft() {
-				m.dialog = dialogQuit
+			m.draftSeq++
+			if err := m.drafts.Clear(); err != nil {
+				m.lastErr = fmt.Errorf("clear empty draft: %w", err)
 				return m, nil
 			}
 			return m, tea.Quit
 		case "enter":
 			if !m.hasDraft() {
 				m.toast = "Write something or attach an image first"
+				return m, nil
+			}
+			if err := m.saveDraft(); err != nil {
+				m.lastErr = fmt.Errorf("save draft before posting: %w", err)
 				return m, nil
 			}
 			m.lastErr = nil
@@ -136,6 +153,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "alt+enter", "ctrl+j":
 			if m.focus == focusEditor {
 				m.editor.InsertString("\n")
+				return m, m.scheduleDraftSave()
 			}
 			return m, nil
 		case "ctrl+v":
@@ -172,6 +190,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			case "backspace", "delete", "ctrl+x":
 				m.removeSelected()
+				return m, m.scheduleDraftSave()
 			case "enter":
 				m.focus = focusEditor
 				return m, m.editor.Focus()
@@ -180,9 +199,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	before := m.editor.Value()
 	var cmd tea.Cmd
 	m.editor, cmd = m.editor.Update(msg)
 	cmds = append(cmds, cmd)
+	if m.editor.Value() != before {
+		cmds = append(cmds, m.scheduleDraftSave())
+	}
 	return m, tea.Batch(cmds...)
 }
 
@@ -208,6 +231,18 @@ func (m Model) updateDialog(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case dialogQuit:
 		switch strings.ToLower(key.String()) {
 		case "y", "enter", "ctrl+c":
+			if err := m.saveDraft(); err != nil {
+				m.dialog = dialogNone
+				m.lastErr = fmt.Errorf("save draft before quitting: %w", err)
+				return m, nil
+			}
+			return m, tea.Quit
+		case "d":
+			if err := m.drafts.Clear(); err != nil {
+				m.dialog = dialogNone
+				m.lastErr = fmt.Errorf("discard saved draft: %w", err)
+				return m, nil
+			}
 			return m, tea.Quit
 		case "n", "esc":
 			m.dialog = dialogNone

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -191,6 +191,9 @@ func (m Model) viewSuccess() string {
 	if m.postID != "" {
 		body += "\n\n" + lipgloss.NewStyle().Width(w).Align(lipgloss.Center).Render("https://x.com/i/status/"+m.postID)
 	}
+	if m.toast != "" {
+		body += "\n\n" + lipgloss.NewStyle().Foreground(red).Width(w).Align(lipgloss.Center).Render(m.toast)
+	}
 	body += "\n\n" + lipgloss.NewStyle().Foreground(muted).Width(w).Align(lipgloss.Center).Render("enter for another  •  q bye")
 	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, body)
 }
@@ -211,9 +214,9 @@ func (m Model) viewDialog() string {
 			"\n\nenter       send your xeet\nalt+enter   new line\nctrl+v      paste clipboard\nctrl+o      add a pic\ntab         pick a pic\ndelete      remove a pic\nesc         head out" +
 			"\n\n" + lipgloss.NewStyle().Foreground(muted).Render("f1 or esc to close")
 	case dialogQuit:
-		body = lipgloss.NewStyle().Foreground(pink).Bold(true).Render("leave this draft behind?") +
-			"\n\nYour words and pics will disappear." +
-			"\n\n" + lipgloss.NewStyle().Foreground(muted).Render("y leave  •  n stay")
+		body = lipgloss.NewStyle().Foreground(pink).Bold(true).Render("save this draft for later?") +
+			"\n\nYour words and pics can be restored next time." +
+			"\n\n" + lipgloss.NewStyle().Foreground(muted).Render("y save & leave  •  d discard  •  n stay")
 	}
 	box := dialogStyle.Width(w - 6).Render(body)
 	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, box)

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -216,7 +216,7 @@ func (m Model) viewDialog() string {
 	case dialogQuit:
 		body = lipgloss.NewStyle().Foreground(pink).Bold(true).Render("save this draft for later?") +
 			"\n\nYour words and pics can be restored next time." +
-			"\n\n" + lipgloss.NewStyle().Foreground(muted).Render("y save & leave  •  d discard  •  n stay")
+			"\n\n" + lipgloss.NewStyle().Foreground(muted).Render("enter/y save & leave  •  d discard  •  esc/n stay")
 	}
 	box := dialogStyle.Width(w - 6).Render(body)
 	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, box)

--- a/main.go
+++ b/main.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
+
 	"xeet/cmd"
 )
 
@@ -16,7 +20,9 @@ func main() {
 	// Set version info for cmd package to use
 	cmd.SetVersion(version, commit, buildTime)
 
-	if err := cmd.Execute(); err != nil {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	if err := cmd.ExecuteContext(ctx); err != nil {
 		os.Exit(1)
 	}
 }

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -1,17 +1,65 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
 // ErrSessionExpired means X rejected the saved cookies. Callers should tell
 // the user to re-run 'xeet auth'; wrapping sites add HTTP detail with %w.
 var ErrSessionExpired = errors.New("session expired or invalid; run 'xeet auth' to reconnect")
+
+// ConnectionError gives network failures a stable, actionable message while
+// retaining the original error for errors.Is/errors.As checks and diagnostics.
+type ConnectionError struct {
+	Kind string
+	Err  error
+}
+
+func (e *ConnectionError) Error() string {
+	switch e.Kind {
+	case "timeout":
+		return "x did not respond in time; check your connection and try again"
+	case "offline":
+		return "can't reach x; check your internet connection and try again"
+	default:
+		return "network request to x failed; try again"
+	}
+}
+
+func (e *ConnectionError) Unwrap() error { return e.Err }
+
+// ServiceUnavailableError means X's servers failed after bounded retries.
+type ServiceUnavailableError struct{ Status int }
+
+func (e *ServiceUnavailableError) Error() string {
+	return fmt.Sprintf("x is temporarily unavailable (HTTP %d); try again shortly", e.Status)
+}
+
+func classifyTransportError(err error) error {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return err
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return &ConnectionError{Kind: "timeout", Err: err}
+	}
+	var networkError net.Error
+	if errors.As(err, &networkError) && networkError.Timeout() {
+		return &ConnectionError{Kind: "timeout", Err: err}
+	}
+	var dnsError *net.DNSError
+	if errors.As(err, &dnsError) || errors.Is(err, syscall.ENETUNREACH) || errors.Is(err, syscall.EHOSTUNREACH) {
+		return &ConnectionError{Kind: "offline", Err: err}
+	}
+	return &ConnectionError{Kind: "network", Err: err}
+}
 
 // AutomationBlockedError means X accepted the HTTP request but rejected this
 // post as suspected automation or spam. The decision can be content-sensitive,

--- a/pkg/api/errors_test.go
+++ b/pkg/api/errors_test.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"xeet/pkg/config"
 )
 
 func newTestClient(handler func(*http.Request) (*http.Response, error)) *WebClient {
@@ -18,6 +22,49 @@ func newTestClient(handler func(*http.Request) (*http.Response, error)) *WebClie
 		queryID:    "qid",
 		retryDelay: time.Millisecond,
 		httpClient: &http.Client{Transport: roundTripFunc(handler)},
+	}
+}
+
+func TestTransportErrorsAreActionableAndKeepTheirCause(t *testing.T) {
+	dns := &net.DNSError{Err: "no such host", Name: "x.com", IsNotFound: true}
+	offline := classifyTransportError(dns)
+	var connection *ConnectionError
+	if !errors.As(offline, &connection) || connection.Kind != "offline" || !errors.Is(offline, dns) {
+		t.Fatalf("offline classification = %#v", offline)
+	}
+	if !strings.Contains(offline.Error(), "internet connection") {
+		t.Fatalf("offline message is not actionable: %q", offline.Error())
+	}
+
+	timedOut := classifyTransportError(context.DeadlineExceeded)
+	if !errors.As(timedOut, &connection) || connection.Kind != "timeout" || !errors.Is(timedOut, context.DeadlineExceeded) {
+		t.Fatalf("timeout classification = %#v", timedOut)
+	}
+}
+
+func TestTimelineReturnsConnectionErrorAfterBoundedRetries(t *testing.T) {
+	attempts := 0
+	client := newTestClient(func(req *http.Request) (*http.Response, error) {
+		attempts++
+		return nil, &net.DNSError{Err: "no route", Name: "x.com"}
+	})
+	_, err := client.FetchHomeTimeline(context.Background(), "", 30)
+	var connection *ConnectionError
+	if !errors.As(err, &connection) || attempts != maxRequestAttempts {
+		t.Fatalf("err=%v attempts=%d", err, attempts)
+	}
+}
+
+func TestTimelineReturnsServiceUnavailableAfterRetries(t *testing.T) {
+	attempts := 0
+	client := newTestClient(func(req *http.Request) (*http.Response, error) {
+		attempts++
+		return response(http.StatusServiceUnavailable, `down`), nil
+	})
+	_, err := client.FetchHomeTimeline(context.Background(), "", 30)
+	var unavailable *ServiceUnavailableError
+	if !errors.As(err, &unavailable) || unavailable.Status != http.StatusServiceUnavailable || attempts != maxRequestAttempts {
+		t.Fatalf("err=%v attempts=%d", err, attempts)
 	}
 }
 
@@ -126,8 +173,9 @@ func TestPostTweetNotRetriedOnTransientFailure(t *testing.T) {
 		return response(http.StatusOK, `{"data":{"home":{"instructions":[]}}}`), nil
 	})
 	_, err := client.PostTweet(context.Background(), "hi", "", nil, nil)
-	if err == nil {
-		t.Fatal("expected error")
+	var ambiguous *AmbiguousPostError
+	if !errors.As(err, &ambiguous) {
+		t.Fatalf("got %v, want AmbiguousPostError", err)
 	}
 	if postAttempts != 1 {
 		t.Fatalf("CreateTweet fired %d times, want 1", postAttempts)
@@ -365,6 +413,37 @@ func TestPostTweetRejectsMissingCreatedID(t *testing.T) {
 	}
 }
 
+func TestConfiguredOperationQueryIDsAreUsed(t *testing.T) {
+	cfg := &config.Config{
+		AuthToken: "auth", CT0: "csrf", HomeTimelineQID: "cached-home",
+		FavoriteTweetQID: "cached-like", UnfavoriteTweetQID: "cached-unlike",
+	}
+	client := NewWebClient(cfg)
+	client.retryDelay = time.Millisecond
+	var paths []string
+	client.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		paths = append(paths, req.URL.Path)
+		if strings.Contains(req.URL.Path, "HomeTimeline") {
+			return response(http.StatusOK, `{"data":{"home":{"instructions":[]}}}`), nil
+		}
+		return response(http.StatusOK, `{"data":{}}`), nil
+	})}
+	if _, err := client.FetchHomeTimeline(context.Background(), "", 30); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.SetTweetLiked(context.Background(), "1", true); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.SetTweetLiked(context.Background(), "1", false); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"/cached-home/HomeTimeline", "/cached-like/FavoriteTweet", "/cached-unlike/UnfavoriteTweet"} {
+		if !slices.ContainsFunc(paths, func(path string) bool { return strings.Contains(path, want) }) {
+			t.Fatalf("paths %v missing %q", paths, want)
+		}
+	}
+}
+
 func TestTimelineRefreshesRotatedQueryID(t *testing.T) {
 	attempts := 0
 	client := newTestClient(func(req *http.Request) (*http.Response, error) {
@@ -384,6 +463,10 @@ func TestTimelineRefreshesRotatedQueryID(t *testing.T) {
 	}
 	if attempts != 2 || len(page.Posts) != 0 {
 		t.Fatalf("attempts=%d page=%+v", attempts, page)
+	}
+	cfg := &config.Config{}
+	if !client.ApplyRefreshedQueryIDs(cfg) || cfg.HomeTimelineQID != "fresh" {
+		t.Fatalf("refreshed timeline id was not applied: %+v", cfg)
 	}
 }
 

--- a/pkg/api/errors_test.go
+++ b/pkg/api/errors_test.go
@@ -55,6 +55,22 @@ func TestTimelineReturnsConnectionErrorAfterBoundedRetries(t *testing.T) {
 	}
 }
 
+func TestTimelineClassifiesDeadlineWhileWaitingToRetry(t *testing.T) {
+	attempts := 0
+	client := newTestClient(func(req *http.Request) (*http.Response, error) {
+		attempts++
+		<-req.Context().Done()
+		return nil, req.Context().Err()
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	_, err := client.FetchHomeTimeline(ctx, "", 30)
+	var connection *ConnectionError
+	if !errors.As(err, &connection) || connection.Kind != "timeout" || attempts != 1 {
+		t.Fatalf("err=%v connection=%+v attempts=%d", err, connection, attempts)
+	}
+}
+
 func TestTimelineReturnsServiceUnavailableAfterRetries(t *testing.T) {
 	attempts := 0
 	client := newTestClient(func(req *http.Request) (*http.Response, error) {

--- a/pkg/api/favorite.go
+++ b/pkg/api/favorite.go
@@ -21,10 +21,11 @@ func (c *WebClient) SetTweetLiked(ctx context.Context, tweetID string, liked boo
 	if tweetID == "" {
 		return fmt.Errorf("tweet id is empty")
 	}
-	operation, qid := "FavoriteTweet", defaultFavoriteTweetQueryID
+	operation, fallback := "FavoriteTweet", defaultFavoriteTweetQueryID
 	if !liked {
-		operation, qid = "UnfavoriteTweet", defaultUnfavoriteTweetQueryID
+		operation, fallback = "UnfavoriteTweet", defaultUnfavoriteTweetQueryID
 	}
+	qid := c.operationQueryID(operation, fallback, "")
 	res, err := c.doTweetLike(ctx, operation, qid, tweetID)
 	if err != nil {
 		return err
@@ -41,6 +42,9 @@ func (c *WebClient) SetTweetLiked(ctx context.Context, tweetID string, liked boo
 	}
 	if err := statusToError(res.status, res.header); err != nil {
 		return err
+	}
+	if isTransientStatus(res.status) {
+		return &ServiceUnavailableError{Status: res.status}
 	}
 	if res.status != http.StatusOK {
 		return fmt.Errorf("like API error %d: %s", res.status, truncate(res.body))

--- a/pkg/api/timeline.go
+++ b/pkg/api/timeline.go
@@ -7,7 +7,6 @@ import (
 	"html"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 )
@@ -103,10 +102,7 @@ func (c *WebClient) FetchHomeTimeline(ctx context.Context, cursor string, count 
 	if count <= 0 || count > 100 {
 		count = 30
 	}
-	qid := defaultHomeTimelineQueryID
-	if value := os.Getenv("XEET_HOMETIMELINE_QID"); value != "" {
-		qid = value
-	}
+	qid := c.operationQueryID("HomeTimeline", defaultHomeTimelineQueryID, "XEET_HOMETIMELINE_QID")
 
 	res, err := c.doHomeTimeline(ctx, qid, cursor, count)
 	if err != nil {
@@ -124,6 +120,9 @@ func (c *WebClient) FetchHomeTimeline(ctx context.Context, cursor string, count 
 	}
 	if err := statusToError(res.status, res.header); err != nil {
 		return nil, err
+	}
+	if isTransientStatus(res.status) {
+		return nil, &ServiceUnavailableError{Status: res.status}
 	}
 	if res.status != http.StatusOK {
 		return nil, fmt.Errorf("timeline API error %d: %s", res.status, truncate(res.body))

--- a/pkg/api/web.go
+++ b/pkg/api/web.go
@@ -116,7 +116,7 @@ func (c *WebClient) send(ctx context.Context, build func() (*http.Request, error
 		if attempt > 1 {
 			select {
 			case <-ctx.Done():
-				return nil, ctx.Err()
+				return nil, classifyTransportError(ctx.Err())
 			case <-time.After(delay):
 			}
 			delay *= 2

--- a/pkg/api/web.go
+++ b/pkg/api/web.go
@@ -72,19 +72,21 @@ type ProgressFunc func(PostEvent)
 // WebClient posts through x.com's internal GraphQL API using a logged-in
 // browser session (auth_token + ct0 cookies) instead of the developer API.
 type WebClient struct {
-	httpClient     *http.Client
-	authToken      string
-	ct0            string
-	queryID        string
-	refreshed      bool          // queryID was re-discovered this session and should be cached
-	retryDelay     time.Duration // base backoff between transient retries; tests shrink it
-	reconcileDelay time.Duration
-	lastDiagnostic string
-	userAgent      string
-	clientPlatform string
-	transactionIDs *transactionIDGenerator
-	transactionID  func(context.Context, string, string) (string, error)
-	discover       func(context.Context, string, string, string) (string, error)
+	httpClient          *http.Client
+	authToken           string
+	ct0                 string
+	queryID             string
+	refreshed           bool // CreateTweet was re-discovered; retained for API compatibility
+	operationQIDs       map[string]string
+	refreshedOperations map[string]string
+	retryDelay          time.Duration // base backoff between transient retries; tests shrink it
+	reconcileDelay      time.Duration
+	lastDiagnostic      string
+	userAgent           string
+	clientPlatform      string
+	transactionIDs      *transactionIDGenerator
+	transactionID       func(context.Context, string, string) (string, error)
+	discover            func(context.Context, string, string, string) (string, error)
 }
 
 // httpResult is one completed HTTP exchange: everything callers need to
@@ -127,7 +129,7 @@ func (c *WebClient) send(ctx context.Context, build func() (*http.Request, error
 		resp, err := c.httpClient.Do(req)
 		if err != nil {
 			if !retryTransient {
-				return nil, fmt.Errorf("http: %w", err)
+				return nil, classifyTransportError(err)
 			}
 			lastErr = err
 			continue
@@ -141,7 +143,7 @@ func (c *WebClient) send(ctx context.Context, build func() (*http.Request, error
 		}
 		return &httpResult{status: resp.StatusCode, header: resp.Header, body: body}, nil
 	}
-	return nil, fmt.Errorf("request failed after %d attempts: %w", maxRequestAttempts, lastErr)
+	return nil, classifyTransportError(lastErr)
 }
 
 func isTransientStatus(status int) bool {
@@ -164,23 +166,30 @@ func needsQueryIDRefresh(res *httpResult) bool {
 }
 
 func NewWebClient(cfg *config.Config) *WebClient {
-	// Prefer an explicit override, then the cached id, then a built-in default
-	// (which may be stale; PostTweet re-discovers automatically on a 404).
-	qid := defaultCreateTweetQueryID
-	if cfg.CreateTweetQID != "" {
-		qid = cfg.CreateTweetQID
+	operationQIDs := map[string]string{
+		"CreateTweet":     cfg.CreateTweetQID,
+		"HomeTimeline":    cfg.HomeTimelineQID,
+		"FavoriteTweet":   cfg.FavoriteTweetQID,
+		"UnfavoriteTweet": cfg.UnfavoriteTweetQID,
+	}
+	qid := operationQIDs["CreateTweet"]
+	if qid == "" {
+		qid = defaultCreateTweetQueryID
 	}
 	if v := os.Getenv("XEET_CREATETWEET_QID"); v != "" {
 		qid = v
 	}
+	operationQIDs["CreateTweet"] = qid
 	client := &WebClient{
-		httpClient:     &http.Client{Timeout: 30 * time.Second},
-		authToken:      cfg.AuthToken,
-		ct0:            cfg.CT0,
-		queryID:        qid,
-		reconcileDelay: 1500 * time.Millisecond,
-		userAgent:      chromiumUserAgent(runtime.GOOS),
-		clientPlatform: chromiumClientPlatform(runtime.GOOS),
+		httpClient:          &http.Client{Timeout: 30 * time.Second},
+		authToken:           cfg.AuthToken,
+		ct0:                 cfg.CT0,
+		queryID:             qid,
+		operationQIDs:       operationQIDs,
+		refreshedOperations: map[string]string{},
+		reconcileDelay:      1500 * time.Millisecond,
+		userAgent:           chromiumUserAgent(runtime.GOOS),
+		clientPlatform:      chromiumClientPlatform(runtime.GOOS),
 	}
 	client.transactionID = client.generateTransactionID
 	return client
@@ -191,15 +200,70 @@ func NewWebClient(cfg *config.Config) *WebClient {
 func (c *WebClient) QueryID() string { return c.queryID }
 
 func (c *WebClient) discoverOperation(ctx context.Context, operation string) (string, error) {
+	var (
+		qid string
+		err error
+	)
 	if c.discover != nil {
-		return c.discover(ctx, c.authToken, c.ct0, operation)
+		qid, err = c.discover(ctx, c.authToken, c.ct0, operation)
+	} else {
+		qid, err = DiscoverOperationQueryID(ctx, c.authToken, c.ct0, operation)
 	}
-	return DiscoverOperationQueryID(ctx, c.authToken, c.ct0, operation)
+	if err != nil {
+		return "", err
+	}
+	if c.operationQIDs == nil {
+		c.operationQIDs = map[string]string{}
+	}
+	if c.refreshedOperations == nil {
+		c.refreshedOperations = map[string]string{}
+	}
+	c.operationQIDs[operation] = qid
+	c.refreshedOperations[operation] = qid
+	if operation == "CreateTweet" {
+		c.queryID = qid
+		c.refreshed = true
+	}
+	return qid, nil
 }
 
 // Refreshed reports whether the query id was re-discovered this session, so the
 // caller knows to persist QueryID() back to the config.
 func (c *WebClient) Refreshed() bool { return c.refreshed }
+
+// ApplyRefreshedQueryIDs copies operation ids discovered by this client into
+// cfg. It reports whether there is anything for the caller to persist.
+func (c *WebClient) ApplyRefreshedQueryIDs(cfg *config.Config) bool {
+	if cfg == nil || len(c.refreshedOperations) == 0 {
+		return false
+	}
+	for operation, qid := range c.refreshedOperations {
+		switch operation {
+		case "CreateTweet":
+			cfg.CreateTweetQID = qid
+		case "HomeTimeline":
+			cfg.HomeTimelineQID = qid
+		case "FavoriteTweet":
+			cfg.FavoriteTweetQID = qid
+		case "UnfavoriteTweet":
+			cfg.UnfavoriteTweetQID = qid
+		}
+	}
+	return true
+}
+
+func (c *WebClient) operationQueryID(operation, fallback, environment string) string {
+	qid := c.operationQIDs[operation]
+	if qid == "" {
+		qid = fallback
+	}
+	if environment != "" {
+		if override := os.Getenv(environment); override != "" {
+			qid = override
+		}
+	}
+	return qid
+}
 
 // LastDiagnostic returns sanitized response-shape metadata from the most recent
 // CreateTweet call. It never includes cookies, request bodies, or post text.
@@ -533,6 +597,9 @@ func (c *WebClient) uploadMedia(ctx context.Context, upload Upload) (string, err
 	}
 	if err := statusToError(res.status, res.header); err != nil {
 		return "", err
+	}
+	if isTransientStatus(res.status) {
+		return "", &ServiceUnavailableError{Status: res.status}
 	}
 	if res.status != http.StatusOK && res.status != http.StatusCreated {
 		return "", fmt.Errorf("upload HTTP %d: %s", res.status, truncate(res.body))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,14 +21,17 @@ import (
 // state: X's rotating GraphQL query id and browser-session source metadata used
 // by `xeet doctor`.
 type Config struct {
-	AuthToken       string    `yaml:"-"`
-	CT0             string    `yaml:"-"`
-	CreateTweetQID  string    `yaml:"create_tweet_qid"`
-	SessionBrowser  string    `yaml:"session_browser,omitempty"`
-	SessionProfile  string    `yaml:"session_profile,omitempty"`
-	SessionDomain   string    `yaml:"session_domain,omitempty"`
-	SessionExpires  time.Time `yaml:"session_expires,omitempty"`
-	SessionImported time.Time `yaml:"session_imported,omitempty"`
+	AuthToken          string    `yaml:"-"`
+	CT0                string    `yaml:"-"`
+	CreateTweetQID     string    `yaml:"create_tweet_qid"`
+	HomeTimelineQID    string    `yaml:"home_timeline_qid,omitempty"`
+	FavoriteTweetQID   string    `yaml:"favorite_tweet_qid,omitempty"`
+	UnfavoriteTweetQID string    `yaml:"unfavorite_tweet_qid,omitempty"`
+	SessionBrowser     string    `yaml:"session_browser,omitempty"`
+	SessionProfile     string    `yaml:"session_profile,omitempty"`
+	SessionDomain      string    `yaml:"session_domain,omitempty"`
+	SessionExpires     time.Time `yaml:"session_expires,omitempty"`
+	SessionImported    time.Time `yaml:"session_imported,omitempty"`
 }
 
 // keyringService is the service name xeet registers its secrets under.
@@ -86,14 +89,17 @@ func (systemKeyring) Delete(key string) error {
 // fileConfig is the on-disk shape. auth_token and ct0 are only read for
 // migration from the pre-keyring layout and are never written back.
 type fileConfig struct {
-	AuthToken       string `yaml:"auth_token,omitempty"`
-	CT0             string `yaml:"ct0,omitempty"`
-	CreateTweetQID  string `yaml:"create_tweet_qid,omitempty"`
-	SessionBrowser  string `yaml:"session_browser,omitempty"`
-	SessionProfile  string `yaml:"session_profile,omitempty"`
-	SessionDomain   string `yaml:"session_domain,omitempty"`
-	SessionExpires  string `yaml:"session_expires,omitempty"`
-	SessionImported string `yaml:"session_imported,omitempty"`
+	AuthToken          string `yaml:"auth_token,omitempty"`
+	CT0                string `yaml:"ct0,omitempty"`
+	CreateTweetQID     string `yaml:"create_tweet_qid,omitempty"`
+	HomeTimelineQID    string `yaml:"home_timeline_qid,omitempty"`
+	FavoriteTweetQID   string `yaml:"favorite_tweet_qid,omitempty"`
+	UnfavoriteTweetQID string `yaml:"unfavorite_tweet_qid,omitempty"`
+	SessionBrowser     string `yaml:"session_browser,omitempty"`
+	SessionProfile     string `yaml:"session_profile,omitempty"`
+	SessionDomain      string `yaml:"session_domain,omitempty"`
+	SessionExpires     string `yaml:"session_expires,omitempty"`
+	SessionImported    string `yaml:"session_imported,omitempty"`
 }
 
 type ConfigManager struct {
@@ -125,10 +131,13 @@ func (cm *ConfigManager) Load() (*Config, error) {
 	}
 
 	config := &Config{
-		CreateTweetQID: fc.CreateTweetQID,
-		SessionBrowser: fc.SessionBrowser,
-		SessionProfile: fc.SessionProfile,
-		SessionDomain:  fc.SessionDomain,
+		CreateTweetQID:     fc.CreateTweetQID,
+		HomeTimelineQID:    fc.HomeTimelineQID,
+		FavoriteTweetQID:   fc.FavoriteTweetQID,
+		UnfavoriteTweetQID: fc.UnfavoriteTweetQID,
+		SessionBrowser:     fc.SessionBrowser,
+		SessionProfile:     fc.SessionProfile,
+		SessionDomain:      fc.SessionDomain,
 	}
 	if fc.SessionExpires != "" {
 		if parsed, parseErr := time.Parse(time.RFC3339, fc.SessionExpires); parseErr == nil {
@@ -208,7 +217,10 @@ func (cm *ConfigManager) Save(config *Config) error {
 		return ErrSessionIncomplete
 	}
 	if config.AuthToken == "" {
-		return cm.writeFile(&fileConfig{CreateTweetQID: config.CreateTweetQID})
+		return cm.writeFile(&fileConfig{
+			CreateTweetQID: config.CreateTweetQID, HomeTimelineQID: config.HomeTimelineQID,
+			FavoriteTweetQID: config.FavoriteTweetQID, UnfavoriteTweetQID: config.UnfavoriteTweetQID,
+		})
 	}
 
 	oldAuth, err := cm.snapshotSecret(keyAuthToken)
@@ -240,10 +252,13 @@ func (cm *ConfigManager) Save(config *Config) error {
 
 func fileConfigFor(config *Config) *fileConfig {
 	result := &fileConfig{
-		CreateTweetQID: config.CreateTweetQID,
-		SessionBrowser: config.SessionBrowser,
-		SessionProfile: config.SessionProfile,
-		SessionDomain:  config.SessionDomain,
+		CreateTweetQID:     config.CreateTweetQID,
+		HomeTimelineQID:    config.HomeTimelineQID,
+		FavoriteTweetQID:   config.FavoriteTweetQID,
+		UnfavoriteTweetQID: config.UnfavoriteTweetQID,
+		SessionBrowser:     config.SessionBrowser,
+		SessionProfile:     config.SessionProfile,
+		SessionDomain:      config.SessionDomain,
 	}
 	if !config.SessionExpires.IsZero() {
 		result.SessionExpires = config.SessionExpires.UTC().Format(time.RFC3339)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -45,6 +45,7 @@ func TestSaveLoadRoundtrip(t *testing.T) {
 
 	in := &Config{
 		AuthToken: "tok123", CT0: "csrf456", CreateTweetQID: "qid789",
+		HomeTimelineQID: "home123", FavoriteTweetQID: "like123", UnfavoriteTweetQID: "unlike123",
 		SessionBrowser: "Firefox", SessionProfile: "default-release", SessionDomain: "x.com",
 		SessionExpires:  time.Date(2027, 1, 2, 3, 4, 5, 0, time.UTC),
 		SessionImported: time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC),


### PR DESCRIPTION
## Summary

- autosave and restore composer drafts, including file and clipboard-image attachments
- classify offline, timeout, outage, rate-limit, and expired-session failures with actionable recovery
- add in-timeline session reconnect and process signal cancellation
- persist discovered GraphQL operation IDs for posting, timeline reads, likes, and unlikes
- add an accessible `A` panel for image descriptions, including text-only mode

## Draft safety

- atomic `0600` draft writes
- private `0700` clipboard-media directory
- symlink refusal
- missing attachments do not discard restored text
- drafts clear only after confirmed posting or explicit discard

## Validation

- `go test -race ./...`
- `go vet ./...`
- `staticcheck ./...`
- cross-builds for Linux, macOS, and Windows on amd64/arm64
- `git diff --check`
