### PR TITLE
Following feed and color themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,6 @@ timeline with inline images, reply, like, done.
 works on macos and linux. windows isn't supported, open an issue if you
 want it.
 
-**grab a release** (recommended): download the archive for your platform
-from [releases](https://github.com/melqtx/xeet/releases), check it against
-`checksums.txt`, drop the binary on your `PATH`:
-
-```bash
-tar -xzf xeet_*_$(uname -s | tr A-Z a-z)_$(uname -m | sed 's/x86_64/amd64/').tar.gz
-sudo install -m 0755 xeet /usr/local/bin/
-```
-
 **with go** (1.26+):
 
 ```bash
@@ -54,6 +45,15 @@ go install github.com/melqtx/xeet@latest
 git clone https://github.com/melqtx/xeet.git
 cd xeet
 make install   # builds and installs to /usr/local/bin/
+```
+
+**or grab a release**: download the archive for your platform from
+[releases](https://github.com/melqtx/xeet/releases), check it against
+`checksums.txt`, drop the binary on your `PATH`:
+
+```bash
+tar -xzf xeet_*_$(uname -s | tr A-Z a-z)_$(uname -m | sed 's/x86_64/amd64/').tar.gz
+sudo install -m 0755 xeet /usr/local/bin/
 ```
 
 ## use it
@@ -74,6 +74,7 @@ then just:
 
 ```bash
 xeet                                  # browse your timeline, images and all
+xeet --following                      # start on the following feed
 xeet --barebones                      # text-only feed
 xeet --compose                        # skip the feed, open the composer
 xeet post "hello from my shell"       # one-shot post
@@ -121,6 +122,7 @@ autosave (including clipboard images) and come back next time.
 | key | does |
 |---|---|
 | `j` / `k` / arrows | move (`ctrl+d`/`ctrl+u` jumps five) |
+| `f` | switch between the for you and following feeds |
 | `enter` | open the post's replies |
 | `e` / `space` | read a truncated post in full |
 | `i` | zoom the post's image to the whole terminal |
@@ -136,6 +138,17 @@ autosave (including clipboard images) and come back next time.
 more posts load automatically near the bottom. inside a conversation,
 `j`/`k` moves through replies, `r` replies to the selected item, `R`
 reloads, and `esc` drops you back exactly where you were in the timeline.
+
+**themes**
+
+colors are configurable; the layout never changes. pick from tokyonight
+(default), catppuccin, gruvbox, nord, rosepine, or mono:
+
+```bash
+xeet theme             # list themes, current one marked
+xeet theme nord        # save a default in ~/.xeet.yaml
+xeet --theme mono      # try one for a single run
+```
 
 <details>
 <summary>details: how images render</summary>

--- a/TODO.md
+++ b/TODO.md
@@ -22,11 +22,11 @@
 - Persistent operation-ID caching for posting, timelines, likes, and unlikes
 - Keyboard-accessible image descriptions, including text-only mode
 - `xeet whoami` session/account display
+- Following timeline (`--following`, `f` key in the timeline)
+- Configurable color themes without layout changes (`xeet theme`, `--theme`)
 
 ## Next
 
-- Following timeline option
-- Configurable theme without changing layout
 - Chunked upload for video and large media
 - Animated GIF playback via the Kitty graphics animation protocol
 - tmux passthrough (DCS-wrapped Kitty graphics) for native images inside tmux 3.3+

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,11 +11,13 @@ import (
 )
 
 var (
-	appVersion   string
-	appCommit    string
-	appBuildTime string
-	barebones    bool
-	composeOnly  bool
+	appVersion    string
+	appCommit     string
+	appBuildTime  string
+	barebones     bool
+	composeOnly   bool
+	rootFollowing bool
+	rootTheme     string
 )
 
 var rootCmd = &cobra.Command{
@@ -38,7 +40,10 @@ func init() {
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "verbose output")
 	rootCmd.Flags().BoolVar(&barebones, "barebones", false, "open a text-only timeline without image previews")
 	rootCmd.Flags().BoolVar(&composeOnly, "compose", false, "open only the post composer")
+	rootCmd.Flags().BoolVar(&rootFollowing, "following", false, "start on the Following feed instead of For You")
+	rootCmd.Flags().StringVar(&rootTheme, "theme", "", "color theme for this run (see 'xeet theme')")
 	rootCmd.MarkFlagsMutuallyExclusive("barebones", "compose")
+	rootCmd.MarkFlagsMutuallyExclusive("compose", "following")
 }
 
 func runRoot(cmd *cobra.Command, args []string) error {
@@ -51,6 +56,9 @@ func runRoot(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	if err := applyConfiguredTheme(rootTheme); err != nil {
+		return err
+	}
 	if composeOnly {
 		return tui.Run()
 	}
@@ -58,5 +66,5 @@ func runRoot(cmd *cobra.Command, args []string) error {
 	if barebones {
 		imageMode = "off"
 	}
-	return runTimeline(cmd.Context(), imageMode)
+	return runTimeline(cmd.Context(), imageMode, rootFollowing)
 }

--- a/cmd/theme.go
+++ b/cmd/theme.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/melqtx/xeet/internal/theme"
+	"github.com/melqtx/xeet/internal/timeline"
+	"github.com/melqtx/xeet/internal/tui"
+	"github.com/melqtx/xeet/pkg/config"
+
+	"github.com/spf13/cobra"
+)
+
+var themeCmd = &cobra.Command{
+	Use:   "theme [name]",
+	Short: "List color themes or set the default",
+	Long: `With no argument, lists the available themes. With a name, saves it as the
+default in ~/.xeet.yaml. Themes only change colors; the layout stays the same.
+Try one without saving: xeet --theme <name>`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		configMgr, err := config.NewConfigManager()
+		if err != nil {
+			return err
+		}
+		cfg, err := configMgr.Load()
+		if err != nil {
+			return err
+		}
+
+		if len(args) == 0 {
+			current := cfg.Theme
+			if current == "" {
+				current = theme.DefaultName
+			}
+			for _, name := range theme.Names() {
+				marker := "  "
+				if name == current {
+					marker = "* "
+				}
+				fmt.Println(marker + name)
+			}
+			fmt.Println("\nxeet theme <name> sets the default; xeet --theme <name> tries one.")
+			return nil
+		}
+
+		name := args[0]
+		if _, ok := theme.Named(name); !ok {
+			return fmt.Errorf("unknown theme %q (available: %s)", name, strings.Join(theme.Names(), ", "))
+		}
+		cfg.Theme = name
+		if err := configMgr.Save(cfg); err != nil {
+			return err
+		}
+		fmt.Printf("theme set to %s\n", name)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(themeCmd)
+}
+
+// applyConfiguredTheme resolves the palette (flag beats config beats default)
+// and recolors both interfaces. An unknown name fails rather than silently
+// falling back.
+func applyConfiguredTheme(flagValue string) error {
+	name := flagValue
+	if name == "" {
+		if configMgr, err := config.NewConfigManager(); err == nil {
+			if cfg, loadErr := configMgr.Load(); loadErr == nil {
+				name = cfg.Theme
+			}
+		}
+	}
+	if name == "" {
+		return nil
+	}
+	palette, ok := theme.Named(name)
+	if !ok {
+		return fmt.Errorf("unknown theme %q (available: %s)", name, strings.Join(theme.Names(), ", "))
+	}
+	timeline.ApplyTheme(palette)
+	tui.ApplyTheme(palette)
+	return nil
+}

--- a/cmd/timeline.go
+++ b/cmd/timeline.go
@@ -10,29 +10,38 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var timelineImageMode string
+var (
+	timelineImageMode string
+	timelineFollowing bool
+	timelineTheme     string
+)
 
 var timelineCmd = &cobra.Command{
 	Use:   "timeline",
 	Short: "Browse your X home timeline",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runTimeline(cmd.Context(), timelineImageMode)
+		if err := applyConfiguredTheme(timelineTheme); err != nil {
+			return err
+		}
+		return runTimeline(cmd.Context(), timelineImageMode, timelineFollowing)
 	},
 }
 
 func init() {
 	timelineCmd.Flags().StringVar(&timelineImageMode, "images", "auto", "image mode: auto, native, ansi, or off")
+	timelineCmd.Flags().BoolVar(&timelineFollowing, "following", false, "start on the Following feed instead of For You")
+	timelineCmd.Flags().StringVar(&timelineTheme, "theme", "", "color theme for this run (see 'xeet theme')")
 	rootCmd.AddCommand(timelineCmd)
 }
 
-func runTimeline(ctx context.Context, imageMode string) error {
+func runTimeline(ctx context.Context, imageMode string, following bool) error {
 	switch imageMode {
 	case "auto", "native", "ansi", "off":
 	default:
 		return fmt.Errorf("invalid --images value %q (use auto, native, ansi, or off)", imageMode)
 	}
 	for {
-		action, err := timeline.Run(imageMode)
+		action, err := timeline.Run(imageMode, following)
 		if err != nil {
 			return err
 		}

--- a/internal/theme/theme.go
+++ b/internal/theme/theme.go
@@ -1,0 +1,115 @@
+// Package theme holds xeet's color palettes. A palette only recolors the
+// interface; layout, spacing, and typography never change with the theme.
+package theme
+
+import (
+	"sort"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Palette names every color role the interface uses. Accent roles (Blue,
+// Lavender, Pink) decorate; Muted/Dim/Bright grade text prominence; Red,
+// Yellow, and Green carry error, warning, and success meaning.
+type Palette struct {
+	Blue     lipgloss.Color
+	Lavender lipgloss.Color
+	Pink     lipgloss.Color
+	Muted    lipgloss.Color
+	Red      lipgloss.Color
+	Yellow   lipgloss.Color
+	Green    lipgloss.Color
+	Bright   lipgloss.Color
+	Dim      lipgloss.Color
+}
+
+// DefaultName is the palette used when no theme is configured.
+const DefaultName = "tokyonight"
+
+var presets = map[string]Palette{
+	"tokyonight": {
+		Blue:     "#7AA2F7",
+		Lavender: "#BB9AF7",
+		Pink:     "#F5C2E7",
+		Muted:    "#7D8590",
+		Red:      "#FF757F",
+		Yellow:   "#E0AF68",
+		Green:    "#9ECE6A",
+		Bright:   "#C0CAF5",
+		Dim:      "#A9B1D6",
+	},
+	"catppuccin": {
+		Blue:     "#89B4FA",
+		Lavender: "#B4BEFE",
+		Pink:     "#F5C2E7",
+		Muted:    "#6C7086",
+		Red:      "#F38BA8",
+		Yellow:   "#F9E2AF",
+		Green:    "#A6E3A1",
+		Bright:   "#CDD6F4",
+		Dim:      "#BAC2DE",
+	},
+	"gruvbox": {
+		Blue:     "#83A598",
+		Lavender: "#D3869B",
+		Pink:     "#FE8019",
+		Muted:    "#928374",
+		Red:      "#FB4934",
+		Yellow:   "#FABD2F",
+		Green:    "#B8BB26",
+		Bright:   "#EBDBB2",
+		Dim:      "#BDAE93",
+	},
+	"nord": {
+		Blue:     "#88C0D0",
+		Lavender: "#B48EAD",
+		Pink:     "#D8B9C8",
+		Muted:    "#616E88",
+		Red:      "#BF616A",
+		Yellow:   "#EBCB8B",
+		Green:    "#A3BE8C",
+		Bright:   "#ECEFF4",
+		Dim:      "#D8DEE9",
+	},
+	"rosepine": {
+		Blue:     "#9CCFD8",
+		Lavender: "#C4A7E7",
+		Pink:     "#EBBCBA",
+		Muted:    "#6E6A86",
+		Red:      "#EB6F92",
+		Yellow:   "#F6C177",
+		Green:    "#9CCFD8",
+		Bright:   "#E0DEF4",
+		Dim:      "#908CAA",
+	},
+	"mono": {
+		Blue:     "#C8C8C8",
+		Lavender: "#B8B8B8",
+		Pink:     "#DADADA",
+		Muted:    "#707070",
+		Red:      "#EFEFEF",
+		Yellow:   "#C0C0C0",
+		Green:    "#B0B0B0",
+		Bright:   "#FFFFFF",
+		Dim:      "#9E9E9E",
+	},
+}
+
+// Default returns the palette xeet ships with.
+func Default() Palette { return presets[DefaultName] }
+
+// Named looks up a preset palette by name.
+func Named(name string) (Palette, bool) {
+	p, ok := presets[name]
+	return p, ok
+}
+
+// Names lists the available palettes in stable order.
+func Names() []string {
+	names := make([]string, 0, len(presets))
+	for name := range presets {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/theme/theme_test.go
+++ b/internal/theme/theme_test.go
@@ -1,0 +1,37 @@
+package theme
+
+import "testing"
+
+func TestPresetsAreComplete(t *testing.T) {
+	for _, name := range Names() {
+		p, ok := Named(name)
+		if !ok {
+			t.Fatalf("Names() lists %q but Named cannot find it", name)
+		}
+		colors := map[string]string{
+			"Blue": string(p.Blue), "Lavender": string(p.Lavender), "Pink": string(p.Pink),
+			"Muted": string(p.Muted), "Red": string(p.Red), "Yellow": string(p.Yellow),
+			"Green": string(p.Green), "Bright": string(p.Bright), "Dim": string(p.Dim),
+		}
+		for role, value := range colors {
+			if len(value) != 7 || value[0] != '#' {
+				t.Errorf("theme %q role %s has malformed color %q", name, role, value)
+			}
+		}
+	}
+}
+
+func TestDefaultExists(t *testing.T) {
+	if _, ok := Named(DefaultName); !ok {
+		t.Fatalf("default theme %q is not a preset", DefaultName)
+	}
+	if Default() != presets[DefaultName] {
+		t.Fatal("Default() does not match the DefaultName preset")
+	}
+}
+
+func TestUnknownName(t *testing.T) {
+	if _, ok := Named("does-not-exist"); ok {
+		t.Fatal("Named accepted an unknown theme")
+	}
+}

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/melqtx/xeet/internal/clip"
+	"github.com/melqtx/xeet/internal/theme"
 	"github.com/melqtx/xeet/pkg/api"
 	"github.com/melqtx/xeet/pkg/config"
 
@@ -20,15 +21,23 @@ import (
 )
 
 var (
-	blue     = lipgloss.Color("#7AA2F7")
-	lavender = lipgloss.Color("#BB9AF7")
-	pink     = lipgloss.Color("#F5C2E7")
-	muted    = lipgloss.Color("#7D8590")
-	red      = lipgloss.Color("#FF757F")
-	yellow   = lipgloss.Color("#E0AF68")
-	bright   = lipgloss.Color("#C0CAF5")
-	dim      = lipgloss.Color("#A9B1D6")
+	blue     lipgloss.Color
+	lavender lipgloss.Color
+	pink     lipgloss.Color
+	muted    lipgloss.Color
+	red      lipgloss.Color
+	yellow   lipgloss.Color
+	bright   lipgloss.Color
+	dim      lipgloss.Color
 )
+
+func init() { ApplyTheme(theme.Default()) }
+
+// ApplyTheme recolors the timeline. Call it before Run; layout is unaffected.
+func ApplyTheme(p theme.Palette) {
+	blue, lavender, pink, muted = p.Blue, p.Lavender, p.Pink, p.Muted
+	red, yellow, bright, dim = p.Red, p.Yellow, p.Bright, p.Dim
+}
 
 type ActionKind int
 
@@ -52,6 +61,8 @@ type Model struct {
 	width, height int
 	imageMode     imageMode
 	imageNote     string
+	following     bool
+	feedSeq       int
 	posts         []api.TimelinePost
 	cursor        string
 	selected      int
@@ -97,6 +108,7 @@ type pageMsg struct {
 	page *api.TimelinePage
 	err  error
 	more bool
+	seq  int
 }
 
 type actionMsg struct {
@@ -190,11 +202,12 @@ func NewWithImageMode(requested string) Model {
 }
 
 func (m Model) Init() tea.Cmd {
-	return tea.Batch(m.spinner.Tick, fetchPage("", false), clockTick())
+	return tea.Batch(m.spinner.Tick, fetchPageSeq(m.following, "", false, m.feedSeq), clockTick())
 }
 
-func Run(images string) (Action, error) {
+func Run(images string, following bool) (Action, error) {
 	m := NewWithImageMode(images)
+	m.following = following
 	// Auto-detected native mode is a claim, not a capability: multiplexers
 	// like cmux inherit ghostty's TERM without reliably rendering graphics.
 	// Confirm with the terminal itself; --images native skips the probe.
@@ -214,24 +227,28 @@ func Run(images string) (Action, error) {
 	return final.action, nil
 }
 
-func fetchPage(cursor string, more bool) tea.Cmd {
+func fetchPageSeq(following bool, cursor string, more bool, seq int) tea.Cmd {
 	return func() tea.Msg {
 		mgr, err := config.NewConfigManager()
 		if err != nil {
-			return pageMsg{err: err, more: more}
+			return pageMsg{err: err, more: more, seq: seq}
 		}
 		cfg, err := mgr.Load()
 		if err != nil {
-			return pageMsg{err: err, more: more}
+			return pageMsg{err: err, more: more, seq: seq}
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
 		defer cancel()
 		client := api.NewWebClient(cfg)
-		page, err := client.FetchHomeTimeline(ctx, cursor, 30)
+		fetch := client.FetchHomeTimeline
+		if following {
+			fetch = client.FetchFollowingTimeline
+		}
+		page, err := fetch(ctx, cursor, 30)
 		if client.ApplyRefreshedQueryIDs(cfg) {
 			_ = mgr.Save(cfg)
 		}
-		return pageMsg{page: page, err: err, more: more}
+		return pageMsg{page: page, err: err, more: more, seq: seq}
 	}
 }
 
@@ -475,6 +492,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case "ctrl+l":
 		m.syncViewport()
 		return m, func() tea.Msg { return tea.ClearScreen() }
+	case "f":
+		return m.switchFeed()
 	case "R", "ctrl+r":
 		if len(m.posts) == 0 {
 			m.loading = true
@@ -482,7 +501,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.refreshing = true
 		}
 		m.err = nil
-		return m, m.imageRepaint(tea.Batch(m.spinner.Tick, fetchPage("", false)))
+		return m, m.imageRepaint(tea.Batch(m.spinner.Tick, fetchPageSeq(m.following, "", false, m.feedSeq)))
 	case "r":
 		if post, ok := m.currentPost(); ok {
 			return m.beginReply(post)
@@ -579,15 +598,37 @@ func (m *Model) moveSelection(target int) {
 	m.ensureSelectedVisible()
 }
 
+// switchFeed flips between the For You and Following feeds in place.
+func (m Model) switchFeed() (tea.Model, tea.Cmd) {
+	m.following = !m.following
+	m.feedSeq++
+	m.posts = nil
+	m.cursor = ""
+	m.selected = 0
+	m.expanded = false
+	m.loading = true
+	m.loadingMore = false
+	m.refreshing = false
+	m.err = nil
+	m.viewport.YOffset = 0
+	m.syncViewport()
+	return m, m.imageRepaint(tea.Batch(m.spinner.Tick, fetchPageSeq(m.following, "", false, m.feedSeq)))
+}
+
 func (m *Model) maybeLoadMore() tea.Cmd {
 	if len(m.posts) > 0 && m.selected >= len(m.posts)-5 && m.cursor != "" && !m.loadingMore {
 		m.loadingMore = true
-		return tea.Batch(m.spinner.Tick, fetchPage(m.cursor, true))
+		return tea.Batch(m.spinner.Tick, fetchPageSeq(m.following, m.cursor, true, m.feedSeq))
 	}
 	return nil
 }
 
 func (m Model) applyFeedPage(msg pageMsg) (tea.Model, tea.Cmd) {
+	if msg.seq != m.feedSeq {
+		// A page from before the last feed switch; the wrong feed's posts
+		// must not leak into the current one.
+		return m, nil
+	}
 	m.loading = false
 	m.loadingMore = false
 	m.refreshing = false

--- a/internal/timeline/view.go
+++ b/internal/timeline/view.go
@@ -69,7 +69,10 @@ func (m Model) contentWidth() int {
 }
 
 func (m Model) header(width int) string {
-	status := "home"
+	status := "for you"
+	if m.following {
+		status = "following"
+	}
 	if m.mode == modeThread {
 		status = "replies"
 	}
@@ -566,12 +569,12 @@ func (m Model) viewHelp() string {
 	if w > 54 {
 		w = 54
 	}
-	keys := "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nl           like / unlike\nr           reply\nR           refresh\nenter       open replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\nP           new post\ng / G       top / bottom\nctrl+l      redraw screen\nq           quit"
+	keys := "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nf           for you / following\nl           like / unlike\nr           reply\nR           refresh\nenter       open replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\nP           new post\ng / G       top / bottom\nctrl+l      redraw screen\nq           quit"
 	if m.mode == modeThread {
 		keys = "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nl           like / unlike\nr           reply to selected\nR           refresh replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\ng / G       top / bottom\nctrl+l      redraw screen\nesc         back to timeline\nq           quit"
 	}
 	if m.height < 25 {
-		keys = "\n\nj/k move · g/G ends\nl like · r reply · y copy\nenter replies · e read · i zoom · A alt text\nR refresh · o browser\nP compose · ctrl+l redraw\nq quit"
+		keys = "\n\nj/k move · g/G ends · f feed\nl like · r reply · y copy\nenter replies · e read · i zoom · A alt text\nR refresh · o browser\nP compose · ctrl+l redraw\nq quit"
 		if m.mode == modeThread {
 			keys = "\n\nj/k move · g/G ends\nl like · r reply · y copy\ne read · i zoom · A alt text\nR refresh · o browser\nesc back · q quit"
 		}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -6,24 +6,34 @@ import (
 	"strings"
 
 	"github.com/melqtx/xeet/internal/media"
+	"github.com/melqtx/xeet/internal/theme"
 	"github.com/melqtx/xeet/pkg/api"
 
 	"github.com/charmbracelet/lipgloss"
 )
 
 var (
-	blue     = lipgloss.Color("#7AA2F7")
-	lavender = lipgloss.Color("#BB9AF7")
-	pink     = lipgloss.Color("#F5C2E7")
-	muted    = lipgloss.Color("#7D8590")
-	green    = lipgloss.Color("#9ECE6A")
-	red      = lipgloss.Color("#FF757F")
+	blue     lipgloss.Color
+	lavender lipgloss.Color
+	pink     lipgloss.Color
+	muted    lipgloss.Color
+	green    lipgloss.Color
+	red      lipgloss.Color
 
-	dialogStyle = lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			BorderForeground(lavender).
-			Padding(1, 2)
+	dialogStyle lipgloss.Style
 )
+
+func init() { ApplyTheme(theme.Default()) }
+
+// ApplyTheme recolors the composer. Call it before Run; layout is unaffected.
+func ApplyTheme(p theme.Palette) {
+	blue, lavender, pink = p.Blue, p.Lavender, p.Pink
+	muted, green, red = p.Muted, p.Green, p.Red
+	dialogStyle = lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lavender).
+		Padding(1, 2)
+}
 
 const xeetLogo = `██╗  ██╗███████╗███████╗████████╗
 ╚██╗██╔╝██╔════╝██╔════╝╚══██╔══╝

--- a/pkg/api/timeline.go
+++ b/pkg/api/timeline.go
@@ -11,7 +11,12 @@ import (
 	"time"
 )
 
-const defaultHomeTimelineQueryID = "lqfNCpeO0wydVAAXAbAU5w"
+const (
+	defaultHomeTimelineQueryID = "lqfNCpeO0wydVAAXAbAU5w"
+	// HomeLatestTimeline backs the website's Following tab. The default is a
+	// best-effort snapshot; a stale id is rediscovered on first use.
+	defaultHomeLatestTimelineQueryID = "U0cdisy7QFIoTfu3-Okw0A"
+)
 
 type TimelineMedia struct {
 	URL     string
@@ -98,24 +103,33 @@ var timelineFieldToggles = map[string]bool{
 
 // FetchHomeTimeline retrieves one page of the authenticated For You feed.
 func (c *WebClient) FetchHomeTimeline(ctx context.Context, cursor string, count int) (*TimelinePage, error) {
+	return c.fetchTimeline(ctx, "HomeTimeline", defaultHomeTimelineQueryID, "XEET_HOMETIMELINE_QID", cursor, count)
+}
+
+// FetchFollowingTimeline retrieves one page of the authenticated Following feed.
+func (c *WebClient) FetchFollowingTimeline(ctx context.Context, cursor string, count int) (*TimelinePage, error) {
+	return c.fetchTimeline(ctx, "HomeLatestTimeline", defaultHomeLatestTimelineQueryID, "XEET_HOMELATESTTIMELINE_QID", cursor, count)
+}
+
+func (c *WebClient) fetchTimeline(ctx context.Context, operation, fallback, environment, cursor string, count int) (*TimelinePage, error) {
 	if c.authToken == "" || c.ct0 == "" {
 		return nil, fmt.Errorf("no session; run 'xeet auth' first")
 	}
 	if count <= 0 || count > 100 {
 		count = 30
 	}
-	qid := c.operationQueryID("HomeTimeline", defaultHomeTimelineQueryID, "XEET_HOMETIMELINE_QID")
+	qid := c.operationQueryID(operation, fallback, environment)
 
-	res, err := c.doHomeTimeline(ctx, qid, cursor, count)
+	res, err := c.doTimeline(ctx, operation, qid, cursor, count)
 	if err != nil {
 		return nil, err
 	}
 	if needsQueryIDRefresh(res) {
-		fresh, discoverErr := c.discoverOperation(ctx, "HomeTimeline")
+		fresh, discoverErr := c.discoverOperation(ctx, operation)
 		if discoverErr != nil {
 			return nil, fmt.Errorf("home timeline endpoint changed and discovery failed: %w", discoverErr)
 		}
-		res, err = c.doHomeTimeline(ctx, fresh, cursor, count)
+		res, err = c.doTimeline(ctx, operation, fresh, cursor, count)
 		if err != nil {
 			return nil, err
 		}
@@ -145,8 +159,8 @@ func (c *WebClient) FetchHomeTimeline(ctx context.Context, cursor string, count 
 	return &page, nil
 }
 
-// doHomeTimeline is a read, so transient failures are retried.
-func (c *WebClient) doHomeTimeline(ctx context.Context, qid, cursor string, count int) (*httpResult, error) {
+// doTimeline is a read, so transient failures are retried.
+func (c *WebClient) doTimeline(ctx context.Context, operation, qid, cursor string, count int) (*httpResult, error) {
 	variables := map[string]any{
 		"count":                  count,
 		"includePromotedContent": true,
@@ -167,7 +181,7 @@ func (c *WebClient) doHomeTimeline(ctx context.Context, qid, cursor string, coun
 	params.Set("variables", string(variablesJSON))
 	params.Set("features", string(featuresJSON))
 	params.Set("fieldToggles", string(fieldTogglesJSON))
-	endpoint := fmt.Sprintf("https://x.com/i/api/graphql/%s/HomeTimeline?%s", qid, params.Encode())
+	endpoint := fmt.Sprintf("https://x.com/i/api/graphql/%s/%s?%s", qid, operation, params.Encode())
 	return c.send(ctx, func() (*http.Request, error) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 		if err != nil {

--- a/pkg/api/web.go
+++ b/pkg/api/web.go
@@ -167,12 +167,13 @@ func needsQueryIDRefresh(res *httpResult) bool {
 
 func NewWebClient(cfg *config.Config) *WebClient {
 	operationQIDs := map[string]string{
-		"CreateTweet":     cfg.CreateTweetQID,
-		"HomeTimeline":    cfg.HomeTimelineQID,
-		"FavoriteTweet":   cfg.FavoriteTweetQID,
-		"UnfavoriteTweet": cfg.UnfavoriteTweetQID,
-		"Viewer":          cfg.ViewerQID,
-		"TweetDetail":     cfg.TweetDetailQID,
+		"CreateTweet":        cfg.CreateTweetQID,
+		"HomeTimeline":       cfg.HomeTimelineQID,
+		"HomeLatestTimeline": cfg.HomeLatestTimelineQID,
+		"FavoriteTweet":      cfg.FavoriteTweetQID,
+		"UnfavoriteTweet":    cfg.UnfavoriteTweetQID,
+		"Viewer":             cfg.ViewerQID,
+		"TweetDetail":        cfg.TweetDetailQID,
 	}
 	qid := operationQIDs["CreateTweet"]
 	if qid == "" {
@@ -245,6 +246,8 @@ func (c *WebClient) ApplyRefreshedQueryIDs(cfg *config.Config) bool {
 			cfg.CreateTweetQID = qid
 		case "HomeTimeline":
 			cfg.HomeTimelineQID = qid
+		case "HomeLatestTimeline":
+			cfg.HomeLatestTimelineQID = qid
 		case "FavoriteTweet":
 			cfg.FavoriteTweetQID = qid
 		case "UnfavoriteTweet":

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,19 +21,21 @@ import (
 // state: X's rotating GraphQL query ids and browser-session source metadata used
 // by `xeet doctor`.
 type Config struct {
-	AuthToken          string    `yaml:"-"`
-	CT0                string    `yaml:"-"`
-	CreateTweetQID     string    `yaml:"create_tweet_qid"`
-	HomeTimelineQID    string    `yaml:"home_timeline_qid,omitempty"`
-	FavoriteTweetQID   string    `yaml:"favorite_tweet_qid,omitempty"`
-	UnfavoriteTweetQID string    `yaml:"unfavorite_tweet_qid,omitempty"`
-	ViewerQID          string    `yaml:"viewer_qid,omitempty"`
-	TweetDetailQID     string    `yaml:"tweet_detail_qid,omitempty"`
-	SessionBrowser     string    `yaml:"session_browser,omitempty"`
-	SessionProfile     string    `yaml:"session_profile,omitempty"`
-	SessionDomain      string    `yaml:"session_domain,omitempty"`
-	SessionExpires     time.Time `yaml:"session_expires,omitempty"`
-	SessionImported    time.Time `yaml:"session_imported,omitempty"`
+	AuthToken             string    `yaml:"-"`
+	CT0                   string    `yaml:"-"`
+	CreateTweetQID        string    `yaml:"create_tweet_qid"`
+	HomeTimelineQID       string    `yaml:"home_timeline_qid,omitempty"`
+	HomeLatestTimelineQID string    `yaml:"home_latest_timeline_qid,omitempty"`
+	FavoriteTweetQID      string    `yaml:"favorite_tweet_qid,omitempty"`
+	UnfavoriteTweetQID    string    `yaml:"unfavorite_tweet_qid,omitempty"`
+	ViewerQID             string    `yaml:"viewer_qid,omitempty"`
+	TweetDetailQID        string    `yaml:"tweet_detail_qid,omitempty"`
+	Theme                 string    `yaml:"theme,omitempty"`
+	SessionBrowser        string    `yaml:"session_browser,omitempty"`
+	SessionProfile        string    `yaml:"session_profile,omitempty"`
+	SessionDomain         string    `yaml:"session_domain,omitempty"`
+	SessionExpires        time.Time `yaml:"session_expires,omitempty"`
+	SessionImported       time.Time `yaml:"session_imported,omitempty"`
 }
 
 // keyringService is the service name xeet registers its secrets under.
@@ -91,19 +93,21 @@ func (systemKeyring) Delete(key string) error {
 // fileConfig is the on-disk shape. auth_token and ct0 are only read for
 // migration from the pre-keyring layout and are never written back.
 type fileConfig struct {
-	AuthToken          string `yaml:"auth_token,omitempty"`
-	CT0                string `yaml:"ct0,omitempty"`
-	CreateTweetQID     string `yaml:"create_tweet_qid,omitempty"`
-	HomeTimelineQID    string `yaml:"home_timeline_qid,omitempty"`
-	FavoriteTweetQID   string `yaml:"favorite_tweet_qid,omitempty"`
-	UnfavoriteTweetQID string `yaml:"unfavorite_tweet_qid,omitempty"`
-	ViewerQID          string `yaml:"viewer_qid,omitempty"`
-	TweetDetailQID     string `yaml:"tweet_detail_qid,omitempty"`
-	SessionBrowser     string `yaml:"session_browser,omitempty"`
-	SessionProfile     string `yaml:"session_profile,omitempty"`
-	SessionDomain      string `yaml:"session_domain,omitempty"`
-	SessionExpires     string `yaml:"session_expires,omitempty"`
-	SessionImported    string `yaml:"session_imported,omitempty"`
+	AuthToken             string `yaml:"auth_token,omitempty"`
+	CT0                   string `yaml:"ct0,omitempty"`
+	CreateTweetQID        string `yaml:"create_tweet_qid,omitempty"`
+	HomeTimelineQID       string `yaml:"home_timeline_qid,omitempty"`
+	HomeLatestTimelineQID string `yaml:"home_latest_timeline_qid,omitempty"`
+	FavoriteTweetQID      string `yaml:"favorite_tweet_qid,omitempty"`
+	UnfavoriteTweetQID    string `yaml:"unfavorite_tweet_qid,omitempty"`
+	ViewerQID             string `yaml:"viewer_qid,omitempty"`
+	TweetDetailQID        string `yaml:"tweet_detail_qid,omitempty"`
+	Theme                 string `yaml:"theme,omitempty"`
+	SessionBrowser        string `yaml:"session_browser,omitempty"`
+	SessionProfile        string `yaml:"session_profile,omitempty"`
+	SessionDomain         string `yaml:"session_domain,omitempty"`
+	SessionExpires        string `yaml:"session_expires,omitempty"`
+	SessionImported       string `yaml:"session_imported,omitempty"`
 }
 
 type ConfigManager struct {
@@ -135,15 +139,17 @@ func (cm *ConfigManager) Load() (*Config, error) {
 	}
 
 	config := &Config{
-		CreateTweetQID:     fc.CreateTweetQID,
-		HomeTimelineQID:    fc.HomeTimelineQID,
-		FavoriteTweetQID:   fc.FavoriteTweetQID,
-		UnfavoriteTweetQID: fc.UnfavoriteTweetQID,
-		ViewerQID:          fc.ViewerQID,
-		TweetDetailQID:     fc.TweetDetailQID,
-		SessionBrowser:     fc.SessionBrowser,
-		SessionProfile:     fc.SessionProfile,
-		SessionDomain:      fc.SessionDomain,
+		CreateTweetQID:        fc.CreateTweetQID,
+		HomeTimelineQID:       fc.HomeTimelineQID,
+		HomeLatestTimelineQID: fc.HomeLatestTimelineQID,
+		FavoriteTweetQID:      fc.FavoriteTweetQID,
+		UnfavoriteTweetQID:    fc.UnfavoriteTweetQID,
+		ViewerQID:             fc.ViewerQID,
+		TweetDetailQID:        fc.TweetDetailQID,
+		Theme:                 fc.Theme,
+		SessionBrowser:        fc.SessionBrowser,
+		SessionProfile:        fc.SessionProfile,
+		SessionDomain:         fc.SessionDomain,
 	}
 	if fc.SessionExpires != "" {
 		if parsed, parseErr := time.Parse(time.RFC3339, fc.SessionExpires); parseErr == nil {
@@ -225,8 +231,10 @@ func (cm *ConfigManager) Save(config *Config) error {
 	if config.AuthToken == "" {
 		return cm.writeFile(&fileConfig{
 			CreateTweetQID: config.CreateTweetQID, HomeTimelineQID: config.HomeTimelineQID,
-			FavoriteTweetQID: config.FavoriteTweetQID, UnfavoriteTweetQID: config.UnfavoriteTweetQID,
+			HomeLatestTimelineQID: config.HomeLatestTimelineQID,
+			FavoriteTweetQID:      config.FavoriteTweetQID, UnfavoriteTweetQID: config.UnfavoriteTweetQID,
 			ViewerQID: config.ViewerQID, TweetDetailQID: config.TweetDetailQID,
+			Theme: config.Theme,
 		})
 	}
 
@@ -259,15 +267,17 @@ func (cm *ConfigManager) Save(config *Config) error {
 
 func fileConfigFor(config *Config) *fileConfig {
 	result := &fileConfig{
-		CreateTweetQID:     config.CreateTweetQID,
-		HomeTimelineQID:    config.HomeTimelineQID,
-		FavoriteTweetQID:   config.FavoriteTweetQID,
-		UnfavoriteTweetQID: config.UnfavoriteTweetQID,
-		ViewerQID:          config.ViewerQID,
-		TweetDetailQID:     config.TweetDetailQID,
-		SessionBrowser:     config.SessionBrowser,
-		SessionProfile:     config.SessionProfile,
-		SessionDomain:      config.SessionDomain,
+		CreateTweetQID:        config.CreateTweetQID,
+		HomeTimelineQID:       config.HomeTimelineQID,
+		HomeLatestTimelineQID: config.HomeLatestTimelineQID,
+		FavoriteTweetQID:      config.FavoriteTweetQID,
+		UnfavoriteTweetQID:    config.UnfavoriteTweetQID,
+		ViewerQID:             config.ViewerQID,
+		TweetDetailQID:        config.TweetDetailQID,
+		Theme:                 config.Theme,
+		SessionBrowser:        config.SessionBrowser,
+		SessionProfile:        config.SessionProfile,
+		SessionDomain:         config.SessionDomain,
 	}
 	if !config.SessionExpires.IsZero() {
 		result.SessionExpires = config.SessionExpires.UTC().Format(time.RFC3339)


### PR DESCRIPTION
Two features from the TODO plus the install-docs reorder.

## following feed
- New `FetchFollowingTimeline` backed by X's `HomeLatestTimeline` operation, sharing all the HomeTimeline plumbing (query-id cache, rediscovery on stale id, transient-read retries).
- `xeet --following` / `xeet timeline --following` start on the Following feed; `f` in the timeline switches feeds in place. The header shows `for you` / `following`.
- A feed sequence number guards against an in-flight page from the previous feed landing after a switch and mixing feeds.

## themes (colors only, layout untouched)
- New `internal/theme` package with six presets: tokyonight (the current colors, still the default), catppuccin, gruvbox, nord, rosepine, mono.
- `xeet theme` lists them (current marked), `xeet theme <name>` persists the choice in `~/.xeet.yaml`, `--theme <name>` applies one for a single run. Unknown names error with the list instead of silently falling back.
- Both the timeline and the composer previously hard-coded duplicate palettes; they now share the theme package.

## docs
- README install section reordered: `go install` and source first, release download after.
- README documents `f`, `--following`, and themes; TODO moves both features to Done.

Tests, vet, and staticcheck pass. The PTY help-screen test caught a real regression during development (an extra wrapped help line pushed the title off a 15-row terminal); fixed by fitting the new key hint into an existing line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)