### PR TITLE
Add whoami and polish draft resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ If a saved session behaves differently from the browser, inspect it without
 posting:
 
 ```bash
+xeet whoami            # show the account connected to the saved session
 xeet doctor            # metadata plus one authenticated timeline read
 xeet doctor --offline  # local metadata only
 ```

--- a/TODO.md
+++ b/TODO.md
@@ -21,10 +21,10 @@
 - Actionable offline, timeout, service outage, rate-limit, and expired-session recovery
 - Persistent operation-ID caching for posting, timelines, likes, and unlikes
 - Keyboard-accessible image descriptions, including text-only mode
+- `xeet whoami` session/account display
 
 ## Next
 
-- `xeet whoami` session/account display
 - Following timeline option
 - Configurable theme without changing layout
 - Chunked upload for video and large media

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"xeet/pkg/api"
+	"xeet/pkg/config"
+
+	"github.com/spf13/cobra"
+)
+
+var whoamiCmd = &cobra.Command{
+	Use:   "whoami",
+	Short: "Show the X account connected to the saved session",
+	Args:  cobra.NoArgs,
+	RunE:  runWhoami,
+}
+
+func init() { rootCmd.AddCommand(whoamiCmd) }
+
+func runWhoami(cmd *cobra.Command, args []string) error {
+	manager, err := config.NewConfigManager()
+	if err != nil {
+		return err
+	}
+	cfg, err := manager.Load()
+	if err != nil {
+		return err
+	}
+	if cfg.AuthToken == "" || cfg.CT0 == "" {
+		return fmt.Errorf("no saved session; run 'xeet auth' first")
+	}
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), 45*time.Second)
+	defer cancel()
+	client := api.NewWebClient(cfg)
+	account, err := client.FetchViewer(ctx)
+	if err != nil {
+		return fmt.Errorf("identify saved session: %w", err)
+	}
+	if client.ApplyRefreshedQueryIDs(cfg) {
+		_ = manager.Save(cfg)
+	}
+	printAccount(cmd.OutOrStdout(), account, sessionSource(cfg))
+	return nil
+}
+
+func printAccount(out io.Writer, account *api.Account, source string) {
+	fmt.Fprintf(out, "account: @%s\n", account.Handle)
+	if account.Name != "" {
+		fmt.Fprintf(out, "name: %s\n", account.Name)
+	}
+	if account.ID != "" {
+		fmt.Fprintf(out, "id: %s\n", account.ID)
+	}
+	if account.Verified {
+		fmt.Fprintln(out, "verified: yes")
+	}
+	fmt.Fprintf(out, "session: %s\n", source)
+}

--- a/cmd/whoami_test.go
+++ b/cmd/whoami_test.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"xeet/pkg/api"
+)
+
+func TestPrintAccount(t *testing.T) {
+	var out bytes.Buffer
+	printAccount(&out, &api.Account{
+		ID: "42", Name: "Alice Example", Handle: "alice", Verified: true,
+	}, "Chrome / Profile 2")
+	for _, want := range []string{
+		"account: @alice", "name: Alice Example", "id: 42", "verified: yes", "session: Chrome / Profile 2",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, out.String())
+		}
+	}
+}
+
+func TestWhoamiCommandRejectsArguments(t *testing.T) {
+	if err := whoamiCmd.Args(whoamiCmd, []string{"extra"}); err == nil {
+		t.Fatal("whoami accepted an argument")
+	}
+}

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -281,8 +281,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.help = false
 				return m, m.imageRepaint()
 			}
+			// Help keys must not trigger actions in the feed underneath it.
+			return m, nil
 		}
