### PR TITLE
feat: add conversation browsing to the timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ xeet                                  # browse your home timeline with images
 xeet --barebones                      # browse a text-only timeline
 xeet --compose                        # open only the interactive composer
 xeet timeline                         # same timeline, with renderer controls
+xeet timeline --threads               # experimental: Enter opens replies
 xeet post "hello from my shell"       # one-shot from the terminal
 echo "piped in" | xeet post           # reads stdin
 xeet post "photos" -i one.png -i two.jpg
@@ -162,6 +163,11 @@ place, **o** to open the post in the browser, **y** to copy its link,
 and **P** to write a new post. **R** refreshes in place: new posts stack on
 top while you keep your position. More posts load automatically near the
 bottom. Press **?** for the in-app key guide.
+
+Try conversation browsing with `xeet timeline --threads`. In this experimental
+mode, **Enter** opens the selected post and its replies, **j/k** moves through
+them, **r** replies to the selected item, and **Esc** returns to the same place
+in the home timeline. Use **e** or **Space** to expand long text.
 
 Images are prefetched around your position in the feed and rendered inline
 for nearby posts, so scrolling lands on already-loaded previews. Videos and

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ xeet                                  # browse your home timeline with images
 xeet --barebones                      # browse a text-only timeline
 xeet --compose                        # open only the interactive composer
 xeet timeline                         # same timeline, with renderer controls
-xeet timeline --threads               # experimental: Enter opens replies
 xeet post "hello from my shell"       # one-shot from the terminal
 echo "piped in" | xeet post           # reads stdin
 xeet post "photos" -i one.png -i two.jpg
