### PR TITLE
Release v0.1.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Build and publish release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out tagged source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install X11 headers
+        run: sudo apt-get update && sudo apt-get install -y libx11-dev
+
+      - name: Run tests
+        run: go test ./...
+
+      - name: Publish binaries and checksums
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,52 @@
+version: 2
+
+project_name: xeet
+
+before:
+  hooks:
+    - go mod download
+
+builds:
+  - id: xeet
+    main: .
+    binary: xeet
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{ .Version }}
+      - -X main.commit={{ .Commit }}
+      - -X main.buildTime={{ .Date }}
+
+archives:
+  - id: archives
+    builds:
+      - xeet
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^Merge '
+      - '^docs:'
+      - '^test:'
+
+release:
+  draft: false
+  prerelease: auto
+  mode: replace

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Xeet v0.1.8-alpha
+# Xeet v0.1.8
 
 A simple terminal interface for posting to and browsing X without developer
 API keys.

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"strings"
 	"time"
 
@@ -73,6 +74,7 @@ type Model struct {
 	previews      map[string]previewState
 	spinner       spinner.Model
 	viewport      viewport.Model
+	wezFrameKey   string
 
 	mode          mode
 	feedSelected  int
@@ -124,6 +126,10 @@ type threadMsg struct {
 type replyBrowserMsg struct{ err error }
 
 type toastClearMsg struct{ seq int }
+
+// wezRepaintMsg asks the model to decide whether the iTerm2-protocol frame
+// moved and therefore needs a full clear before Bubble Tea repaints.
+type wezRepaintMsg struct{}
 
 type clockTickMsg time.Time
 
@@ -308,6 +314,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.syncViewport()
 		}
 		return m, clockTick()
+	}
+	if _, ok := msg.(wezRepaintMsg); ok {
+		if m.imageMode != imageModeWezTerm {
+			return m, nil
+		}
+		// iTerm2-protocol images are painted pixels, not cells: when content
+		// scrolls, Bubble Tea's line diff can leave stale pixels behind on
+		// rows whose text did not change. Clearing forces a full repaint, but
+		// doing it on every keystroke made iTerm2 flicker constantly, so it
+		// only happens when the frame's layout actually moved.
+		if key := m.imageFrameKey(); key != m.wezFrameKey {
+			m.wezFrameKey = key
+			return m, func() tea.Msg { return tea.ClearScreen() }
+		}
+		return m, nil
 	}
 	if clear, ok := msg.(toastClearMsg); ok {
 		if clear.seq == m.toastSeq {
@@ -1054,12 +1075,30 @@ func (m Model) imageRepaint(cmds ...tea.Cmd) tea.Cmd {
 		}
 	}
 	if m.imageMode == imageModeWezTerm {
-		filtered = append(filtered, func() tea.Msg { return tea.ClearScreen() })
+		filtered = append(filtered, func() tea.Msg { return wezRepaintMsg{} })
 	}
 	if len(filtered) == 0 {
 		return nil
 	}
 	return tea.Batch(filtered...)
+}
+
+// imageFrameKey fingerprints everything that determines where images sit on
+// screen: scroll offset, viewport geometry, overlay state, and the layout of
+// every rendered block. Selection-only changes keep the same key because
+// block heights do not move.
+func (m Model) imageFrameKey() string {
+	hash := fnv.New64a()
+	fmt.Fprintf(hash, "%d|%d|%d|%d|%v|%v|%v|%v|%v|",
+		m.viewport.YOffset, m.viewport.Width, m.viewport.Height,
+		m.mode, m.help, m.altText, m.zoom, m.expanded, m.loading)
+	for _, start := range m.starts {
+		fmt.Fprintf(hash, "%d,", start)
+	}
+	if len(m.ends) > 0 {
+		fmt.Fprintf(hash, "|%d", m.ends[len(m.ends)-1])
+	}
+	return fmt.Sprintf("%x", hash.Sum64())
 }
 
 func (m *Model) resize() {

--- a/internal/timeline/preview.go
+++ b/internal/timeline/preview.go
@@ -291,26 +291,56 @@ func fetchPreview(postID string, media api.TimelineMedia, width, maxRows int, mo
 			return previewMsg{postID: postID, err: fmt.Errorf("decode image: %w", err)}
 		}
 		if mode == imageModeNative {
-			path, err := writePreviewPNG(decoded)
+			columns, rows := nativeCellSize(decoded.Bounds(), width, maxRows)
+			path, err := writePreviewPNG(downscaleForCells(decoded, columns, rows))
 			if err != nil {
 				return previewMsg{postID: postID, err: err}
 			}
-			columns, rows := nativeCellSize(decoded.Bounds(), width, maxRows)
 			return previewMsg{
 				postID: postID, nativePath: path, imageID: previewImageID(postID),
 				columns: columns, rows: rows,
 			}
 		}
 		if mode == imageModeWezTerm {
-			encoded, err := encodePreviewPNG(decoded)
+			columns, rows := nativeCellSize(decoded.Bounds(), width, maxRows)
+			encoded, err := encodePreviewPNG(downscaleForCells(decoded, columns, rows))
 			if err != nil {
 				return previewMsg{postID: postID, err: err}
 			}
-			columns, rows := nativeCellSize(decoded.Bounds(), width, maxRows)
 			return previewMsg{postID: postID, nativeData: encoded, columns: columns, rows: rows}
 		}
 		return previewMsg{postID: postID, content: renderANSIImage(decoded, width, maxRows)}
 	}