-		return m, nil
+		// Keep applying background results while help is open.
 	}
 	if m.altText {
 		if key, ok := msg.(tea.KeyMsg); ok {

--- a/internal/timeline/model_test.go
+++ b/internal/timeline/model_test.go
@@ -158,6 +158,22 @@ func TestAltTextPanelProcessesBackgroundResults(t *testing.T) {
 	}
 }
 
+func TestHelpProcessesBackgroundResults(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.loading = false
+	m.help = true
+	m.posts = []api.TimelinePost{{ID: "1", Liked: true, LikeCount: 1}}
+	m.liking["1"] = true
+	next, _ := m.Update(likeMsg{id: "1", liked: true, err: errors.New("rejected")})
+	m = next.(Model)
+	if !m.help {
+		t.Fatal("background result unexpectedly closed help")
+	}
+	if m.liking["1"] || m.posts[0].Liked || m.posts[0].LikeCount != 0 {
+		t.Fatalf("like result was dropped: liking=%v post=%+v", m.liking, m.posts[0])
+	}
+}
+
 func TestRefreshKey(t *testing.T) {
 	m := New()
 	m.loading = false

--- a/internal/tui/draft.go
+++ b/internal/tui/draft.go
@@ -157,6 +157,14 @@ func (s *fileDraftStore) saveClipboardAttachment(attachment media.Attachment) (s
 	if err := rejectSymlink(path); err != nil {
 		return "", err
 	}
+	// IDs are content hashes and the sidecar directory is private. Once this
+	// exact-size sidecar exists, avoid rewriting and syncing the full image on
+	// every subsequent text autosave.
+	if info, err := os.Stat(path); err == nil && info.Size() == int64(len(attachment.Data)) {
+		return path, nil
+	} else if err != nil && !os.IsNotExist(err) {
+		return "", err
+	}
 	if err := atomicWrite0600(path, attachment.Data); err != nil {
 		return "", fmt.Errorf("save clipboard attachment: %w", err)
 	}

--- a/internal/tui/draft_test.go
+++ b/internal/tui/draft_test.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"xeet/internal/media"
 
@@ -63,6 +64,13 @@ func TestClipboardDraftAttachmentIsPersistedAndCleaned(t *testing.T) {
 	if err != nil || len(entries) != 1 {
 		t.Fatalf("draft media entries=%v err=%v", entries, err)
 	}
+	mediaDirInfo, err := os.Stat(store.mediaDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.GOOS != "windows" && mediaDirInfo.Mode().Perm() != 0700 {
+		t.Fatalf("draft media permissions = %o, want 700", mediaDirInfo.Mode().Perm())
+	}
 
 	text, attachments, err := store.Load()
 	if err != nil {
@@ -78,6 +86,25 @@ func TestClipboardDraftAttachmentIsPersistedAndCleaned(t *testing.T) {
 	}
 	if _, err := os.Stat(attachments[0].Path); err != nil {
 		t.Fatalf("restored clipboard sidecar was removed: %v", err)
+	}
+
+	// The in-memory clipboard attachment remains marked as clipboard-sourced.
+	// Later text autosaves must reuse its content-addressed sidecar rather than
+	// rewriting and syncing the full image each time.
+	sidecar := filepath.Join(store.mediaDir, attachment.ID+".png")
+	oldTime := time.Unix(1_600_000_000, 0)
+	if err := os.Chtimes(sidecar, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Save("edited text", []media.Attachment{attachment}); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(sidecar)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.ModTime().Equal(oldTime) {
+		t.Fatalf("clipboard sidecar was rewritten: mtime=%v", info.ModTime())
 	}
 	if err := store.Clear(); err != nil {
 		t.Fatal(err)

--- a/pkg/api/account.go
+++ b/pkg/api/account.go
@@ -1,0 +1,133 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+const defaultViewerQueryID = "u4ni7JqpqdAQxWQfkLsdUQ"
+
+// Account is the identity attached to the imported browser session.
+type Account struct {
+	ID       string
+	Name     string
+	Handle   string
+	Verified bool
+}
+
+var viewerFeatures = map[string]bool{
+	"responsive_web_graphql_exclude_directive_enabled":                  true,
+	"responsive_web_graphql_skip_user_profile_image_extensions_enabled": false,
+	"responsive_web_graphql_timeline_navigation_enabled":                true,
+	"responsive_web_twitter_article_notes_tab_enabled":                  true,
+	"verified_phone_label_enabled":                                      false,
+}
+
+// FetchViewer returns the account represented by the client's session cookies.
+// It is a read-only request and refreshes X's rotating Viewer operation id once
+// when necessary.
+func (c *WebClient) FetchViewer(ctx context.Context) (*Account, error) {
+	if c.authToken == "" || c.ct0 == "" {
+		return nil, fmt.Errorf("no session; run 'xeet auth' first")
+	}
+	qid := c.operationQueryID("Viewer", defaultViewerQueryID, "XEET_VIEWER_QID")
+	res, err := c.doViewer(ctx, qid)
+	if err != nil {
+		return nil, err
+	}
+	if needsQueryIDRefresh(res) {
+		fresh, discoverErr := c.discoverOperation(ctx, "Viewer")
+		if discoverErr != nil {
+			return nil, fmt.Errorf("account identity endpoint changed and discovery failed: %w", discoverErr)
+		}
+		res, err = c.doViewer(ctx, fresh)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if err := statusToError(res.status, res.header); err != nil {
+		return nil, err
+	}
+	if isTransientStatus(res.status) {
+		return nil, &ServiceUnavailableError{Status: res.status}
+	}
+	if res.status != http.StatusOK {
+		return nil, fmt.Errorf("account identity API error %d: %s", res.status, truncate(res.body))
+	}
+
+	var payload any
+	if err := json.Unmarshal(res.body, &payload); err != nil {
+		return nil, fmt.Errorf("decode account identity: %w", err)
+	}
+	if err := graphQLError(payload); err != nil {
+		return nil, err
+	}
+	account, ok := accountFromViewer(payload)
+	if !ok || account.Handle == "" {
+		return nil, fmt.Errorf("x returned no account identity for this session")
+	}
+	return &account, nil
+}
+
+func (c *WebClient) doViewer(ctx context.Context, qid string) (*httpResult, error) {
+	variables, _ := json.Marshal(map[string]bool{"withCommunitiesMemberships": true})
+	features, _ := json.Marshal(viewerFeatures)
+	params := url.Values{}
+	params.Set("variables", string(variables))
+	params.Set("features", string(features))
+	endpoint := fmt.Sprintf("https://x.com/i/api/graphql/%s/Viewer?%s", qid, params.Encode())
+	return c.send(ctx, func() (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+		if err != nil {
+			return nil, err
+		}
+		c.setHeaders(req)
+		return req, nil
+	}, true, 4<<20)
+}
+
+func accountFromViewer(payload any) (Account, bool) {
+	root, _ := payload.(map[string]any)
+	data, _ := root["data"].(map[string]any)
+	viewer := data["viewer"]
+	return findViewerAccount(viewer)
+}
+
+func findViewerAccount(node any) (Account, bool) {
+	switch value := node.(type) {
+	case map[string]any:
+		core, _ := value["core"].(map[string]any)
+		legacy, _ := value["legacy"].(map[string]any)
+		handle, _ := core["screen_name"].(string)
+		name, _ := core["name"].(string)
+		if handle == "" {
+			handle, _ = legacy["screen_name"].(string)
+		}
+		if name == "" {
+			name, _ = legacy["name"].(string)
+		}
+		if handle != "" {
+			id, _ := value["rest_id"].(string)
+			verified, _ := value["is_blue_verified"].(bool)
+			if legacyVerified, _ := legacy["verified"].(bool); legacyVerified {
+				verified = true
+			}
+			return Account{ID: id, Name: name, Handle: handle, Verified: verified}, true
+		}
+		for _, child := range value {
+			if account, ok := findViewerAccount(child); ok {
+				return account, true
+			}
+		}
+	case []any:
+		for _, child := range value {
+			if account, ok := findViewerAccount(child); ok {
+				return account, true
+			}
+		}
+	}
+	return Account{}, false
+}

--- a/pkg/api/account_test.go
+++ b/pkg/api/account_test.go
@@ -1,0 +1,77 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"xeet/pkg/config"
+)
+
+func TestFetchViewerParsesCurrentAccount(t *testing.T) {
+	client := newTestClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.Contains(req.URL.Path, "/Viewer") {
+			t.Fatalf("path = %q", req.URL.Path)
+		}
+		if req.URL.Query().Get("variables") == "" || req.URL.Query().Get("features") == "" {
+			t.Fatalf("missing Viewer parameters: %s", req.URL.RawQuery)
+		}
+		return response(http.StatusOK, `{
+			"data":{"viewer":{"user_results":{"result":{
+				"rest_id":"42","is_blue_verified":true,
+				"core":{"name":"Alice Example","screen_name":"alice"}
+			}}}}
+		}`), nil
+	})
+	account, err := client.FetchViewer(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if account.ID != "42" || account.Name != "Alice Example" || account.Handle != "alice" || !account.Verified {
+		t.Fatalf("account = %+v", account)
+	}
+}
+
+func TestFetchViewerSupportsLegacyShape(t *testing.T) {
+	client := newTestClient(func(req *http.Request) (*http.Response, error) {
+		return response(http.StatusOK, `{"data":{"viewer":{"result":{"rest_id":"7","legacy":{"name":"Bob","screen_name":"bob","verified":true}}}}}`), nil
+	})
+	account, err := client.FetchViewer(context.Background())
+	if err != nil || account.Handle != "bob" || account.Name != "Bob" || !account.Verified {
+		t.Fatalf("account=%+v err=%v", account, err)
+	}
+}
+
+func TestFetchViewerRefreshesAndExposesRotatedQueryID(t *testing.T) {
+	attempts := 0
+	client := newTestClient(func(req *http.Request) (*http.Response, error) {
+		attempts++
+		if attempts == 1 {
+			return response(http.StatusNotFound, `not found`), nil
+		}
+		if !strings.Contains(req.URL.Path, "/fresh-viewer/Viewer") {
+			t.Fatalf("refreshed path = %q", req.URL.Path)
+		}
+		return response(http.StatusOK, `{"data":{"viewer":{"result":{"rest_id":"1","core":{"name":"A","screen_name":"a"}}}}}`), nil
+	})
+	client.discover = func(context.Context, string, string, string) (string, error) {
+		return "fresh-viewer", nil
+	}
+	if _, err := client.FetchViewer(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{}
+	if attempts != 2 || !client.ApplyRefreshedQueryIDs(cfg) || cfg.ViewerQID != "fresh-viewer" {
+		t.Fatalf("attempts=%d config=%+v", attempts, cfg)
+	}
+}
+
+func TestFetchViewerRejectsMissingIdentity(t *testing.T) {
+	client := newTestClient(func(req *http.Request) (*http.Response, error) {
+		return response(http.StatusOK, `{"data":{"viewer":{}}}`), nil
+	})
+	if _, err := client.FetchViewer(context.Background()); err == nil || !strings.Contains(err.Error(), "no account identity") {
+		t.Fatalf("err = %v", err)
+	}
+}

--- a/pkg/api/web.go
+++ b/pkg/api/web.go
@@ -171,6 +171,7 @@ func NewWebClient(cfg *config.Config) *WebClient {
 		"HomeTimeline":    cfg.HomeTimelineQID,
 		"FavoriteTweet":   cfg.FavoriteTweetQID,
 		"UnfavoriteTweet": cfg.UnfavoriteTweetQID,
+		"Viewer":          cfg.ViewerQID,
 	}
 	qid := operationQIDs["CreateTweet"]
 	if qid == "" {
@@ -247,6 +248,8 @@ func (c *WebClient) ApplyRefreshedQueryIDs(cfg *config.Config) bool {
 			cfg.FavoriteTweetQID = qid
 		case "UnfavoriteTweet":
 			cfg.UnfavoriteTweetQID = qid
+		case "Viewer":
+			cfg.ViewerQID = qid
 		}
 	}
 	return true
@@ -618,9 +621,8 @@ func (c *WebClient) uploadMedia(ctx context.Context, upload Upload) (string, err
 }
 
 // Verify confirms the session cookies with a non-mutating authenticated
-// timeline read. X no longer exposes the old web-session account settings
-// endpoint, so the account handle is currently unavailable and the returned
-// string is empty on success.
+// timeline read. Account identity is handled separately by FetchViewer; the
+// returned string is retained for compatibility and is empty on success.
 func (c *WebClient) Verify(ctx context.Context) (string, error) {
 	if c.authToken == "" || c.ct0 == "" {
 		return "", fmt.Errorf("web session not configured")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	HomeTimelineQID    string    `yaml:"home_timeline_qid,omitempty"`
 	FavoriteTweetQID   string    `yaml:"favorite_tweet_qid,omitempty"`
 	UnfavoriteTweetQID string    `yaml:"unfavorite_tweet_qid,omitempty"`
+	ViewerQID          string    `yaml:"viewer_qid,omitempty"`
 	SessionBrowser     string    `yaml:"session_browser,omitempty"`
 	SessionProfile     string    `yaml:"session_profile,omitempty"`
 	SessionDomain      string    `yaml:"session_domain,omitempty"`
@@ -95,6 +96,7 @@ type fileConfig struct {
 	HomeTimelineQID    string `yaml:"home_timeline_qid,omitempty"`
 	FavoriteTweetQID   string `yaml:"favorite_tweet_qid,omitempty"`
 	UnfavoriteTweetQID string `yaml:"unfavorite_tweet_qid,omitempty"`
+	ViewerQID          string `yaml:"viewer_qid,omitempty"`
 	SessionBrowser     string `yaml:"session_browser,omitempty"`
 	SessionProfile     string `yaml:"session_profile,omitempty"`
 	SessionDomain      string `yaml:"session_domain,omitempty"`
@@ -135,6 +137,7 @@ func (cm *ConfigManager) Load() (*Config, error) {
 		HomeTimelineQID:    fc.HomeTimelineQID,
 		FavoriteTweetQID:   fc.FavoriteTweetQID,
 		UnfavoriteTweetQID: fc.UnfavoriteTweetQID,
+		ViewerQID:          fc.ViewerQID,
 		SessionBrowser:     fc.SessionBrowser,
 		SessionProfile:     fc.SessionProfile,
 		SessionDomain:      fc.SessionDomain,
@@ -220,6 +223,7 @@ func (cm *ConfigManager) Save(config *Config) error {
 		return cm.writeFile(&fileConfig{
 			CreateTweetQID: config.CreateTweetQID, HomeTimelineQID: config.HomeTimelineQID,
 			FavoriteTweetQID: config.FavoriteTweetQID, UnfavoriteTweetQID: config.UnfavoriteTweetQID,
+			ViewerQID: config.ViewerQID,
 		})
 	}
 
@@ -256,6 +260,7 @@ func fileConfigFor(config *Config) *fileConfig {
 		HomeTimelineQID:    config.HomeTimelineQID,
 		FavoriteTweetQID:   config.FavoriteTweetQID,
 		UnfavoriteTweetQID: config.UnfavoriteTweetQID,
+		ViewerQID:          config.ViewerQID,
 		SessionBrowser:     config.SessionBrowser,
 		SessionProfile:     config.SessionProfile,
 		SessionDomain:      config.SessionDomain,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -45,7 +45,7 @@ func TestSaveLoadRoundtrip(t *testing.T) {
 
 	in := &Config{
 		AuthToken: "tok123", CT0: "csrf456", CreateTweetQID: "qid789",
-		HomeTimelineQID: "home123", FavoriteTweetQID: "like123", UnfavoriteTweetQID: "unlike123",
+		HomeTimelineQID: "home123", FavoriteTweetQID: "like123", UnfavoriteTweetQID: "unlike123", ViewerQID: "viewer123",
 		SessionBrowser: "Firefox", SessionProfile: "default-release", SessionDomain: "x.com",
 		SessionExpires:  time.Date(2027, 1, 2, 3, 4, 5, 0, time.UTC),
 		SessionImported: time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC),


### PR DESCRIPTION
## Summary

- add a read-only `xeet whoami` command that displays the account attached to the saved browser session
- discover and persist X's rotating Viewer operation ID
- stop rewriting clipboard image sidecars on every draft autosave
- keep timeline background results flowing while help is open
- verify private `0700` permissions for saved draft media

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- staticcheck
- linux/darwin cross-builds
- live `xeet whoami` read against an imported session

All account lookup and verification operations are read-only.