@@ -156,7 +155,8 @@ xeet timeline         # explicit timeline command
 ```
 
 Use **j/k** or the arrow keys to move (**Ctrl+D/U** jumps five posts),
-**Enter** to read a truncated post in full, **i** to zoom the selected post's
+**Enter** to open the selected post's replies, **e** or **Space** to read a
+truncated post in full, **i** to zoom the selected post's
 image to the whole terminal, **A** to read descriptions for all attached images
 (even when previews are off), **l** to like or unlike, **r** to reply in
 place, **o** to open the post in the browser, **y** to copy its link,
@@ -164,10 +164,11 @@ and **P** to write a new post. **R** refreshes in place: new posts stack on
 top while you keep your position. More posts load automatically near the
 bottom. Press **?** for the in-app key guide.
 
-Try conversation browsing with `xeet timeline --threads`. In this experimental
-mode, **Enter** opens the selected post and its replies, **j/k** moves through
-them, **r** replies to the selected item, and **Esc** returns to the same place
-in the home timeline. Use **e** or **Space** to expand long text.
+Inside a conversation, **j/k** moves through the replies, **r** replies to the
+selected item, **R** reloads the conversation, and **Esc** returns to the same
+place in the home timeline. Xeet reads conversations through the same
+unsupported web endpoints as the rest of the timeline; they are read-only
+requests and never retried as mutations.
 
 Images are prefetched around your position in the feed and rendered inline
 for nearby posts, so scrolling lands on already-loaded previews. Videos and

--- a/cmd/timeline.go
+++ b/cmd/timeline.go
@@ -10,33 +10,29 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	timelineImageMode string
-	timelineThreads   bool
-)
+var timelineImageMode string
 
 var timelineCmd = &cobra.Command{
 	Use:   "timeline",
 	Short: "Browse your X home timeline",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runTimeline(cmd.Context(), timelineImageMode, timelineThreads)
+		return runTimeline(cmd.Context(), timelineImageMode)
 	},
 }
 
 func init() {
 	timelineCmd.Flags().StringVar(&timelineImageMode, "images", "auto", "image mode: auto, native, ansi, or off")
-	timelineCmd.Flags().BoolVar(&timelineThreads, "threads", false, "experimental: Enter opens a post's replies")
 	rootCmd.AddCommand(timelineCmd)
 }
 
-func runTimeline(ctx context.Context, imageMode string, threads ...bool) error {
+func runTimeline(ctx context.Context, imageMode string) error {
 	switch imageMode {
 	case "auto", "native", "ansi", "off":
 	default:
 		return fmt.Errorf("invalid --images value %q (use auto, native, ansi, or off)", imageMode)
 	}
 	for {
-		action, err := timeline.Run(imageMode, len(threads) > 0 && threads[0])
+		action, err := timeline.Run(imageMode)
 		if err != nil {
 			return err
 		}

--- a/cmd/timeline.go
+++ b/cmd/timeline.go
@@ -10,29 +10,33 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var timelineImageMode string
+var (
+	timelineImageMode string
+	timelineThreads   bool
+)
 
 var timelineCmd = &cobra.Command{
 	Use:   "timeline",
 	Short: "Browse your X home timeline",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runTimeline(cmd.Context(), timelineImageMode)
+		return runTimeline(cmd.Context(), timelineImageMode, timelineThreads)
 	},
 }
 
 func init() {
 	timelineCmd.Flags().StringVar(&timelineImageMode, "images", "auto", "image mode: auto, native, ansi, or off")
+	timelineCmd.Flags().BoolVar(&timelineThreads, "threads", false, "experimental: Enter opens a post's replies")
 	rootCmd.AddCommand(timelineCmd)
 }
 
-func runTimeline(ctx context.Context, imageMode string) error {
+func runTimeline(ctx context.Context, imageMode string, threads ...bool) error {
 	switch imageMode {
 	case "auto", "native", "ansi", "off":
 	default:
 		return fmt.Errorf("invalid --images value %q (use auto, native, ansi, or off)", imageMode)
 	}
 	for {
-		action, err := timeline.Run(imageMode)
+		action, err := timeline.Run(imageMode, len(threads) > 0 && threads[0])
 		if err != nil {
 			return err
 		}

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -689,8 +689,13 @@ func (m Model) applyThreadPage(msg threadMsg, repaint bool) (tea.Model, tea.Cmd)
 			seen[post.ID] = true
 		}
 	}
-	if len(merged) == 0 && len(m.threadPosts) > 0 {
-		merged = append(merged, m.threadPosts[0])
+	// X can omit the focal post from a refresh while still returning replies.
+	// The conversation must always keep its root: without it a refresh would
+	// silently turn the thread into a list of orphaned replies.
+	if !seen[m.threadRootID] {
+		if root, ok := m.threadRootPost(); ok {
+			merged = append([]api.ConversationPost{root}, merged...)
+		}
 	}
 	m.threadPosts = merged
 	m.normalizeThreadDepths()
@@ -705,6 +710,16 @@ func (m Model) applyThreadPage(msg threadMsg, repaint bool) (tea.Model, tea.Cmd)
 		return m, m.imageRepaint(m.requestPreviews())
 	}
 	return m, nil
+}
+
+func (m Model) threadRootPost() (api.ConversationPost, bool) {
+	for _, post := range m.threadPosts {
+		if post.ID == m.threadRootID {
+			post.Depth = 0
+			return post, true
+		}
+	}
+	return api.ConversationPost{}, false
 }
 
 func (m Model) resolveConversationPosts(page *api.ConversationPage) []api.ConversationPost {
@@ -796,6 +811,7 @@ func (m Model) updateThread(msg tea.Msg) (tea.Model, tea.Cmd) {
 			content: msg.content, nativePath: msg.nativePath, nativeData: msg.nativeData, imageID: msg.imageID,
 			columns: msg.columns, rows: msg.rows, err: msg.err,
 		}
+		m.evictDistantPreviews()
 		m.syncViewport()
 		m.ensureSelectedVisible()
 		return m, m.imageRepaint()
@@ -821,10 +837,23 @@ func (m Model) updateThread(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.expanded = false
 		m.threadLoading = false
 		m.threadMore = false
+		// An expired session affects every request, not just this thread.
+		// Hand the error to the feed so its reconnect flow stays reachable.
+		if errors.Is(m.threadErr, api.ErrSessionExpired) {
+			m.err = m.threadErr
+		}
 		m.threadErr = nil
 		m.syncViewport()
 		m.ensureSelectedVisible()
 		return m, m.imageRepaint()
+	case "a":
+		if errors.Is(m.threadErr, api.ErrSessionExpired) {
+			m.action = Action{Kind: ActionAuthenticate}
+			return m, tea.Quit
+		}
+	case "ctrl+l":
+		m.syncViewport()
+		return m, func() tea.Msg { return tea.ClearScreen() }
 	case "?", "f1":
 		m.help = true
 		return m, m.imageRepaint()

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -74,22 +74,21 @@ type Model struct {
 	spinner       spinner.Model
 	viewport      viewport.Model
 
-	mode           mode
-	threadsEnabled bool
-	feedSelected   int
-	threadRootID   string
-	threadPosts    []api.ConversationPost
-	threadCursor   string
-	threadLoading  bool
-	threadMore     bool
-	threadErr      error
-	threadSeq      int
-	replyReturn    mode
-	replyEditor    textarea.Model
-	replyPost      api.TimelinePost
-	replyPosting   bool
-	replyErr       error
-	replyNotice    string
+	mode          mode
+	feedSelected  int
+	threadRootID  string
+	threadPosts   []api.ConversationPost
+	threadCursor  string
+	threadLoading bool
+	threadMore    bool
+	threadErr     error
+	threadSeq     int
+	replyReturn   mode
+	replyEditor   textarea.Model
+	replyPost     api.TimelinePost
+	replyPosting  bool
+	replyErr      error
+	replyNotice   string
 }
 
 type pageMsg struct {
@@ -166,10 +165,6 @@ func New() Model {
 }
 
 func NewWithImageMode(requested string) Model {
-	return newModel(requested, false)
-}
-
-func newModel(requested string, threads bool) Model {
 	s := spinner.New()
 	s.Spinner = spinner.Dot
 	vp := viewport.New(72, 18)
@@ -184,7 +179,7 @@ func newModel(requested string, threads bool) Model {
 	return Model{
 		width: 80, height: 24, imageMode: mode, imageNote: note, loading: true,
 		liking: map[string]bool{}, previews: map[string]previewState{},
-		spinner: s, viewport: vp, replyEditor: editor, threadsEnabled: threads,
+		spinner: s, viewport: vp, replyEditor: editor,
 	}
 }
 
@@ -192,9 +187,8 @@ func (m Model) Init() tea.Cmd {
 	return tea.Batch(m.spinner.Tick, fetchPage("", false), clockTick())
 }
 
-func Run(images string, threads ...bool) (Action, error) {
-	enableThreads := len(threads) > 0 && threads[0]
-	m := newModel(images, enableThreads)
+func Run(images string) (Action, error) {
+	m := NewWithImageMode(images)
 	// Auto-detected native mode is a claim, not a capability: multiplexers
 	// like cmux inherit ghostty's TERM without reliably rendering graphics.
 	// Confirm with the terminal itself; --images native skips the probe.
@@ -481,7 +475,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.action = Action{Kind: ActionCompose}
 		return m, tea.Quit
 	case "enter":
-		if post, ok := m.currentPost(); ok && m.threadsEnabled {
+		if post, ok := m.currentPost(); ok {
 			m.feedSelected = m.selected
 			m.mode = modeThread
 			m.threadRootID = post.ID
@@ -494,12 +488,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.viewport.YOffset = 0
 			m.syncViewport()
 			return m, m.imageRepaint(tea.Batch(m.spinner.Tick, m.requestThread("", false), m.requestPreviews()))
-		}
-		if len(m.posts) > 0 {
-			m.expanded = !m.expanded
-			m.syncViewport()
-			m.ensureSelectedVisible()
-			return m, m.imageRepaint()
 		}
 	case " ", "e":
 		if len(m.posts) > 0 {

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -43,6 +43,7 @@ type mode int
 
 const (
 	modeFeed mode = iota
+	modeThread
 	modeReply
 )
 
@@ -73,12 +74,22 @@ type Model struct {
 	spinner       spinner.Model
 	viewport      viewport.Model
 
-	mode         mode
-	replyEditor  textarea.Model
-	replyPost    api.TimelinePost
-	replyPosting bool
-	replyErr     error
-	replyNotice  string
+	mode           mode
+	threadsEnabled bool
+	feedSelected   int
+	threadRootID   string
+	threadPosts    []api.ConversationPost
+	threadCursor   string
+	threadLoading  bool
+	threadMore     bool
+	threadErr      error
+	threadSeq      int
+	replyReturn    mode
+	replyEditor    textarea.Model
+	replyPost      api.TimelinePost
+	replyPosting   bool
+	replyErr       error
+	replyNotice    string
 }
 
 type pageMsg struct {
@@ -101,6 +112,14 @@ type likeMsg struct {
 type replyResultMsg struct {
 	id  string
 	err error
+}
+
+type threadMsg struct {
+	rootID string
+	seq    int
+	page   *api.ConversationPage
+	err    error
+	more   bool
 }
 
 type replyBrowserMsg struct{ err error }
@@ -147,6 +166,10 @@ func New() Model {
 }
 
 func NewWithImageMode(requested string) Model {
+	return newModel(requested, false)
+}
+
+func newModel(requested string, threads bool) Model {
 	s := spinner.New()
 	s.Spinner = spinner.Dot
 	vp := viewport.New(72, 18)
@@ -161,7 +184,7 @@ func NewWithImageMode(requested string) Model {
 	return Model{
 		width: 80, height: 24, imageMode: mode, imageNote: note, loading: true,
 		liking: map[string]bool{}, previews: map[string]previewState{},
-		spinner: s, viewport: vp, replyEditor: editor,
+		spinner: s, viewport: vp, replyEditor: editor, threadsEnabled: threads,
 	}
 }
 
@@ -169,8 +192,9 @@ func (m Model) Init() tea.Cmd {
 	return tea.Batch(m.spinner.Tick, fetchPage("", false), clockTick())
 }
 
-func Run(images string) (Action, error) {
-	m := NewWithImageMode(images)
+func Run(images string, threads ...bool) (Action, error) {
+	enableThreads := len(threads) > 0 && threads[0]
+	m := newModel(images, enableThreads)
 	// Auto-detected native mode is a claim, not a capability: multiplexers
 	// like cmux inherit ghostty's TERM without reliably rendering graphics.
 	// Confirm with the terminal itself; --images native skips the probe.
@@ -209,6 +233,32 @@ func fetchPage(cursor string, more bool) tea.Cmd {
 		}
 		return pageMsg{page: page, err: err, more: more}
 	}
+}
+
+func fetchThread(tweetID, cursor string, more bool, seq int) tea.Cmd {
+	return func() tea.Msg {
+		mgr, err := config.NewConfigManager()
+		if err != nil {
+			return threadMsg{rootID: tweetID, seq: seq, err: err, more: more}
+		}
+		cfg, err := mgr.Load()
+		if err != nil {
+			return threadMsg{rootID: tweetID, seq: seq, err: err, more: more}
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+		defer cancel()
+		client := api.NewWebClient(cfg)
+		page, err := client.FetchTweetDetail(ctx, tweetID, cursor, 40)
+		if client.ApplyRefreshedQueryIDs(cfg) {
+			_ = mgr.Save(cfg)
+		}
+		return threadMsg{rootID: tweetID, seq: seq, page: page, err: err, more: more}
+	}
+}
+
+func (m *Model) requestThread(cursor string, more bool) tea.Cmd {
+	m.threadSeq++
+	return fetchThread(m.threadRootID, cursor, more, m.threadSeq)
 }
 
 func setLike(tweetID string, liked bool) tea.Cmd {
@@ -328,6 +378,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if m.mode == modeReply {
 		return m.updateReply(msg)
 	}
+	if m.mode == modeThread {
+		return m.updateThread(msg)
+	}
 
 	switch msg := msg.(type) {
 	case spinner.TickMsg:
@@ -337,60 +390,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, cmd
 		}
 	case pageMsg:
-		m.loading = false
-		m.loadingMore = false
-		m.refreshing = false
-		if msg.err != nil {
-			m.err = msg.err
-			return m, nil
-		}
-		m.err = nil
-		seen := make(map[string]bool, len(m.posts))
-		for _, post := range m.posts {
-			seen[post.ID] = true
-		}
-		var toast tea.Cmd
-		if !msg.more && len(m.posts) > 0 {
-			// In-place refresh: unseen posts stack on top, the selection stays
-			// on the same post, and the old cursor keeps pagination intact.
-			var fresh []api.TimelinePost
-			for _, post := range msg.page.Posts {
-				if !seen[post.ID] {
-					fresh = append(fresh, post)
-				}
-			}
-			if len(fresh) > 0 {
-				m.posts = append(fresh, m.posts...)
-				m.selected += len(fresh)
-				label := "posts"
-				if len(fresh) == 1 {
-					label = "post"
-				}
-				toast = m.showToast(fmt.Sprintf("%d new %s · g jumps to top", len(fresh), label))
-			} else {
-				toast = m.showToast("all caught up")
-			}
-		} else {
-			selectedID := ""
-			if post, ok := m.currentPost(); ok {
-				selectedID = post.ID
-			}
-			for _, post := range msg.page.Posts {
-				if !seen[post.ID] {
-					m.posts = append(m.posts, post)
-					seen[post.ID] = true
-				}
-			}
-			m.cursor = msg.page.Cursor
-			m.selected = indexOfPost(m.posts, selectedID)
-			if m.selected < 0 {
-				m.selected = 0
-			}
-			m.toast = ""
-		}
-		m.syncViewport()
-		m.ensureSelectedVisible()
-		return m, m.imageRepaint(m.requestPreviews(), toast)
+		return m.applyFeedPage(msg)
 	case actionMsg:
 		if msg.err != nil {
 			return m, m.showToast(msg.err.Error())
@@ -470,13 +470,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.imageRepaint(tea.Batch(m.spinner.Tick, fetchPage("", false)))
 	case "r":
 		if post, ok := m.currentPost(); ok {
-			m.mode = modeReply
-			m.replyPost = post
-			m.replyErr = nil
-			m.replyNotice = ""
-			m.replyEditor.Reset()
-			m.resize()
-			return m, m.imageRepaint(m.replyEditor.Focus())
+			return m.beginReply(post)
 		}
 	case "a":
 		if errors.Is(m.err, api.ErrSessionExpired) {
@@ -487,6 +481,27 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.action = Action{Kind: ActionCompose}
 		return m, tea.Quit
 	case "enter":
+		if post, ok := m.currentPost(); ok && m.threadsEnabled {
+			m.feedSelected = m.selected
+			m.mode = modeThread
+			m.threadRootID = post.ID
+			m.threadPosts = []api.ConversationPost{{TimelinePost: post}}
+			m.threadCursor = ""
+			m.threadLoading = true
+			m.threadErr = nil
+			m.selected = 0
+			m.expanded = false
+			m.viewport.YOffset = 0
+			m.syncViewport()
+			return m, m.imageRepaint(tea.Batch(m.spinner.Tick, m.requestThread("", false), m.requestPreviews()))
+		}
+		if len(m.posts) > 0 {
+			m.expanded = !m.expanded
+			m.syncViewport()
+			m.ensureSelectedVisible()
+			return m, m.imageRepaint()
+		}
+	case " ", "e":
 		if len(m.posts) > 0 {
 			m.expanded = !m.expanded
 			m.syncViewport()
@@ -563,8 +578,368 @@ func (m *Model) maybeLoadMore() tea.Cmd {
 	return nil
 }
 
+func (m Model) applyFeedPage(msg pageMsg) (tea.Model, tea.Cmd) {
+	m.loading = false
+	m.loadingMore = false
+	m.refreshing = false
+	if msg.err != nil {
+		m.err = msg.err
+		return m, nil
+	}
+	m.err = nil
+	threadContext := m.mode == modeThread || (m.mode == modeReply && m.replyReturn == modeThread)
+	feedIndex := m.selected
+	if threadContext {
+		feedIndex = m.feedSelected
+	}
+	selectedID := ""
+	if feedIndex >= 0 && feedIndex < len(m.posts) {
+		selectedID = m.posts[feedIndex].ID
+	}
+	seen := make(map[string]bool, len(m.posts))
+	for _, post := range m.posts {
+		seen[post.ID] = true
+	}
+	var toast tea.Cmd
+	if !msg.more && len(m.posts) > 0 {
+		var fresh []api.TimelinePost
+		for _, post := range msg.page.Posts {
+			if !seen[post.ID] {
+				fresh = append(fresh, post)
+			}
+		}
+		if len(fresh) > 0 {
+			m.posts = append(fresh, m.posts...)
+			feedIndex += len(fresh)
+			label := "posts"
+			if len(fresh) == 1 {
+				label = "post"
+			}
+			toast = m.showToast(fmt.Sprintf("%d new %s · g jumps to top", len(fresh), label))
+		} else {
+			toast = m.showToast("all caught up")
+		}
+	} else {
+		for _, post := range msg.page.Posts {
+			if !seen[post.ID] {
+				m.posts = append(m.posts, post)
+				seen[post.ID] = true
+			}
+		}
+		m.cursor = msg.page.Cursor
+		feedIndex = indexOfPost(m.posts, selectedID)
+		if feedIndex < 0 {
+			feedIndex = 0
+		}
+		m.toast = ""
+	}
+	if threadContext {
+		m.feedSelected = feedIndex
+	} else {
+		m.selected = feedIndex
+	}
+	if m.mode == modeReply {
+		return m, toast
+	}
+	m.syncViewport()
+	m.ensureSelectedVisible()
+	if m.mode == modeFeed {
+		return m, m.imageRepaint(m.requestPreviews(), toast)
+	}
+	return m, toast
+}
+
+func (m Model) beginReply(post api.TimelinePost) (tea.Model, tea.Cmd) {
+	m.replyReturn = m.mode
+	m.mode = modeReply
+	m.replyPost = post
+	m.replyErr = nil
+	m.replyNotice = ""
+	m.replyEditor.Reset()
+	m.resize()
+	return m, m.imageRepaint(m.replyEditor.Focus())
+}
+
+func (m Model) applyThreadPage(msg threadMsg, repaint bool) (tea.Model, tea.Cmd) {
+	if msg.rootID != m.threadRootID || msg.seq != m.threadSeq {
+		return m, nil
+	}
+	m.threadLoading = false
+	m.threadMore = false
+	if msg.err != nil {
+		m.threadErr = msg.err
+		return m, nil
+	}
+	m.threadErr = nil
+	selectedID := ""
+	if m.selected >= 0 && m.selected < len(m.threadPosts) {
+		selectedID = m.threadPosts[m.selected].ID
+	}
+	seen := map[string]bool{}
+	var merged []api.ConversationPost
+	if msg.more {
+		merged = append(merged, m.threadPosts...)
+		for _, post := range merged {
+			seen[post.ID] = true
+		}
+	}
+	for _, post := range m.resolveConversationPosts(msg.page) {
+		if !seen[post.ID] {
+			merged = append(merged, post)
+			seen[post.ID] = true
+		}
+	}
+	if len(merged) == 0 && len(m.threadPosts) > 0 {
+		merged = append(merged, m.threadPosts[0])
+	}
+	m.threadPosts = merged
+	m.normalizeThreadDepths()
+	m.threadCursor = msg.page.Cursor
+	m.selected = indexOfConversationPost(m.threadPosts, selectedID)
+	if m.selected < 0 {
+		m.selected = 0
+	}
+	if repaint {
+		m.syncViewport()
+		m.ensureSelectedVisible()
+		return m, m.imageRepaint(m.requestPreviews())
+	}
+	return m, nil
+}
+
+func (m Model) resolveConversationPosts(page *api.ConversationPage) []api.ConversationPost {
+	resolved := append([]api.ConversationPost(nil), page.Posts...)
+	depths := make(map[string]int, len(m.threadPosts)+len(resolved))
+	for _, post := range m.threadPosts {
+		depths[post.ID] = post.Depth
+	}
+	for _, post := range resolved {
+		depths[post.ID] = post.Depth
+	}
+	pending := append([]api.TimelinePost(nil), page.Unresolved...)
+	for len(pending) > 0 {
+		progress := false
+		next := pending[:0]
+		for _, post := range pending {
+			parentDepth, ok := depths[post.InReplyToID]
+			if !ok {
+				next = append(next, post)
+				continue
+			}
+			depth := parentDepth + 1
+			resolved = append(resolved, api.ConversationPost{TimelinePost: post, Depth: depth})
+			depths[post.ID] = depth
+			progress = true
+		}
+		if !progress {
+			break
+		}
+		pending = next
+	}
+	return resolved
+}
+
+func (m *Model) normalizeThreadDepths() {
+	byID := make(map[string]api.ConversationPost, len(m.threadPosts))
+	for _, post := range m.threadPosts {
+		byID[post.ID] = post
+	}
+	for i := range m.threadPosts {
+		if m.threadPosts[i].ID == m.threadRootID {
+			m.threadPosts[i].Depth = 0
+			continue
+		}
+		depth := 1
+		parent := m.threadPosts[i].InReplyToID
+		visited := map[string]bool{m.threadPosts[i].ID: true}
+		for parent != "" && parent != m.threadRootID && !visited[parent] {
+			visited[parent] = true
+			ancestor, ok := byID[parent]
+			if !ok {
+				break
+			}
+			parent = ancestor.InReplyToID
+			depth++
+		}
+		m.threadPosts[i].Depth = depth
+	}
+}
+
+func (m Model) updateThread(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case spinner.TickMsg:
+		if m.threadLoading || m.threadMore || m.zoomLoading() {
+			var cmd tea.Cmd
+			m.spinner, cmd = m.spinner.Update(msg)
+			return m, cmd
+		}
+	case pageMsg:
+		return m.applyFeedPage(msg)
+	case threadMsg:
+		return m.applyThreadPage(msg, true)
+	case likeMsg:
+		delete(m.liking, msg.id)
+		var toast tea.Cmd
+		if msg.err != nil {
+			m.applyLike(msg.id, !msg.liked)
+			toast = m.showToast("couldn't update like")
+		} else if msg.liked {
+			toast = m.showToast("liked ♥")
+		} else {
+			toast = m.showToast("like removed")
+		}
+		m.syncViewport()
+		m.ensureSelectedVisible()
+		return m, toast
+	case previewMsg:
+		m.previews[msg.postID] = previewState{
+			content: msg.content, nativePath: msg.nativePath, nativeData: msg.nativeData, imageID: msg.imageID,
+			columns: msg.columns, rows: msg.rows, err: msg.err,
+		}
+		m.syncViewport()
+		m.ensureSelectedVisible()
+		return m, m.imageRepaint()
+	case actionMsg:
+		if msg.err != nil {
+			return m, m.showToast(msg.err.Error())
+		}
+		return m, m.showToast(msg.message)
+	}
+
+	key, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+	switch key.String() {
+	case "q", "ctrl+c":
+		return m, tea.Quit
+	case "esc":
+		m.mode = modeFeed
+		m.selected = m.feedSelected
+		m.threadSeq++
+		m.threadRootID = ""
+		m.expanded = false
+		m.threadLoading = false
+		m.threadMore = false
+		m.threadErr = nil
+		m.syncViewport()
+		m.ensureSelectedVisible()
+		return m, m.imageRepaint()
+	case "?", "f1":
+		m.help = true
+		return m, m.imageRepaint()
+	case "j", "down":
+		m.moveThreadSelection(m.selected + 1)
+		return m, m.imageRepaint(m.requestPreviews(), m.maybeLoadMoreThread())
+	case "k", "up":
+		m.moveThreadSelection(m.selected - 1)
+		return m, m.imageRepaint(m.requestPreviews())
+	case "ctrl+d":
+		m.moveThreadSelection(m.selected + 5)
+		return m, m.imageRepaint(m.requestPreviews(), m.maybeLoadMoreThread())
+	case "ctrl+u":
+		m.moveThreadSelection(m.selected - 5)
+		return m, m.imageRepaint(m.requestPreviews())
+	case "g", "home":
+		m.moveThreadSelection(0)
+		return m, m.imageRepaint(m.requestPreviews())
+	case "G", "end":
+		m.moveThreadSelection(len(m.threadPosts) - 1)
+		return m, m.imageRepaint(m.requestPreviews(), m.maybeLoadMoreThread())
+	case "R", "ctrl+r":
+		m.threadLoading = true
+		m.threadMore = false
+		m.threadErr = nil
+		return m, m.imageRepaint(tea.Batch(m.spinner.Tick, m.requestThread("", false)))
+	case "r":
+		if post, ok := m.currentPost(); ok {
+			return m.beginReply(post)
+		}
+	case "enter", " ", "e":
+		m.expanded = !m.expanded
+		m.syncViewport()
+		m.ensureSelectedVisible()
+		return m, m.imageRepaint()
+	case "o":
+		if post, ok := m.currentPost(); ok {
+			return m, openURL(postURL(post))
+		}
+	case "A":
+		if post, ok := m.currentPost(); ok && len(post.Media) > 0 {
+			m.altText = true
+			m.altTextScroll = 0
+			return m, m.imageRepaint()
+		}
+	case "i":
+		if post, ok := m.currentPost(); ok && len(post.Media) > 0 {
+			if m.imageMode == imageModeOff {
+				return m, m.showToast("image previews are off (--images)")
+			}
+			m.zoom = true
+			return m, m.imageRepaint(tea.Batch(m.spinner.Tick, m.requestZoom()))
+		}
+	case "l":
+		if post, ok := m.currentPost(); ok && !m.liking[post.ID] {
+			liked := !post.Liked
+			m.liking[post.ID] = true
+			m.applyLike(post.ID, liked)
+			m.syncViewport()
+			return m, setLike(post.ID, liked)
+		}
+	case "y":
+		if post, ok := m.currentPost(); ok {
+			if !m.clipboardOK {
+				return m, m.showToast("clipboard unavailable")
+			}
+			if err := clip.WriteText(postURL(post)); err != nil {
+				return m, m.showToast("clipboard unavailable; open the post with o")
+			}
+			return m, m.showToast("link copied")
+		}
+	}
+	return m, nil
+}
+
+func (m *Model) moveThreadSelection(target int) {
+	if len(m.threadPosts) == 0 {
+		return
+	}
+	m.selected = max(0, min(len(m.threadPosts)-1, target))
+	m.expanded = false
+	m.toast = ""
+	m.syncViewport()
+	m.ensureSelectedVisible()
+}
+
+func (m *Model) maybeLoadMoreThread() tea.Cmd {
+	if len(m.threadPosts) > 0 && m.selected >= len(m.threadPosts)-5 && m.threadCursor != "" && !m.threadLoading && !m.threadMore {
+		m.threadMore = true
+		return tea.Batch(m.spinner.Tick, m.requestThread(m.threadCursor, true))
+	}
+	return nil
+}
+
 func (m Model) updateReply(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	case threadMsg:
+		if m.replyReturn != modeThread {
+			return m, nil
+		}
+		return m.applyThreadPage(msg, false)
+	case pageMsg:
+		return m.applyFeedPage(msg)
+	case likeMsg:
+		delete(m.liking, msg.id)
+		if msg.err != nil {
+			m.applyLike(msg.id, !msg.liked)
+		}
+		return m, nil
+	case previewMsg:
+		m.previews[msg.postID] = previewState{
+			content: msg.content, nativePath: msg.nativePath, nativeData: msg.nativeData, imageID: msg.imageID,
+			columns: msg.columns, rows: msg.rows, err: msg.err,
+		}
+		return m, nil
 	case spinner.TickMsg:
 		if m.replyPosting {
 			var cmd tea.Cmd
@@ -578,12 +953,17 @@ func (m Model) updateReply(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.replyNotice = ""
 			return m, m.replyEditor.Focus()
 		}
-		m.mode = modeFeed
+		m.mode = m.replyReturn
 		m.replyEditor.Blur()
 		m.replyEditor.Reset()
 		toast := m.showToast("reply sent ♥")
 		m.syncViewport()
 		m.ensureSelectedVisible()
+		if m.mode == modeThread {
+			m.threadLoading = true
+			m.threadMore = false
+			return m, m.imageRepaint(tea.Batch(toast, m.spinner.Tick, m.requestThread("", false)))
+		}
 		return m, m.imageRepaint(toast)
 	case replyBrowserMsg:
 		if msg.err != nil {
@@ -606,12 +986,12 @@ func (m Model) updateReply(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, openReplyInX(m.replyPost.ID, m.replyEditor.Value())
 			}
 		case "esc", "ctrl+c":
-			m.mode = modeFeed
+			m.mode = m.replyReturn
 			m.replyEditor.Blur()
 			m.replyErr = nil
 			m.replyNotice = ""
 			m.syncViewport()
-			return m, m.imageRepaint()
+			return m, m.imageRepaint(m.requestPreviews())
 		case "enter":
 			if strings.TrimSpace(m.replyEditor.Value()) == "" {
 				m.replyErr = fmt.Errorf("write a reply first")
@@ -680,7 +1060,13 @@ func (m *Model) resize() {
 }
 
 func (m *Model) syncViewport() {
-	content, starts, ends := m.renderFeedContent()
+	var content string
+	var starts, ends []int
+	if m.mode == modeThread {
+		content, starts, ends = m.renderThreadContent()
+	} else {
+		content, starts, ends = m.renderFeedContent()
+	}
 	m.starts = starts
 	m.ends = ends
 	m.viewport.SetContent(content)
@@ -709,7 +1095,24 @@ func (m *Model) ensureSelectedVisible() {
 	m.viewport.YOffset = max(0, min(top, maxTop))
 }
 
+func (m Model) activePosts() []api.TimelinePost {
+	if m.mode == modeThread {
+		posts := make([]api.TimelinePost, len(m.threadPosts))
+		for i := range m.threadPosts {
+			posts[i] = m.threadPosts[i].TimelinePost
+		}
+		return posts
+	}
+	return m.posts
+}
+
 func (m Model) currentPost() (api.TimelinePost, bool) {
+	if m.mode == modeThread {
+		if m.selected < 0 || m.selected >= len(m.threadPosts) {
+			return api.TimelinePost{}, false
+		}
+		return m.threadPosts[m.selected].TimelinePost, true
+	}
 	if m.selected < 0 || m.selected >= len(m.posts) {
 		return api.TimelinePost{}, false
 	}
@@ -717,18 +1120,35 @@ func (m Model) currentPost() (api.TimelinePost, bool) {
 }
 
 func (m *Model) applyLike(id string, liked bool) {
-	for i := range m.posts {
-		if m.posts[i].ID != id || m.posts[i].Liked == liked {
-			continue
+	apply := func(post *api.TimelinePost) {
+		if post.ID != id || post.Liked == liked {
+			return
 		}
-		m.posts[i].Liked = liked
+		post.Liked = liked
 		if liked {
-			m.posts[i].LikeCount++
-		} else if m.posts[i].LikeCount > 0 {
-			m.posts[i].LikeCount--
+			post.LikeCount++
+		} else if post.LikeCount > 0 {
+			post.LikeCount--
 		}
-		return
 	}
+	for i := range m.posts {
+		apply(&m.posts[i])
+	}
+	for i := range m.threadPosts {
+		apply(&m.threadPosts[i].TimelinePost)
+	}
+}
+
+func indexOfConversationPost(posts []api.ConversationPost, id string) int {
+	if id == "" {
+		return 0
+	}
+	for i := range posts {
+		if posts[i].ID == id {
+			return i
+		}
+	}
+	return -1
 }
 
 func indexOfPost(posts []api.TimelinePost, id string) int {

--- a/internal/timeline/model_test.go
+++ b/internal/timeline/model_test.go
@@ -453,6 +453,93 @@ func TestThreadIgnoresOlderRequestForSameRoot(t *testing.T) {
 	}
 }
 
+func TestThreadErrorIsVisibleWithSeededRoot(t *testing.T) {
+	m := newModel("off", true)
+	m.loading = false
+	m.mode = modeThread
+	m.threadRootID = "root"
+	m.threadSeq = 1
+	m.threadLoading = true
+	m.threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}}}
+	m = update(t, m, threadMsg{rootID: "root", seq: 1, err: errors.New("discovery failed badly")})
+	view := m.View()
+	if !strings.Contains(view, "discovery failed badly") || !strings.Contains(view, "R retry") {
+		t.Fatalf("thread error not shown despite seeded root:\n%s", view)
+	}
+}
+
+func TestThreadSessionExpiryOffersReconnect(t *testing.T) {
+	m := newModel("off", true)
+	m.loading = false
+	m.mode = modeThread
+	m.threadRootID = "root"
+	m.threadSeq = 1
+	m.threadLoading = true
+	m.threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}}}
+	m = update(t, m, threadMsg{rootID: "root", seq: 1, err: api.ErrSessionExpired})
+	if !strings.Contains(m.View(), "a reconnect") {
+		t.Fatalf("session-expired thread did not offer reconnect:\n%s", m.View())
+	}
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	m = next.(Model)
+	if m.action.Kind != ActionAuthenticate || cmd == nil {
+		t.Fatal("a did not start the reconnect flow from thread mode")
+	}
+}
+
+func TestThreadEscPromotesSessionExpiryToFeed(t *testing.T) {
+	m := newModel("off", true)
+	m.loading = false
+	m.mode = modeThread
+	m.threadRootID = "root"
+	m.threadErr = api.ErrSessionExpired
+	m.threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}}}
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyEsc})
+	if m.mode != modeFeed || !errors.Is(m.err, api.ErrSessionExpired) {
+		t.Fatalf("esc dropped the expired session: mode=%v err=%v", m.mode, m.err)
+	}
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	m = next.(Model)
+	if m.action.Kind != ActionAuthenticate || cmd == nil {
+		t.Fatal("feed reconnect was unreachable after leaving the thread")
+	}
+}
+
+func TestThreadEscKeepsOrdinaryErrorsOutOfFeed(t *testing.T) {
+	m := newModel("off", true)
+	m.loading = false
+	m.mode = modeThread
+	m.threadRootID = "root"
+	m.threadErr = errors.New("replies timed out")
+	m.threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}}}
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyEsc})
+	if m.mode != modeFeed || m.err != nil {
+		t.Fatalf("thread-only error leaked into the feed: err=%v", m.err)
+	}
+}
+
+func TestThreadRefreshKeepsRootWhenPageOmitsIt(t *testing.T) {
+	m := newModel("off", true)
+	m.loading = false
+	m.mode = modeThread
+	m.threadRootID = "root"
+	m.threadSeq = 1
+	m.threadLoading = true
+	m.threadPosts = []api.ConversationPost{
+		{TimelinePost: api.TimelinePost{ID: "root", Text: "the focal post"}},
+		{TimelinePost: api.TimelinePost{ID: "old", Text: "old reply", InReplyToID: "root"}, Depth: 1},
+	}
+	m = update(t, m, threadMsg{rootID: "root", seq: 1, page: &api.ConversationPage{Posts: []api.ConversationPost{
+		{TimelinePost: api.TimelinePost{ID: "reply", Text: "only reply", InReplyToID: "root"}, Depth: 1},
+	}}})
+	if len(m.threadPosts) != 2 || m.threadPosts[0].ID != "root" || m.threadPosts[0].Depth != 0 {
+		t.Fatalf("refresh dropped the focal post: %+v", m.threadPosts)
+	}
+	if m.threadPosts[1].ID != "reply" {
+		t.Fatalf("refresh lost the new reply: %+v", m.threadPosts)
+	}
+}
+
 func TestThreadReplyTargetsSelectedReplyAndReturnsToThread(t *testing.T) {
 	m := newModel("off", true)
 	m.loading = false

--- a/internal/timeline/model_test.go
+++ b/internal/timeline/model_test.go
@@ -325,8 +325,8 @@ func TestToastExpiresOnlyForLatestSequence(t *testing.T) {
 	}
 }
 
-func TestExperimentalEnterOpensRepliesAndEscRestoresFeed(t *testing.T) {
-	m := newModel("off", true)
+func TestEnterOpensRepliesAndEscRestoresFeed(t *testing.T) {
+	m := NewWithImageMode("off")
 	m.loading = false
 	m.posts = []api.TimelinePost{
 		{ID: "first", Handle: "one", Text: "first"},
@@ -353,7 +353,7 @@ func TestExperimentalEnterOpensRepliesAndEscRestoresFeed(t *testing.T) {
 }
 
 func TestThreadIgnoresStaleConversationAndKeepsFeedUpdatesAlive(t *testing.T) {
-	m := newModel("off", true)
+	m := NewWithImageMode("off")
 	m.loading = false
 	m.posts = []api.TimelinePost{{ID: "root", Text: "root"}}
 	m.mode = modeThread
@@ -374,7 +374,7 @@ func TestThreadIgnoresStaleConversationAndKeepsFeedUpdatesAlive(t *testing.T) {
 }
 
 func TestThreadContinuationResolvesParentFromEarlierPage(t *testing.T) {
-	m := newModel("off", true)
+	m := NewWithImageMode("off")
 	m.loading = false
 	m.mode = modeThread
 	m.threadRootID = "root"
@@ -393,7 +393,7 @@ func TestThreadContinuationResolvesParentFromEarlierPage(t *testing.T) {
 }
 
 func TestThreadResultCompletesWhileReplyEditorIsOpen(t *testing.T) {
-	m := newModel("off", true)
+	m := NewWithImageMode("off")
 	m.loading = false
 	m.mode = modeThread
 	m.threadRootID = "root"
@@ -415,7 +415,7 @@ func TestThreadResultCompletesWhileReplyEditorIsOpen(t *testing.T) {
 }
 
 func TestFeedResultDuringThreadReplyPreservesBothSelections(t *testing.T) {
-	m := newModel("off", true)
+	m := NewWithImageMode("off")
 	m.loading = false
 	m.posts = []api.TimelinePost{{ID: "a", Text: "a"}, {ID: "root", Text: "root"}}
 	m.feedSelected = 1
@@ -438,7 +438,7 @@ func TestFeedResultDuringThreadReplyPreservesBothSelections(t *testing.T) {
 }
 
 func TestThreadIgnoresOlderRequestForSameRoot(t *testing.T) {
-	m := newModel("off", true)
+	m := NewWithImageMode("off")
 	m.loading = false
 	m.mode = modeThread
 	m.threadRootID = "root"
@@ -454,7 +454,7 @@ func TestThreadIgnoresOlderRequestForSameRoot(t *testing.T) {
 }
 
 func TestThreadErrorIsVisibleWithSeededRoot(t *testing.T) {
-	m := newModel("off", true)
+	m := NewWithImageMode("off")
 	m.loading = false
 	m.mode = modeThread
 	m.threadRootID = "root"
@@ -469,7 +469,7 @@ func TestThreadErrorIsVisibleWithSeededRoot(t *testing.T) {
 }
 
 func TestThreadSessionExpiryOffersReconnect(t *testing.T) {
-	m := newModel("off", true)
+	m := NewWithImageMode("off")
 	m.loading = false
 	m.mode = modeThread
 	m.threadRootID = "root"
@@ -488,7 +488,7 @@ func TestThreadSessionExpiryOffersReconnect(t *testing.T) {
 }
 
 func TestThreadEscPromotesSessionExpiryToFeed(t *testing.T) {
-	m := newModel("off", true)
+	m := NewWithImageMode("off")
 	m.loading = false
 	m.mode = modeThread
 	m.threadRootID = "root"
@@ -506,7 +506,7 @@ func TestThreadEscPromotesSessionExpiryToFeed(t *testing.T) {
 }
 
 func TestThreadEscKeepsOrdinaryErrorsOutOfFeed(t *testing.T) {
-	m := newModel("off", true)
+	m := NewWithImageMode("off")
 	m.loading = false
 	m.mode = modeThread
 	m.threadRootID = "root"
@@ -519,7 +519,7 @@ func TestThreadEscKeepsOrdinaryErrorsOutOfFeed(t *testing.T) {
 }
 
 func TestThreadRefreshKeepsRootWhenPageOmitsIt(t *testing.T) {
-	m := newModel("off", true)
+	m := NewWithImageMode("off")
 	m.loading = false
 	m.mode = modeThread
 	m.threadRootID = "root"
@@ -541,7 +541,7 @@ func TestThreadRefreshKeepsRootWhenPageOmitsIt(t *testing.T) {
 }
 
 func TestThreadReplyTargetsSelectedReplyAndReturnsToThread(t *testing.T) {
-	m := newModel("off", true)
+	m := NewWithImageMode("off")
 	m.loading = false
 	m.mode = modeThread
 	m.threadRootID = "root"
@@ -562,7 +562,7 @@ func TestThreadReplyTargetsSelectedReplyAndReturnsToThread(t *testing.T) {
 	}
 }
 
-func TestEnterExpandsTruncatedPost(t *testing.T) {
+func TestReadKeyExpandsTruncatedPost(t *testing.T) {
 	m := New()
 	m.loading = false
 	m.posts = []api.TimelinePost{{
@@ -573,17 +573,17 @@ func TestEnterExpandsTruncatedPost(t *testing.T) {
 	if strings.Contains(m.viewport.View(), "ENDMARKER") {
 		t.Fatal("long post was not truncated")
 	}
-	m = update(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
 	if !m.expanded {
-		t.Fatal("enter did not expand the post")
+		t.Fatal("e did not expand the post")
 	}
 	content, _, _ := m.renderFeedContent()
 	if !strings.Contains(content, "ENDMARKER") {
 		t.Fatal("expanded post is still truncated")
 	}
-	m = update(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
 	if m.expanded {
-		t.Fatal("enter did not collapse the post")
+		t.Fatal("e did not collapse the post")
 	}
 }
 

--- a/internal/timeline/model_test.go
+++ b/internal/timeline/model_test.go
@@ -325,6 +325,156 @@ func TestToastExpiresOnlyForLatestSequence(t *testing.T) {
 	}
 }
 
+func TestExperimentalEnterOpensRepliesAndEscRestoresFeed(t *testing.T) {
+	m := newModel("off", true)
+	m.loading = false
+	m.posts = []api.TimelinePost{
+		{ID: "first", Handle: "one", Text: "first"},
+		{ID: "root", Handle: "alice", Text: "root"},
+	}
+	m.selected = 1
+	m.syncViewport()
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if cmd == nil || m.mode != modeThread || m.threadRootID != "root" || m.feedSelected != 1 {
+		t.Fatalf("thread did not open: mode=%v root=%q feedSelected=%d", m.mode, m.threadRootID, m.feedSelected)
+	}
+	m = update(t, m, threadMsg{rootID: "root", seq: 1, page: &api.ConversationPage{Posts: []api.ConversationPost{
+		{TimelinePost: api.TimelinePost{ID: "root", Handle: "alice", Text: "root"}},
+		{TimelinePost: api.TimelinePost{ID: "reply", Handle: "bob", Text: "hello", InReplyToID: "root"}, Depth: 1},
+	}}})
+	if m.threadLoading || len(m.threadPosts) != 2 || !strings.Contains(m.View(), "↳ reply") {
+		t.Fatalf("thread did not render: loading=%v posts=%+v", m.threadLoading, m.threadPosts)
+	}
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyEsc})
+	if m.mode != modeFeed || m.selected != 1 || m.posts[m.selected].ID != "root" {
+		t.Fatalf("feed position was not restored: mode=%v selected=%d", m.mode, m.selected)
+	}
+}
+
+func TestThreadIgnoresStaleConversationAndKeepsFeedUpdatesAlive(t *testing.T) {
+	m := newModel("off", true)
+	m.loading = false
+	m.posts = []api.TimelinePost{{ID: "root", Text: "root"}}
+	m.mode = modeThread
+	m.threadRootID = "root"
+	m.threadPosts = []api.ConversationPost{{TimelinePost: m.posts[0]}}
+	m.threadLoading = true
+	m = update(t, m, threadMsg{rootID: "old", page: &api.ConversationPage{Posts: []api.ConversationPost{{
+		TimelinePost: api.TimelinePost{ID: "wrong", Text: "wrong"},
+	}}}})
+	if len(m.threadPosts) != 1 || m.threadPosts[0].ID != "root" || !m.threadLoading {
+		t.Fatalf("stale thread result was applied: %+v", m.threadPosts)
+	}
+	m.loadingMore = true
+	m = update(t, m, pageMsg{more: true, page: &api.TimelinePage{Posts: []api.TimelinePost{{ID: "next", Text: "next"}}}})
+	if m.loadingMore || len(m.posts) != 2 || m.mode != modeThread || m.selected != 0 {
+		t.Fatalf("feed update was dropped in thread mode: loadingMore=%v posts=%d selected=%d", m.loadingMore, len(m.posts), m.selected)
+	}
+}
+
+func TestThreadContinuationResolvesParentFromEarlierPage(t *testing.T) {
+	m := newModel("off", true)
+	m.loading = false
+	m.mode = modeThread
+	m.threadRootID = "root"
+	m.threadSeq = 1
+	m.threadMore = true
+	m.threadPosts = []api.ConversationPost{
+		{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}},
+		{TimelinePost: api.TimelinePost{ID: "parent", Text: "parent", InReplyToID: "root"}, Depth: 1},
+	}
+	m = update(t, m, threadMsg{rootID: "root", seq: 1, more: true, page: &api.ConversationPage{
+		Unresolved: []api.TimelinePost{{ID: "nested", Text: "nested", InReplyToID: "parent"}},
+	}})
+	if len(m.threadPosts) != 3 || m.threadPosts[2].ID != "nested" || m.threadPosts[2].Depth != 2 {
+		t.Fatalf("continuation was not resolved: %+v", m.threadPosts)
+	}
+}
+
+func TestThreadResultCompletesWhileReplyEditorIsOpen(t *testing.T) {
+	m := newModel("off", true)
+	m.loading = false
+	m.mode = modeThread
+	m.threadRootID = "root"
+	m.threadSeq = 1
+	m.threadLoading = true
+	m.threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}}}
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	m = update(t, m, threadMsg{rootID: "root", seq: 1, page: &api.ConversationPage{Posts: []api.ConversationPost{
+		{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}},
+		{TimelinePost: api.TimelinePost{ID: "reply", Text: "reply"}, Depth: 1},
+	}}})
+	if m.mode != modeReply || m.threadLoading || len(m.threadPosts) != 2 {
+		t.Fatalf("background thread result was dropped: mode=%v loading=%v posts=%d", m.mode, m.threadLoading, len(m.threadPosts))
+	}
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyEsc})
+	if m.mode != modeThread || len(m.threadPosts) != 2 {
+		t.Fatalf("cancel did not reveal loaded thread: mode=%v posts=%d", m.mode, len(m.threadPosts))
+	}
+}
+
+func TestFeedResultDuringThreadReplyPreservesBothSelections(t *testing.T) {
+	m := newModel("off", true)
+	m.loading = false
+	m.posts = []api.TimelinePost{{ID: "a", Text: "a"}, {ID: "root", Text: "root"}}
+	m.feedSelected = 1
+	m.mode = modeThread
+	m.threadRootID = "root"
+	m.threadPosts = []api.ConversationPost{
+		{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}},
+		{TimelinePost: api.TimelinePost{ID: "reply", Text: "reply"}, Depth: 1},
+	}
+	m.selected = 1
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	m = update(t, m, pageMsg{page: &api.TimelinePage{Posts: []api.TimelinePost{{ID: "new", Text: "new"}}}})
+	if m.mode != modeReply || m.selected != 1 || m.feedSelected != 2 {
+		t.Fatalf("background feed result corrupted selections: mode=%v thread=%d feed=%d", m.mode, m.selected, m.feedSelected)
+	}
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyEsc})
+	if m.mode != modeThread || m.selected != 1 || m.threadPosts[m.selected].ID != "reply" {
+		t.Fatalf("thread selection was not restored: mode=%v selected=%d", m.mode, m.selected)
+	}
+}
+
+func TestThreadIgnoresOlderRequestForSameRoot(t *testing.T) {
+	m := newModel("off", true)
+	m.loading = false
+	m.mode = modeThread
+	m.threadRootID = "root"
+	m.threadSeq = 2
+	m.threadLoading = true
+	m.threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "new root"}}}
+	m = update(t, m, threadMsg{rootID: "root", seq: 1, page: &api.ConversationPage{Posts: []api.ConversationPost{{
+		TimelinePost: api.TimelinePost{ID: "root", Text: "stale root"},
+	}}}})
+	if !m.threadLoading || m.threadPosts[0].Text != "new root" {
+		t.Fatalf("older same-root request was applied: loading=%v post=%+v", m.threadLoading, m.threadPosts[0])
+	}
+}
+
+func TestThreadReplyTargetsSelectedReplyAndReturnsToThread(t *testing.T) {
+	m := newModel("off", true)
+	m.loading = false
+	m.mode = modeThread
+	m.threadRootID = "root"
+	m.threadPosts = []api.ConversationPost{
+		{TimelinePost: api.TimelinePost{ID: "root", Handle: "alice", Text: "root"}},
+		{TimelinePost: api.TimelinePost{ID: "reply", Handle: "bob", Text: "hello"}, Depth: 1},
+	}
+	m.selected = 1
+	m.syncViewport()
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if m.mode != modeReply || m.replyReturn != modeThread || m.replyPost.ID != "reply" {
+		t.Fatalf("reply target=%q mode=%v return=%v", m.replyPost.ID, m.mode, m.replyReturn)
+	}
+	m.replyEditor.SetValue("nested answer")
+	m = update(t, m, replyResultMsg{id: "new"})
+	if m.mode != modeThread || !m.threadLoading || m.toast != "reply sent ♥" {
+		t.Fatalf("reply did not return and refresh thread: mode=%v loading=%v toast=%q", m.mode, m.threadLoading, m.toast)
+	}
+}
+
 func TestEnterExpandsTruncatedPost(t *testing.T) {
 	m := New()
 	m.loading = false

--- a/internal/timeline/preview.go
+++ b/internal/timeline/preview.go
@@ -93,7 +93,8 @@ func resolveImageMode(requested string) (imageMode, string) {
 }
 
 func (m *Model) requestPreviews() tea.Cmd {
-	if m.imageMode == imageModeOff || len(m.posts) == 0 || m.selected < 0 || m.selected >= len(m.posts) {
+	posts := m.activePosts()
+	if m.imageMode == imageModeOff || len(posts) == 0 || m.selected < 0 || m.selected >= len(posts) {
 		return nil
 	}
 	width := max(12, m.contentWidth()-4)
@@ -107,23 +108,23 @@ func (m *Model) requestPreviews() tea.Cmd {
 	var cmds []tea.Cmd
 	selectedChanged := false
 	from := max(0, m.selected-prefetchBehind)
-	to := min(len(m.posts)-1, m.selected+prefetchAhead)
+	to := min(len(posts)-1, m.selected+prefetchAhead)
 	if m.imageMode == imageModeNative || m.imageMode == imageModeWezTerm {
 		// Native terminals can render every image currently visible without the
 		// large text payload of ANSI previews. Include the viewport so images in
 		// tall windows load before the cursor lands directly on their post.
-		for i := range m.posts {
+		for i := range posts {
 			if i >= len(m.starts) || i >= len(m.ends) {
 				break
 			}
 			if m.ends[i] >= m.viewport.YOffset && m.starts[i] < m.viewport.YOffset+m.viewport.Height {
 				from = min(from, max(0, i-1))
-				to = max(to, min(len(m.posts)-1, i+1))
+				to = max(to, min(len(posts)-1, i+1))
 			}
 		}
 	}
 	for i := from; i <= to; i++ {
-		post := m.posts[i]
+		post := posts[i]
 		if len(post.Media) == 0 {
 			continue
 		}
@@ -187,9 +188,10 @@ func (m *Model) evictDistantPreviews() {
 	if len(m.previews) <= maxCachedPreviews {
 		return
 	}
-	index := make(map[string]int, len(m.posts))
-	for i := range m.posts {
-		index[m.posts[i].ID] = i
+	posts := m.activePosts()
+	index := make(map[string]int, len(posts))
+	for i := range posts {
+		index[posts[i].ID] = i
 	}
 	activeZoom := ""
 	if post, ok := m.currentPost(); ok && m.zoom {

--- a/internal/timeline/preview_test.go
+++ b/internal/timeline/preview_test.go
@@ -324,6 +324,20 @@ func TestPreviewsPrefetchAroundSelection(t *testing.T) {
 	}
 }
 
+func TestThreadSelectionRequestsInlinePreview(t *testing.T) {
+	m := NewWithImageMode("ansi")
+	m.loading = false
+	m.mode = modeThread
+	m.threadRootID = "root"
+	m.threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{
+		ID: "root", Text: "photo", Media: []api.TimelineMedia{{URL: "https://example.com/photo.jpg"}},
+	}}}
+	m.syncViewport()
+	if cmd := m.requestPreviews(); cmd == nil || !m.previews["root"].loading {
+		t.Fatalf("thread preview was not requested: cmd=%v state=%+v", cmd, m.previews["root"])
+	}
+}
+
 func TestNativePrefetchIncludesVisiblePosts(t *testing.T) {
 	m := NewWithImageMode("native")
 	m.imageMode = imageModeNative

--- a/internal/timeline/view.go
+++ b/internal/timeline/view.go
@@ -106,16 +106,9 @@ func (m Model) footer() string {
 		return fmt.Sprintf("%d/%d  ·  ? help", position, len(m.posts))
 	}
 	if m.expanded {
-		key := "enter"
-		if m.threadsEnabled {
-			key = "e"
-		}
-		return fmt.Sprintf("%d/%d · %s collapse · o browser · ? help", position, len(m.posts), key)
+		return fmt.Sprintf("%d/%d · e collapse · o browser · ? help", position, len(m.posts))
 	}
-	if m.threadsEnabled {
-		return fmt.Sprintf("%d/%d · enter replies · e read · r reply · ? help", position, len(m.posts))
-	}
-	return fmt.Sprintf("%d/%d · enter read · l like · r reply · ? help", position, len(m.posts))
+	return fmt.Sprintf("%d/%d · enter replies · e read · r reply · ? help", position, len(m.posts))
 }
 
 func (m Model) errorFooter(includeQuit bool) string {
@@ -573,18 +566,12 @@ func (m Model) viewHelp() string {
 	if w > 54 {
 		w = 54
 	}
-	keys := "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nl           like / unlike\nr           reply\nR           refresh\nenter       read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\nP           new post\ng / G       top / bottom\nctrl+l      redraw screen\nq           quit"
-	if m.threadsEnabled {
-		keys = strings.Replace(keys, "enter       read full post", "enter       open replies\ne / space   read full post", 1)
-	}
+	keys := "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nl           like / unlike\nr           reply\nR           refresh\nenter       open replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\nP           new post\ng / G       top / bottom\nctrl+l      redraw screen\nq           quit"
 	if m.mode == modeThread {
 		keys = "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nl           like / unlike\nr           reply to selected\nR           refresh replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\ng / G       top / bottom\nctrl+l      redraw screen\nesc         back to timeline\nq           quit"
 	}
 	if m.height < 25 {
-		keys = "\n\nj/k move · g/G ends\nl like · r reply · y copy\nenter read · i zoom · A alt text\nR refresh · o browser\nP compose · ctrl+l redraw\nq quit"
-		if m.threadsEnabled {
-			keys = strings.Replace(keys, "enter read", "enter replies · e read", 1)
-		}
+		keys = "\n\nj/k move · g/G ends\nl like · r reply · y copy\nenter replies · e read · i zoom · A alt text\nR refresh · o browser\nP compose · ctrl+l redraw\nq quit"
 		if m.mode == modeThread {
 			keys = "\n\nj/k move · g/G ends\nl like · r reply · y copy\ne read · i zoom · A alt text\nR refresh · o browser\nesc back · q quit"
 		}

--- a/internal/timeline/view.go
+++ b/internal/timeline/view.go
@@ -28,6 +28,9 @@ func (m Model) View() string {
 	if m.mode == modeReply {
 		return m.viewReply()
 	}
+	if m.mode == modeThread {
+		return m.viewThread()
+	}
 
 	footer := m.footer()
 	if m.loading && len(m.posts) == 0 {
@@ -67,7 +70,12 @@ func (m Model) contentWidth() int {
 
 func (m Model) header(width int) string {
 	status := "home"
-	if m.refreshing {
+	if m.mode == modeThread {
+		status = "replies"
+	}
+	if m.mode == modeThread && (m.threadLoading || m.threadMore) {
+		status = m.spinner.View() + " loading replies"
+	} else if m.refreshing {
 		status = m.spinner.View() + " refreshing"
 	} else if m.loadingMore {
 		status = m.spinner.View() + " loading more"
@@ -98,7 +106,14 @@ func (m Model) footer() string {
 		return fmt.Sprintf("%d/%d  ·  ? help", position, len(m.posts))
 	}
 	if m.expanded {
-		return fmt.Sprintf("%d/%d · enter collapse · o browser · ? help", position, len(m.posts))
+		key := "enter"
+		if m.threadsEnabled {
+			key = "e"
+		}
+		return fmt.Sprintf("%d/%d · %s collapse · o browser · ? help", position, len(m.posts), key)
+	}
+	if m.threadsEnabled {
+		return fmt.Sprintf("%d/%d · enter replies · e read · r reply · ? help", position, len(m.posts))
 	}
 	return fmt.Sprintf("%d/%d · enter read · l like · r reply · ? help", position, len(m.posts))
 }
@@ -112,6 +127,63 @@ func (m Model) errorFooter(includeQuit bool) string {
 		parts = append(parts, "q quit")
 	}
 	return strings.Join(parts, "  ·  ")
+}
+
+func (m Model) viewThread() string {
+	footer := m.threadFooter()
+	if m.threadLoading && len(m.threadPosts) <= 1 {
+		center := lipgloss.Place(m.viewport.Width, m.viewport.Height, lipgloss.Center, lipgloss.Center,
+			lipgloss.NewStyle().Foreground(lavender).Render(m.spinner.View()+" gathering replies…"))
+		return m.shell(center, footer)
+	}
+	if m.threadErr != nil && len(m.threadPosts) == 0 {
+		center := lipgloss.Place(m.viewport.Width, m.viewport.Height, lipgloss.Center, lipgloss.Center,
+			lipgloss.NewStyle().Foreground(red).Width(max(20, m.viewport.Width-8)).Align(lipgloss.Center).
+				Render("the cat lost the replies\n\n"+m.threadErr.Error()))
+		return m.shell(center, "R retry · esc back")
+	}
+	return m.shell(m.viewport.View(), footer)
+}
+
+func (m Model) threadFooter() string {
+	if m.toast != "" {
+		return m.toast
+	}
+	if m.threadErr != nil {
+		return "R retry · esc back"
+	}
+	position := 0
+	if len(m.threadPosts) > 0 {
+		position = m.selected + 1
+	}
+	return fmt.Sprintf("%d/%d · r reply · e read · esc back · ? help", position, len(m.threadPosts))
+}
+
+func (m Model) renderThreadContent() (string, []int, []int) {
+	if len(m.threadPosts) == 0 {
+		return lipgloss.NewStyle().Foreground(muted).Width(m.contentWidth()).Align(lipgloss.Center).Render("no replies yet · press r to start one"), nil, nil
+	}
+	blocks := make([]string, 0, len(m.threadPosts))
+	starts := make([]int, 0, len(m.threadPosts))
+	ends := make([]int, 0, len(m.threadPosts))
+	line := 0
+	for i, item := range m.threadPosts {
+		block := m.renderPost(item.TimelinePost, i == m.selected, true)
+		if item.Depth > 0 {
+			depth := min(item.Depth, 3)
+			branch := strings.Repeat("  ", depth-1) + "↳ reply"
+			block = lipgloss.NewStyle().Foreground(muted).Render(branch) + "\n" + block
+		}
+		height := lipgloss.Height(block)
+		starts = append(starts, line)
+		ends = append(ends, line+height-1)
+		blocks = append(blocks, block)
+		line += height
+		if i < len(m.threadPosts)-1 {
+			line++
+		}
+	}
+	return strings.Join(blocks, "\n\n"), starts, ends
 }
 
 func (m Model) renderFeedContent() (string, []int, []int) {
@@ -494,8 +566,20 @@ func (m Model) viewHelp() string {
 		w = 54
 	}
 	keys := "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nl           like / unlike\nr           reply\nR           refresh\nenter       read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\nP           new post\ng / G       top / bottom\nctrl+l      redraw screen\nq           quit"
+	if m.threadsEnabled {
+		keys = strings.Replace(keys, "enter       read full post", "enter       open replies\ne / space   read full post", 1)
+	}
+	if m.mode == modeThread {
+		keys = "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nl           like / unlike\nr           reply to selected\nR           refresh replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\ng / G       top / bottom\nesc         back to timeline\nq           quit"
+	}
 	if m.height < 25 {
 		keys = "\n\nj/k move · g/G ends\nl like · r reply · y copy\nenter read · i zoom · A alt text\nR refresh · o browser\nP compose · ctrl+l redraw\nq quit"
+		if m.threadsEnabled {
+			keys = strings.Replace(keys, "enter read", "enter replies · e read", 1)
+		}
+		if m.mode == modeThread {
+			keys = "\n\nj/k move · g/G ends\nl like · r reply · y copy\ne read · i zoom · A alt text\nR refresh · o browser\nesc back · q quit"
+		}
 	}
 	images := "images: " + string(m.imageMode)
 	if m.imageNote != "" && m.height >= 28 {

--- a/internal/timeline/view.go
+++ b/internal/timeline/view.go
@@ -81,7 +81,7 @@ func (m Model) header(width int) string {
 		status = m.spinner.View() + " loading more"
 	}
 	face := "( o.o )"
-	if m.err != nil {
+	if m.err != nil || (m.mode == modeThread && m.threadErr != nil) {
 		face = "( >.< )"
 	}
 	cat := lipgloss.NewStyle().Foreground(pink).Render(" /\\_/\\") +
@@ -136,11 +136,14 @@ func (m Model) viewThread() string {
 			lipgloss.NewStyle().Foreground(lavender).Render(m.spinner.View()+" gathering replies…"))
 		return m.shell(center, footer)
 	}
-	if m.threadErr != nil && len(m.threadPosts) == 0 {
+	// The thread opens pre-seeded with the focal post, so a fetch failure
+	// almost never leaves the list empty. Show the error over the posts we
+	// have instead of hiding it behind a bare retry footer.
+	if m.threadErr != nil {
 		center := lipgloss.Place(m.viewport.Width, m.viewport.Height, lipgloss.Center, lipgloss.Center,
 			lipgloss.NewStyle().Foreground(red).Width(max(20, m.viewport.Width-8)).Align(lipgloss.Center).
 				Render("the cat lost the replies\n\n"+m.threadErr.Error()))
-		return m.shell(center, "R retry · esc back")
+		return m.shell(center, footer)
 	}
 	return m.shell(m.viewport.View(), footer)
 }
@@ -150,7 +153,12 @@ func (m Model) threadFooter() string {
 		return m.toast
 	}
 	if m.threadErr != nil {
-		return "R retry · esc back"
+		parts := []string{"R retry"}
+		if errors.Is(m.threadErr, api.ErrSessionExpired) {
+			parts = append([]string{"a reconnect"}, parts...)
+		}
+		parts = append(parts, "esc back")
+		return strings.Join(parts, "  ·  ")
 	}
 	position := 0
 	if len(m.threadPosts) > 0 {
@@ -570,7 +578,7 @@ func (m Model) viewHelp() string {
 		keys = strings.Replace(keys, "enter       read full post", "enter       open replies\ne / space   read full post", 1)
 	}
 	if m.mode == modeThread {
-		keys = "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nl           like / unlike\nr           reply to selected\nR           refresh replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\ng / G       top / bottom\nesc         back to timeline\nq           quit"
+		keys = "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nl           like / unlike\nr           reply to selected\nR           refresh replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\ng / G       top / bottom\nctrl+l      redraw screen\nesc         back to timeline\nq           quit"
 	}
 	if m.height < 25 {
 		keys = "\n\nj/k move · g/G ends\nl like · r reply · y copy\nenter read · i zoom · A alt text\nR refresh · o browser\nP compose · ctrl+l redraw\nq quit"

--- a/pkg/api/conversation.go
+++ b/pkg/api/conversation.go
@@ -1,0 +1,245 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// ConversationPost is one post in a TweetDetail conversation. Depth is
+// relative to the focal post (the focal post itself has depth zero).
+type ConversationPost struct {
+	TimelinePost
+	Depth int
+}
+
+// ConversationPage is one ordered page from X's TweetDetail timeline.
+type ConversationPage struct {
+	Posts      []ConversationPost
+	Unresolved []TimelinePost
+	Cursor     string
+}
+
+// FetchTweetDetail retrieves a post and the replies X returns for it.
+func (c *WebClient) FetchTweetDetail(ctx context.Context, tweetID, cursor string, count int) (*ConversationPage, error) {
+	if c.authToken == "" || c.ct0 == "" {
+		return nil, fmt.Errorf("no session; run 'xeet auth' first")
+	}
+	if tweetID == "" {
+		return nil, fmt.Errorf("tweet id is required")
+	}
+	if count <= 0 || count > 100 {
+		count = 40
+	}
+
+	qid := c.operationQueryID("TweetDetail", "", "XEET_TWEETDETAIL_QID")
+	if qid == "" {
+		fresh, err := c.discoverOperation(ctx, "TweetDetail")
+		if err != nil {
+			return nil, fmt.Errorf("discover tweet detail endpoint: %w", err)
+		}
+		qid = fresh
+	}
+	res, err := c.doTweetDetail(ctx, qid, tweetID, cursor, count)
+	if err != nil {
+		return nil, err
+	}
+	if needsQueryIDRefresh(res) {
+		fresh, discoverErr := c.discoverOperation(ctx, "TweetDetail")
+		if discoverErr != nil {
+			return nil, fmt.Errorf("tweet detail endpoint changed and discovery failed: %w", discoverErr)
+		}
+		res, err = c.doTweetDetail(ctx, fresh, tweetID, cursor, count)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if err := statusToError(res.status, res.header); err != nil {
+		return nil, err
+	}
+	if isTransientStatus(res.status) {
+		return nil, &ServiceUnavailableError{Status: res.status}
+	}
+	if res.status != http.StatusOK {
+		return nil, fmt.Errorf("tweet detail API error %d: %s", res.status, truncate(res.body))
+	}
+
+	var payload any
+	if err := json.Unmarshal(res.body, &payload); err != nil {
+		return nil, fmt.Errorf("decode tweet detail: %w", err)
+	}
+	root, ok := payload.(map[string]any)
+	if !ok || root["data"] == nil {
+		return nil, fmt.Errorf("x returned a malformed tweet detail response")
+	}
+	if err := graphQLError(payload); err != nil {
+		return nil, err
+	}
+	page := parseConversation(payload, tweetID)
+	return &page, nil
+}
+
+// doTweetDetail is a read, so transient failures are retried.
+func (c *WebClient) doTweetDetail(ctx context.Context, qid, tweetID, cursor string, count int) (*httpResult, error) {
+	variables := map[string]any{
+		"focalTweetId":                           tweetID,
+		"referrer":                               "tweet",
+		"with_rux_injections":                    false,
+		"rankingMode":                            "Relevance",
+		"includePromotedContent":                 false,
+		"withCommunity":                          true,
+		"withQuickPromoteEligibilityTweetFields": true,
+		"withBirdwatchNotes":                     true,
+		"withVoice":                              true,
+	}
+	if cursor != "" {
+		variables["cursor"] = cursor
+	}
+	// TweetDetail has changed its count variable over time. Sending it is
+	// harmless when ignored and keeps continuation pages bounded when honored.
+	variables["count"] = count
+	variablesJSON, _ := json.Marshal(variables)
+	featuresJSON, _ := json.Marshal(timelineFeatures)
+	fieldTogglesJSON, _ := json.Marshal(timelineFieldToggles)
+
+	params := url.Values{}
+	params.Set("variables", string(variablesJSON))
+	params.Set("features", string(featuresJSON))
+	params.Set("fieldToggles", string(fieldTogglesJSON))
+	endpoint := fmt.Sprintf("https://x.com/i/api/graphql/%s/TweetDetail?%s", qid, params.Encode())
+	return c.send(ctx, func() (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+		if err != nil {
+			return nil, err
+		}
+		c.setHeaders(req)
+		return req, nil
+	}, true, 20<<20)
+}
+
+func parseConversation(payload any, focalID string) ConversationPage {
+	page := ConversationPage{}
+	seen := map[string]bool{}
+	var ordered []TimelinePost
+
+	parseItemContent := func(raw any) {
+		item, ok := raw.(map[string]any)
+		if !ok {
+			return
+		}
+		if post, ok := parseTimelineItem(item); ok && !seen[post.ID] {
+			seen[post.ID] = true
+			ordered = append(ordered, post)
+		}
+	}
+
+	parseEntry := func(raw any) {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			return
+		}
+		content, _ := entry["content"].(map[string]any)
+		if content == nil {
+			content = entry
+		}
+		parseCursor := func(item map[string]any) {
+			cursorType, _ := item["cursorType"].(string)
+			kind := strings.ToLower(cursorType)
+			if kind == "bottom" || strings.Contains(kind, "showmore") {
+				if value, _ := item["value"].(string); value != "" {
+					page.Cursor = value
+				}
+			}
+		}
+		parseCursor(content)
+		if item, ok := content["itemContent"].(map[string]any); ok {
+			parseCursor(item)
+			parseItemContent(item)
+		}
+		if items, ok := content["items"].([]any); ok {
+			for _, rawItem := range items {
+				moduleItem, _ := rawItem.(map[string]any)
+				item, _ := moduleItem["item"].(map[string]any)
+				if item == nil {
+					item = moduleItem
+				}
+				if itemContent, ok := item["itemContent"].(map[string]any); ok {
+					parseCursor(itemContent)
+					parseItemContent(itemContent)
+				}
+			}
+		}
+	}
+
+	// Locate instruction entry arrays, then parse each array in API order.
+	var walk func(any)
+	walk = func(node any) {
+		switch value := node.(type) {
+		case map[string]any:
+			if entries, ok := value["entries"].([]any); ok {
+				for _, entry := range entries {
+					parseEntry(entry)
+				}
+				return
+			}
+			for _, child := range value {
+				walk(child)
+			}
+		case []any:
+			for _, child := range value {
+				walk(child)
+			}
+		}
+	}
+	walk(payload)
+
+	byID := make(map[string]TimelinePost, len(ordered))
+	for _, post := range ordered {
+		byID[post.ID] = post
+	}
+	depthOf := func(post TimelinePost) (int, bool) {
+		if post.ID == focalID {
+			return 0, true
+		}
+		depth := 1
+		parent := post.InReplyToID
+		visited := map[string]bool{post.ID: true}
+		for parent != "" && !visited[parent] {
+			if parent == focalID {
+				return depth, true
+			}
+			visited[parent] = true
+			ancestor, ok := byID[parent]
+			if !ok {
+				return 0, false
+			}
+			parent = ancestor.InReplyToID
+			depth++
+		}
+		return 0, false
+	}
+
+	// The API may place ancestors before the focal post. Keep only the focal
+	// post and its descendants, while preserving reply order from X.
+	if focal, ok := byID[focalID]; ok {
+		page.Posts = append(page.Posts, ConversationPost{TimelinePost: focal})
+	}
+	for _, post := range ordered {
+		if post.ID == focalID {
+			continue
+		}
+		if depth, ok := depthOf(post); ok {
+			page.Posts = append(page.Posts, ConversationPost{TimelinePost: post, Depth: depth})
+		} else if post.InReplyToID != "" {
+			// A continuation can omit a nested reply's parent because that parent
+			// was delivered on an earlier page. The model resolves these against
+			// its accumulated conversation; ancestors and unrelated posts remain
+			// unresolved and are not displayed.
+			page.Unresolved = append(page.Unresolved, post)
+		}
+	}
+	return page
+}

--- a/pkg/api/conversation_live_test.go
+++ b/pkg/api/conversation_live_test.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"xeet/pkg/config"
+)
+
+// Read-only smoke test for X's unsupported TweetDetail endpoint.
+func TestTweetDetailLive(t *testing.T) {
+	if os.Getenv("XEET_LIVE_CONVERSATION") != "1" {
+		t.Skip("set XEET_LIVE_CONVERSATION=1 to run")
+	}
+	mgr, err := config.NewConfigManager()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := mgr.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	client := NewWebClient(cfg)
+	home, err := client.FetchHomeTimeline(ctx, "", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(home.Posts) == 0 {
+		t.Skip("home timeline returned no posts")
+	}
+	page, err := client.FetchTweetDetail(ctx, home.Posts[0].ID, "", 40)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Posts) == 0 || page.Posts[0].ID != home.Posts[0].ID {
+		t.Fatalf("focal post missing: selected=%s page=%+v", home.Posts[0].ID, page)
+	}
+	if page.Cursor != "" {
+		if _, err := client.FetchTweetDetail(ctx, home.Posts[0].ID, page.Cursor, 40); err != nil {
+			t.Fatalf("fetch reply continuation: %v", err)
+		}
+	}
+}

--- a/pkg/api/conversation_test.go
+++ b/pkg/api/conversation_test.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"xeet/pkg/config"
+)
+
+func TestParseConversationKeepsFocalAndDescendantsInOrder(t *testing.T) {
+	item := func(id, text, parent string) map[string]any {
+		legacy := map[string]any{"full_text": text}
+		if parent != "" {
+			legacy["in_reply_to_status_id_str"] = parent
+		}
+		return map[string]any{"tweet_results": map[string]any{"result": map[string]any{
+			"rest_id": id, "legacy": legacy,
+		}}}
+	}
+	entry := func(id, text, parent string) map[string]any {
+		return map[string]any{"content": map[string]any{"itemContent": item(id, text, parent)}}
+	}
+	payload := map[string]any{"data": map[string]any{"thread": map[string]any{"instructions": []any{
+		map[string]any{"entries": []any{
+			entry("9", "ancestor", ""),
+			entry("10", "root", "9"),
+			map[string]any{"content": map[string]any{"items": []any{
+				map[string]any{"item": map[string]any{"itemContent": item("11", "first", "10")}},
+				map[string]any{"item": map[string]any{"itemContent": item("12", "nested", "11")}},
+			}}},
+			entry("20", "unrelated", "99"),
+			map[string]any{"content": map[string]any{"itemContent": map[string]any{"cursorType": "ShowMoreThreads", "value": "next-replies"}}},
+		}},
+	}}}}
+	page := parseConversation(payload, "10")
+	if page.Cursor != "next-replies" || len(page.Posts) != 3 {
+		t.Fatalf("page=%+v", page)
+	}
+	for i, want := range []struct {
+		id    string
+		depth int
+	}{{"10", 0}, {"11", 1}, {"12", 2}} {
+		if page.Posts[i].ID != want.id || page.Posts[i].Depth != want.depth {
+			t.Fatalf("post %d = %+v, want id=%s depth=%d", i, page.Posts[i], want.id, want.depth)
+		}
+	}
+}
+
+func TestParseConversationDefersReplyWhoseParentIsOnEarlierPage(t *testing.T) {
+	item := func(id, parent string) map[string]any {
+		return map[string]any{"tweet_results": map[string]any{"result": map[string]any{
+			"rest_id": id, "legacy": map[string]any{"full_text": id, "in_reply_to_status_id_str": parent},
+		}}}
+	}
+	payload := map[string]any{"data": map[string]any{"thread": map[string]any{"entries": []any{
+		map[string]any{"content": map[string]any{"itemContent": item("root", "")}},
+		map[string]any{"content": map[string]any{"itemContent": item("nested", "parent-from-page-one")}},
+	}}}}
+	page := parseConversation(payload, "root")
+	if len(page.Posts) != 1 || len(page.Unresolved) != 1 || page.Unresolved[0].ID != "nested" {
+		t.Fatalf("page=%+v", page)
+	}
+}
+
+func TestFetchTweetDetailUsesConfiguredQueryIDAndVariables(t *testing.T) {
+	client := NewWebClient(&config.Config{AuthToken: "auth", CT0: "csrf", TweetDetailQID: "detail-qid"})
+	client.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if !strings.Contains(req.URL.Path, "/detail-qid/TweetDetail") {
+			t.Fatalf("path=%s", req.URL.Path)
+		}
+		variables := req.URL.Query().Get("variables")
+		for _, want := range []string{`"focalTweetId":"123"`, `"cursor":"next"`, `"count":25`} {
+			if !strings.Contains(variables, want) {
+				t.Fatalf("variables %s missing %s", variables, want)
+			}
+		}
+		return response(http.StatusOK, `{"data":{"threaded_conversation_with_injections_v2":{"instructions":[]}}}`), nil
+	})}
+	page, err := client.FetchTweetDetail(context.Background(), "123", "next", 25)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Posts) != 0 {
+		t.Fatalf("posts=%+v", page.Posts)
+	}
+}
+
+func TestTweetDetailRefreshesRotatedQueryID(t *testing.T) {
+	attempts := 0
+	client := newTestClient(func(req *http.Request) (*http.Response, error) {
+		attempts++
+		if attempts == 1 {
+			return response(http.StatusNotFound, `{}`), nil
+		}
+		if !strings.Contains(req.URL.Path, "/fresh-detail/TweetDetail") {
+			t.Fatalf("retry path=%s", req.URL.Path)
+		}
+		return response(http.StatusOK, `{"data":{"threaded_conversation_with_injections_v2":{"instructions":[]}}}`), nil
+	})
+	client.operationQIDs = map[string]string{"TweetDetail": "stale-detail"}
+	client.discover = func(context.Context, string, string, string) (string, error) { return "fresh-detail", nil }
+	if _, err := client.FetchTweetDetail(context.Background(), "123", "", 40); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{}
+	if attempts != 2 || !client.ApplyRefreshedQueryIDs(cfg) || cfg.TweetDetailQID != "fresh-detail" {
+		t.Fatalf("attempts=%d cfg=%+v", attempts, cfg)
+	}
+}

--- a/pkg/api/conversation_test.go
+++ b/pkg/api/conversation_test.go
@@ -87,6 +87,14 @@ func TestFetchTweetDetailUsesConfiguredQueryIDAndVariables(t *testing.T) {
 	}
 }
 
+func TestOperationHintKeepsTweetDetailOffTheComposeBundle(t *testing.T) {
+	// The generic "Tweet" hint maps to the Compose bundle, which does not
+	// contain the TweetDetail operation. Discovery must search its own chunk.
+	if got := operationHint("TweetDetail"); got != "TweetDetail" {
+		t.Fatalf("operationHint(TweetDetail) = %q", got)
+	}
+}
+
 func TestTweetDetailRefreshesRotatedQueryID(t *testing.T) {
 	attempts := 0
 	client := newTestClient(func(req *http.Request) (*http.Response, error) {

--- a/pkg/api/discover.go
+++ b/pkg/api/discover.go
@@ -103,6 +103,9 @@ func webpackChunkURLs(runtime, operation string) []string {
 }
 
 func operationHint(operation string) string {
+	if operation == "TweetDetail" {
+		return "TweetDetail"
+	}
 	if strings.Contains(operation, "Home") {
 		return "HomeTimeline"
 	}

--- a/pkg/api/timeline.go
+++ b/pkg/api/timeline.go
@@ -22,18 +22,20 @@ type TimelineMedia struct {
 }
 
 type TimelinePost struct {
-	ID          string
-	Text        string
-	AuthorName  string
-	Handle      string
-	CreatedAt   time.Time
-	ReplyCount  int
-	RepostCount int
-	LikeCount   int
-	ViewCount   string
-	MediaCount  int
-	Media       []TimelineMedia
-	Liked       bool
+	ID             string
+	Text           string
+	AuthorName     string
+	Handle         string
+	CreatedAt      time.Time
+	ReplyCount     int
+	RepostCount    int
+	LikeCount      int
+	ViewCount      string
+	MediaCount     int
+	Media          []TimelineMedia
+	Liked          bool
+	InReplyToID    string
+	ConversationID string
 }
 
 type TimelinePage struct {
@@ -239,6 +241,8 @@ func parseTimelineItem(item map[string]any) (TimelinePost, bool) {
 	post.RepostCount = intValue(legacy["retweet_count"])
 	post.LikeCount = intValue(legacy["favorite_count"])
 	post.Liked, _ = legacy["favorited"].(bool)
+	post.InReplyToID, _ = legacy["in_reply_to_status_id_str"].(string)
+	post.ConversationID, _ = legacy["conversation_id_str"].(string)
 	if created, _ := legacy["created_at"].(string); created != "" {
 		post.CreatedAt, _ = time.Parse("Mon Jan 02 15:04:05 -0700 2006", created)
 	}

--- a/pkg/api/web.go
+++ b/pkg/api/web.go
@@ -172,6 +172,7 @@ func NewWebClient(cfg *config.Config) *WebClient {
 		"FavoriteTweet":   cfg.FavoriteTweetQID,
 		"UnfavoriteTweet": cfg.UnfavoriteTweetQID,
 		"Viewer":          cfg.ViewerQID,
+		"TweetDetail":     cfg.TweetDetailQID,
 	}
 	qid := operationQIDs["CreateTweet"]
 	if qid == "" {
@@ -250,6 +251,8 @@ func (c *WebClient) ApplyRefreshedQueryIDs(cfg *config.Config) bool {
 			cfg.UnfavoriteTweetQID = qid
 		case "Viewer":
 			cfg.ViewerQID = qid
+		case "TweetDetail":
+			cfg.TweetDetailQID = qid
 		}
 	}
 	return true

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,10 +15,10 @@ import (
 )
 
 // Config is the whole of xeet's saved state: your x.com browser session plus
-// one cached, non-secret value. AuthToken is the session cookie and CT0 is the
-// matching CSRF token; both live in the OS keyring (macOS Keychain, Linux
+// cached, non-secret operation ids and session metadata. AuthToken is the
+// session cookie and CT0 is the matching CSRF token; both live in the OS keyring (macOS Keychain, Linux
 // Secret Service), never on disk. The config file contains only non-secret
-// state: X's rotating GraphQL query id and browser-session source metadata used
+// state: X's rotating GraphQL query ids and browser-session source metadata used
 // by `xeet doctor`.
 type Config struct {
 	AuthToken          string    `yaml:"-"`
@@ -28,6 +28,7 @@ type Config struct {
 	FavoriteTweetQID   string    `yaml:"favorite_tweet_qid,omitempty"`
 	UnfavoriteTweetQID string    `yaml:"unfavorite_tweet_qid,omitempty"`
 	ViewerQID          string    `yaml:"viewer_qid,omitempty"`
+	TweetDetailQID     string    `yaml:"tweet_detail_qid,omitempty"`
 	SessionBrowser     string    `yaml:"session_browser,omitempty"`
 	SessionProfile     string    `yaml:"session_profile,omitempty"`
 	SessionDomain      string    `yaml:"session_domain,omitempty"`
@@ -97,6 +98,7 @@ type fileConfig struct {
 	FavoriteTweetQID   string `yaml:"favorite_tweet_qid,omitempty"`
 	UnfavoriteTweetQID string `yaml:"unfavorite_tweet_qid,omitempty"`
 	ViewerQID          string `yaml:"viewer_qid,omitempty"`
+	TweetDetailQID     string `yaml:"tweet_detail_qid,omitempty"`
 	SessionBrowser     string `yaml:"session_browser,omitempty"`
 	SessionProfile     string `yaml:"session_profile,omitempty"`
 	SessionDomain      string `yaml:"session_domain,omitempty"`
@@ -138,6 +140,7 @@ func (cm *ConfigManager) Load() (*Config, error) {
 		FavoriteTweetQID:   fc.FavoriteTweetQID,
 		UnfavoriteTweetQID: fc.UnfavoriteTweetQID,
 		ViewerQID:          fc.ViewerQID,
+		TweetDetailQID:     fc.TweetDetailQID,
 		SessionBrowser:     fc.SessionBrowser,
 		SessionProfile:     fc.SessionProfile,
 		SessionDomain:      fc.SessionDomain,
@@ -223,7 +226,7 @@ func (cm *ConfigManager) Save(config *Config) error {
 		return cm.writeFile(&fileConfig{
 			CreateTweetQID: config.CreateTweetQID, HomeTimelineQID: config.HomeTimelineQID,
 			FavoriteTweetQID: config.FavoriteTweetQID, UnfavoriteTweetQID: config.UnfavoriteTweetQID,
-			ViewerQID: config.ViewerQID,
+			ViewerQID: config.ViewerQID, TweetDetailQID: config.TweetDetailQID,
 		})
 	}
 
@@ -261,6 +264,7 @@ func fileConfigFor(config *Config) *fileConfig {
 		FavoriteTweetQID:   config.FavoriteTweetQID,
 		UnfavoriteTweetQID: config.UnfavoriteTweetQID,
 		ViewerQID:          config.ViewerQID,
+		TweetDetailQID:     config.TweetDetailQID,
 		SessionBrowser:     config.SessionBrowser,
 		SessionProfile:     config.SessionProfile,
 		SessionDomain:      config.SessionDomain,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -46,6 +46,7 @@ func TestSaveLoadRoundtrip(t *testing.T) {
 	in := &Config{
 		AuthToken: "tok123", CT0: "csrf456", CreateTweetQID: "qid789",
 		HomeTimelineQID: "home123", FavoriteTweetQID: "like123", UnfavoriteTweetQID: "unlike123", ViewerQID: "viewer123",
+		TweetDetailQID: "detail123",
 		SessionBrowser: "Firefox", SessionProfile: "default-release", SessionDomain: "x.com",
 		SessionExpires:  time.Date(2027, 1, 2, 3, 4, 5, 0, time.UTC),
 		SessionImported: time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC),


### PR DESCRIPTION
## Summary

- **Enter** on a timeline post now opens its conversation: the focal post plus its replies, in place.
- **e / Space** reads a truncated post in full (replaces Enter's old expand role).
- Inside a conversation: **j/k** navigate, **r** replies to the selected item, **R** reloads, **Esc** returns to the same feed position.
- New read-only `FetchTweetDetail` API: TweetDetail query-ID discovery and caching (`TweetDetailQID`), nested reply parsing with cross-page parent resolution, cursor pagination (including ShowMoreThreads), and stale-request protection (rootID + sequence guards).
- Thread errors are shown in full with the sad-face header; session expiry offers **a** reconnect in thread mode and hands the error back to the feed on Esc.
- A refresh that omits the focal post keeps the conversation root.
- Inline image previews work inside conversations, with cache eviction.

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...` / `staticcheck ./...`
- `go build ./...`
- Opt-in read-only live test: `XEET_LIVE_CONVERSATION=1 go test -run TestTweetDetailLive ./pkg/api`

## Notes

TweetDetail is an unsupported x.com web endpoint; requests are read-only GETs and are never retried as mutations. Its persisted-query id is discovered from X's live JS bundles and cached in the config like the other operations.