+}
+
+// Pixel budget per terminal cell for native image payloads, generous enough
+// for 2x/retina displays. Full-resolution photos previously went to the
+// terminal untouched: a timeline of them exhausts the terminal's image
+// storage quota, at which point kitty-protocol terminals silently evict the
+// oldest transmissions and earlier previews disappear from the screen.
+const (
+	cellPixelWidth  = 20
+	cellPixelHeight = 40
+)
+
+// downscaleForCells bounds an image to the pixel area its terminal cells can
+// actually show. It never upscales.
+func downscaleForCells(source image.Image, columns, rows int) image.Image {
+	bounds := source.Bounds()
+	maxWidth := columns * cellPixelWidth
+	maxHeight := rows * cellPixelHeight
+	if maxWidth <= 0 || maxHeight <= 0 || (bounds.Dx() <= maxWidth && bounds.Dy() <= maxHeight) {
+		return source
+	}
+	width := maxWidth
+	height := max(1, bounds.Dy()*width/bounds.Dx())
+	if height > maxHeight {
+		height = maxHeight
+		width = max(1, bounds.Dx()*height/bounds.Dy())
+	}
+	target := image.NewNRGBA(image.Rect(0, 0, width, height))
+	draw.CatmullRom.Scale(target, target.Bounds(), source, bounds, draw.Over, nil)
+	return target
 }
 
 func encodePreviewPNG(source image.Image) (string, error) {
@@ -436,7 +466,13 @@ func (m Model) wezTermPreviewBlock(preview previewState) string {
 			if preview.rows > 1 {
 				fmt.Fprintf(&output, "\x1b[%dA", preview.rows-1)
 			}
+			// Wrap the image emit in DECSC/DECRC. WezTerm honors
+			// doNotMoveCursor=1, but iTerm2 moves the cursor after drawing an
+			// inline image; without the restore every later relative movement
+			// lands offset and the frame around the image corrupts.
+			output.WriteString("\x1b7")
 			output.WriteString(wezTermDisplay(preview.nativeData, preview.columns, preview.rows))
+			output.WriteString("\x1b8")
 			if preview.rows > 1 {
 				fmt.Fprintf(&output, "\x1b[%dB", preview.rows-1)
 			}

--- a/internal/timeline/preview_test.go
+++ b/internal/timeline/preview_test.go
@@ -205,9 +205,70 @@ func TestWezTermBlockReservesAndRestoresCells(t *testing.T) {
 	if !strings.Contains(block, "\x1b]1337;File=width=20") || !strings.Contains(block, "doNotMoveCursor=1") {
 		t.Fatal("wezterm image command missing")
 	}
+	// iTerm2 ignores doNotMoveCursor and moves the cursor after drawing, so
+	// the emit must be bracketed by DECSC/DECRC to keep the frame aligned.
+	if !strings.Contains(block, "\x1b7\x1b]1337;") || !strings.Contains(block, "\x1b\\\x1b8") {
+		t.Fatal("wezterm image emit is not cursor-save/restore protected")
+	}
 	lastLine := strings.Split(block, "\n")[3]
 	if truncated := ansi.Truncate(lastLine, 80, ""); !strings.Contains(truncated, "\x1b]1337;File=") {
 		t.Fatal("renderer truncation removed wezterm image command")
+	}
+}
+
+func TestDownscaleForCellsBoundsLargeImages(t *testing.T) {
+	large := image.NewNRGBA(image.Rect(0, 0, 4096, 2304))
+	scaled := downscaleForCells(large, 40, 10)
+	bounds := scaled.Bounds()
+	if bounds.Dx() > 40*cellPixelWidth || bounds.Dy() > 10*cellPixelHeight {
+		t.Fatalf("downscale left %dx%d for 40x10 cells", bounds.Dx(), bounds.Dy())
+	}
+	if ratio := float64(bounds.Dx()) / float64(bounds.Dy()); ratio < 1.6 || ratio > 2.0 {
+		t.Fatalf("downscale distorted aspect ratio: %dx%d", bounds.Dx(), bounds.Dy())
+	}
+}
+
+func TestDownscaleForCellsKeepsSmallImages(t *testing.T) {
+	small := image.NewNRGBA(image.Rect(0, 0, 200, 100))
+	if scaled := downscaleForCells(small, 40, 10); scaled != image.Image(small) {
+		t.Fatal("small image was rescaled needlessly")
+	}
+}
+
+func TestWezRepaintClearsOnlyWhenFrameMoves(t *testing.T) {
+	m := New()
+	m.imageMode = imageModeWezTerm
+	m.loading = false
+	m.posts = mediaPosts(6)
+	m.width, m.height = 80, 24
+	m.resize()
+
+	next, cmd := m.Update(wezRepaintMsg{})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("first repaint did not clear the screen")
+	}
+	next, cmd = m.Update(wezRepaintMsg{})
+	m = next.(Model)
+	if cmd != nil {
+		t.Fatal("unmoved frame still cleared the screen (iTerm2 flicker)")
+	}
+
+	m.viewport.YOffset += 3
+	next, cmd = m.Update(wezRepaintMsg{})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("scrolled frame did not clear stale image pixels")
+	}
+	if _, cmd = m.Update(wezRepaintMsg{}); cmd != nil {
+		t.Fatal("repeat repaint after scroll cleared again")
+	}
+}
+
+func TestWezRepaintIgnoredOutsideWezTermMode(t *testing.T) {
+	m := NewWithImageMode("off")
+	if _, cmd := m.Update(wezRepaintMsg{}); cmd != nil {
+		t.Fatal("non-iterm2 mode reacted to a wezterm repaint message")
 	}
 }
 


### PR DESCRIPTION
Release v0.1.8.

- Add automated GoReleaser releases for v* tags.
- Build binaries and checksums for Linux, macOS, and Windows.
- Run release tests with required X11 headers.