### PR TITLE
Native images inside tmux + chunked video upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,11 @@ cookie values.
 | `F1` | help |
 | `ctrl+c` / `esc` | quit (drafts ask first) |
 
-up to four png/jpeg/gif/webp images per post. the composer shows real
-format, dimensions, and size before anything uploads. unfinished drafts
-autosave (including clipboard images) and come back next time.
+up to four png/jpeg/gif/webp images per post, or one mp4/mov video (up
+to 512 MiB, uploaded in chunks straight from disk with live progress).
+the composer shows real format, dimensions, and size before anything
+uploads. unfinished drafts autosave (including clipboard images) and
+come back next time.
 
 **timeline**
 
@@ -159,8 +161,9 @@ chip.
 
 - direct ghostty and kitty sessions use kitty unicode-placeholder graphics
 - iterm2 and wezterm use the iterm2 inline-image protocol
-- zellij and tmux get the portable ansi renderer, because they don't
-  reliably pass graphics protocols through
+- tmux 3.3+ gets native kitty graphics too when `allow-passthrough` is on
+  and the terminal running tmux is kitty or ghostty; otherwise (and in
+  zellij) the portable ansi renderer takes over
 
 in auto mode xeet verifies kitty graphics before trusting them: apps that
 merely embed libghostty (cmux, for one) inherit a ghostty `TERM` but don't

--- a/TODO.md
+++ b/TODO.md
@@ -24,12 +24,12 @@
 - `xeet whoami` session/account display
 - Following timeline (`--following`, `f` key in the timeline)
 - Configurable color themes without layout changes (`xeet theme`, `--theme`)
+- tmux passthrough (DCS-wrapped Kitty graphics) for native images inside tmux 3.3+
+- Chunked upload for video and large media
 
 ## Next
 
-- Chunked upload for video and large media
 - Animated GIF playback via the Kitty graphics animation protocol
-- tmux passthrough (DCS-wrapped Kitty graphics) for native images inside tmux 3.3+
 - Windows browser-cookie import using DPAPI
 
 Scheduling, bulk posting, scraping, automated engagement, and mass-posting

--- a/cmd/post.go
+++ b/cmd/post.go
@@ -27,13 +27,14 @@ var postCmd = &cobra.Command{
   echo "piped tweet" | xeet post
   xeet post "photo" --image ./photo.png
   xeet post --image one.png --image two.jpg
+  xeet post "clip" --image ./clip.mp4
   xeet post "a reply" --reply 1234567890`,
 	RunE: runPost,
 }
 
 func init() {
 	postCmd.Flags().StringVar(&replyTo, "reply", "", "tweet id to reply to")
-	postCmd.Flags().StringArrayVarP(&imagePaths, "image", "i", nil, "image path (repeat up to 4 times)")
+	postCmd.Flags().StringArrayVarP(&imagePaths, "image", "i", nil, "image or video path (up to 4 images, or 1 video)")
 	rootCmd.AddCommand(postCmd)
 }
 
@@ -54,14 +55,21 @@ func runPost(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("a post can have at most %d images", media.MaxAttachments)
 	}
 	uploads := make([]api.Upload, 0, len(imagePaths))
+	videos := 0
 	for _, path := range imagePaths {
 		attachment, err := media.FromPath(path)
 		if err != nil {
 			return fmt.Errorf("attach %q: %w", path, err)
 		}
-		uploads = append(uploads, api.Upload{
-			Filename: attachment.Name, ContentType: attachment.MIME, Data: attachment.Data,
-		})
+		upload := api.Upload{Filename: attachment.Name, ContentType: attachment.MIME, Data: attachment.Data}
+		if attachment.IsVideo() {
+			videos++
+			upload.Path = attachment.Path
+		}
+		uploads = append(uploads, upload)
+	}
+	if videos > 0 && len(uploads) > 1 {
+		return fmt.Errorf("a video must be the only attachment")
 	}
 	if strings.TrimSpace(text) == "" && len(uploads) == 0 {
 		return fmt.Errorf("nothing to post: pass text, pipe stdin, or add --image")
@@ -87,7 +95,13 @@ func runPost(cmd *cobra.Command, args []string) error {
 		if v, _ := cmd.Flags().GetBool("verbose"); v {
 			switch event.Stage {
 			case api.PostStageUploading:
-				fmt.Fprintf(os.Stderr, "uploading %d/%d: %s\n", event.Current, event.Total, event.Name)
+				if event.TotalBytes > 0 {
+					fmt.Fprintf(os.Stderr, "uploading %s: %d%%\n", event.Name, event.TransferredBytes*100/event.TotalBytes)
+				} else {
+					fmt.Fprintf(os.Stderr, "uploading %d/%d: %s\n", event.Current, event.Total, event.Name)
+				}
+			case api.PostStageProcessing:
+				fmt.Fprintln(os.Stderr, "waiting for X to process the media…")
 			case api.PostStageDiscovering:
 				fmt.Fprintln(os.Stderr, "refreshing X endpoint…")
 			case api.PostStagePublishing:

--- a/internal/media/attachment.go
+++ b/internal/media/attachment.go
@@ -24,6 +24,7 @@ const (
 	MaxAttachments = 4
 	MaxImageBytes  = 5 << 20
 	MaxGIFBytes    = 15 << 20
+	MaxVideoBytes  = 512 << 20
 )
 
 type Source string
@@ -46,6 +47,12 @@ type Attachment struct {
 	Data   []byte
 }
 
+// IsVideo reports whether the attachment streams from disk as video rather
+// than travelling in Data as an image.
+func (a Attachment) IsVideo() bool {
+	return strings.HasPrefix(a.MIME, "video/")
+}
+
 func FromClipboard(data []byte) (Attachment, error) {
 	return fromBytes("Clipboard image", "", SourceClipboard, data)
 }
@@ -57,18 +64,82 @@ func FromPath(input string) (Attachment, error) {
 	}
 	f, err := os.Open(path)
 	if err != nil {
-		return Attachment{}, fmt.Errorf("open image: %w", err)
+		return Attachment{}, fmt.Errorf("open media: %w", err)
 	}
 	defer f.Close()
 
-	data, err := io.ReadAll(io.LimitReader(f, MaxGIFBytes+1))
+	head := make([]byte, 16)
+	headLen, err := io.ReadFull(f, head)
+	if err != nil && err != io.ErrUnexpectedEOF && err != io.EOF {
+		return Attachment{}, fmt.Errorf("read media: %w", err)
+	}
+	head = head[:headLen]
+	if mime := videoMIME(head); mime != "" {
+		return videoFromFile(f, path, mime)
+	}
+	rest, err := io.ReadAll(io.LimitReader(f, MaxGIFBytes+1))
 	if err != nil {
 		return Attachment{}, fmt.Errorf("read image: %w", err)
 	}
+	data := append(head, rest...)
 	if len(data) > MaxGIFBytes {
 		return Attachment{}, fmt.Errorf("image is larger than %s", HumanBytes(MaxGIFBytes))
 	}
 	return fromBytes(filepath.Base(path), path, SourceFile, data)
+}
+
+// videoMIME sniffs the container from the file's first bytes. MP4 and
+// QuickTime are the formats X accepts; other known video magic returns
+// "" here and surfaces a targeted error from fromBytes via looksLikeVideo.
+func videoMIME(head []byte) string {
+	if len(head) < 12 || string(head[4:8]) != "ftyp" {
+		return ""
+	}
+	if string(head[8:10]) == "qt" {
+		return "video/quicktime"
+	}
+	return "video/mp4"
+}
+
+// looksLikeVideo recognizes common non-MP4 video containers so the error can
+// say "convert it" instead of "corrupt image".
+func looksLikeVideo(head []byte) bool {
+	if len(head) >= 4 && head[0] == 0x1A && head[1] == 0x45 && head[2] == 0xDF && head[3] == 0xA3 {
+		return true // Matroska/WebM
+	}
+	if len(head) >= 12 && string(head[:4]) == "RIFF" && string(head[8:12]) == "AVI " {
+		return true
+	}
+	return false
+}
+
+// videoFromFile builds a path-backed attachment: video never loads into
+// memory here; the uploader streams it from disk in chunks.
+func videoFromFile(f *os.File, path, mime string) (Attachment, error) {
+	info, err := f.Stat()
+	if err != nil {
+		return Attachment{}, fmt.Errorf("read video: %w", err)
+	}
+	if info.Size() > MaxVideoBytes {
+		return Attachment{}, fmt.Errorf("videos must be %s or smaller", HumanBytes(MaxVideoBytes))
+	}
+	if info.Size() == 0 {
+		return Attachment{}, fmt.Errorf("video is empty")
+	}
+	sum := sha256.Sum256([]byte(fmt.Sprintf("%s|%d|%d", path, info.Size(), info.ModTime().UnixNano())))
+	format := "MP4"
+	if mime == "video/quicktime" {
+		format = "MOV"
+	}
+	return Attachment{
+		ID:     hex.EncodeToString(sum[:6]),
+		Name:   filepath.Base(path),
+		Source: SourceFile,
+		Path:   path,
+		MIME:   mime,
+		Format: format,
+		Size:   info.Size(),
+	}, nil
 }
 
 func fromBytes(name, path string, source Source, data []byte) (Attachment, error) {
@@ -77,6 +148,9 @@ func fromBytes(name, path string, source Source, data []byte) (Attachment, error
 	}
 	cfg, format, err := image.DecodeConfig(bytes.NewReader(data))
 	if err != nil {
+		if looksLikeVideo(data) {
+			return Attachment{}, fmt.Errorf("unsupported video format; X accepts MP4 (H.264/AAC) or MOV")
+		}
 		return Attachment{}, fmt.Errorf("unsupported or corrupt image: %w", err)
 	}
 	format = strings.ToLower(format)

--- a/internal/media/attachment_test.go
+++ b/internal/media/attachment_test.go
@@ -6,6 +6,7 @@ import (
 	"image/png"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -67,5 +68,51 @@ func TestNormalizePath(t *testing.T) {
 func TestRejectsGarbage(t *testing.T) {
 	if _, err := FromClipboard([]byte("not an image")); err == nil {
 		t.Fatal("expected corrupt image error")
+	}
+}
+
+func TestFromPathDetectsMP4Video(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "clip.mp4")
+	data := append([]byte{0, 0, 0, 0x18}, []byte("ftypisom")...)
+	data = append(data, make([]byte, 64)...)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	a, err := FromPath(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !a.IsVideo() || a.MIME != "video/mp4" || a.Format != "MP4" {
+		t.Fatalf("attachment = %+v, want mp4 video", a)
+	}
+	if len(a.Data) != 0 || a.Path != path || a.Size != int64(len(data)) {
+		t.Fatalf("video must stay path-backed: %+v", a)
+	}
+}
+
+func TestFromPathDetectsQuickTime(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "clip.mov")
+	data := append([]byte{0, 0, 0, 0x14}, []byte("ftypqt  ")...)
+	data = append(data, make([]byte, 32)...)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	a, err := FromPath(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.MIME != "video/quicktime" || a.Format != "MOV" {
+		t.Fatalf("attachment = %+v, want quicktime video", a)
+	}
+}
+
+func TestFromPathRejectsUnsupportedVideo(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "clip.webm")
+	if err := os.WriteFile(path, []byte{0x1A, 0x45, 0xDF, 0xA3, 0, 0, 0, 0}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := FromPath(path)
+	if err == nil || !strings.Contains(err.Error(), "unsupported video format") {
+		t.Fatalf("expected targeted video error, got %v", err)
 	}
 }

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -211,7 +211,9 @@ func Run(images string, following bool) (Action, error) {
 	// Auto-detected native mode is a claim, not a capability: multiplexers
 	// like cmux inherit ghostty's TERM without reliably rendering graphics.
 	// Confirm with the terminal itself; --images native skips the probe.
-	if m.imageMode == imageModeNative && images != "native" {
+	// Inside tmux the probe reply never reaches this pane, so native mode is
+	// vetted by tmuxNativeSupport during resolveImageMode instead.
+	if m.imageMode == imageModeNative && images != "native" && !insideTmux() {
 		if err := probeNativeGraphics(); err != nil {
 			m.imageMode = imageModeANSI
 			m.imageNote = "terminal didn't confirm kitty graphics; using ansi (--images native to force)"

--- a/internal/timeline/preview.go
+++ b/internal/timeline/preview.go
@@ -62,9 +62,21 @@ func resolveImageMode(requested string) (imageMode, string) {
 		return imageModeANSI, ""
 	}
 	// Zellij does not currently pass the Kitty graphics protocol through.
-	// tmux requires explicit passthrough configuration we cannot assume.
-	if os.Getenv("ZELLIJ") != "" || os.Getenv("TMUX") != "" {
-		return imageModeANSI, "tmux/zellij blocks native graphics; run xeet directly in the terminal for sharp images"
+	if os.Getenv("ZELLIJ") != "" {
+		return imageModeANSI, "zellij blocks native graphics; run xeet directly in the terminal for sharp images"
+	}
+	// tmux 3.3+ forwards DCS-wrapped kitty graphics to the outer terminal when
+	// allow-passthrough is on; every kitty escape below goes through tmuxWrap.
+	// The Unicode-placeholder cells are ordinary text tmux redraws itself, so
+	// images survive pane moves and window switches.
+	if insideTmux() {
+		if requested == "native" {
+			return imageModeNative, ""
+		}
+		if ok, note := tmuxNativeSupport(); !ok {
+			return imageModeANSI, note + " (--images native to force)"
+		}
+		return imageModeNative, ""
 	}
 	program := strings.ToLower(strings.TrimSpace(os.Getenv("TERM_PROGRAM")))
 	term := strings.ToLower(os.Getenv("TERM"))
@@ -407,11 +419,11 @@ func kittyImageColor(imageID uint32) (red, green, blue uint32) {
 
 func kittyTransmit(path string, imageID uint32) string {
 	payload := base64.StdEncoding.EncodeToString([]byte(path))
-	return fmt.Sprintf("\x1b_Ga=t,f=100,t=f,i=%d,q=2;%s\x1b\\", imageID, payload)
+	return tmuxWrap(fmt.Sprintf("\x1b_Ga=t,f=100,t=f,i=%d,q=2;%s\x1b\\", imageID, payload))
 }
 
 func kittyVirtualPlacement(imageID uint32, columns, rows int) string {
-	return fmt.Sprintf("\x1b_Ga=p,U=1,i=%d,c=%d,r=%d,q=2\x1b\\", imageID, columns, rows)
+	return tmuxWrap(fmt.Sprintf("\x1b_Ga=p,U=1,i=%d,c=%d,r=%d,q=2\x1b\\", imageID, columns, rows))
 }
 
 func wezTermDisplay(encoded string, columns, rows int) string {

--- a/internal/timeline/tmux.go
+++ b/internal/timeline/tmux.go
@@ -32,6 +32,16 @@ func tmuxWrap(seq string) string {
 // with Unicode placeholders (kitty and ghostty do; wezterm's kitty support
 // lacks virtual placements). Returns ok plus a note explaining any refusal.
 func tmuxNativeSupport() (bool, string) {
+	// Previews transmit as a temp-file path (t=f), so the emulator process has
+	// to be able to open a file this process wrote. Over ssh it cannot: the
+	// PNG lands on this host while the terminal drawing it runs on another.
+	// Outside tmux the startup probe catches that by transmitting a real file
+	// and demanding an acknowledgement; here there is no probe, and previews
+	// run with errors suppressed (q=2), so an unchecked native mode would
+	// leave silent blank gaps where images belong.
+	if os.Getenv("SSH_CONNECTION") != "" || os.Getenv("SSH_TTY") != "" || os.Getenv("SSH_CLIENT") != "" {
+		return false, "native images need a local terminal; using ansi"
+	}
 	tmuxBin, err := exec.LookPath("tmux")
 	if err != nil {
 		return false, "tmux blocks native graphics; using ansi"

--- a/internal/timeline/tmux.go
+++ b/internal/timeline/tmux.go
@@ -1,0 +1,63 @@
+package timeline
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// insideTmux reports whether this pane sits behind a tmux server, which
+// consumes escape sequences it does not recognize unless they arrive wrapped
+// in its passthrough DCS.
+func insideTmux() bool {
+	return os.Getenv("TMUX") != ""
+}
+
+// tmuxWrap re-encodes an escape sequence as a tmux passthrough DCS
+// (tmux 3.3+ with `allow-passthrough on`): tmux strips the wrapper, undoubles
+// the ESC bytes, and forwards the payload to the outer terminal verbatim.
+// Outside tmux the sequence is returned unchanged.
+func tmuxWrap(seq string) string {
+	if !insideTmux() {
+		return seq
+	}
+	return "\x1bPtmux;" + strings.ReplaceAll(seq, "\x1b", "\x1b\x1b") + "\x1b\\"
+}
+
+// tmuxNativeSupport decides whether native kitty graphics can work from
+// inside tmux. The interactive graphics probe is unreliable here — replies
+// from the outer terminal are not routed back to the pane — so it checks the
+// two hard requirements directly: the pane's session must allow passthrough,
+// and the attached client's terminal must speak the kitty graphics protocol
+// with Unicode placeholders (kitty and ghostty do; wezterm's kitty support
+// lacks virtual placements). Returns ok plus a note explaining any refusal.
+func tmuxNativeSupport() (bool, string) {
+	tmuxBin, err := exec.LookPath("tmux")
+	if err != nil {
+		return false, "tmux blocks native graphics; using ansi"
+	}
+	passthrough, err := exec.Command(tmuxBin, "show", "-Ap", "allow-passthrough").Output()
+	if err != nil || !tmuxOptionEnabled(string(passthrough)) {
+		return false, "native images need `tmux set -g allow-passthrough on`; using ansi"
+	}
+	clientTerm, err := exec.Command(tmuxBin, "display", "-p", "#{client_termname}").Output()
+	if err != nil {
+		return false, "tmux blocks native graphics; using ansi"
+	}
+	term := strings.ToLower(strings.TrimSpace(string(clientTerm)))
+	if !strings.Contains(term, "kitty") && !strings.Contains(term, "ghostty") {
+		return false, "the terminal running tmux has no kitty graphics; using ansi"
+	}
+	return true, ""
+}
+
+// tmuxOptionEnabled parses `tmux show` output such as "allow-passthrough on";
+// "all" also enables passthrough (it additionally covers invisible panes).
+func tmuxOptionEnabled(output string) bool {
+	fields := strings.Fields(output)
+	if len(fields) == 0 {
+		return false
+	}
+	value := fields[len(fields)-1]
+	return value == "on" || value == "all"
+}

--- a/internal/timeline/tmux_test.go
+++ b/internal/timeline/tmux_test.go
@@ -40,8 +40,28 @@ func TestTmuxOptionEnabled(t *testing.T) {
 	}
 }
 
+// A remote tmux reports the ssh client's terminal name, so the capability
+// check would otherwise green-light native mode for previews whose temp
+// files that terminal can never open.
+func TestTmuxNativeSupportRefusesOverSSH(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux-0/default,1,0")
+	t.Setenv("SSH_CONNECTION", "10.0.0.2 51000 10.0.0.1 22")
+	ok, note := tmuxNativeSupport()
+	if ok || note == "" {
+		t.Fatalf("tmuxNativeSupport over ssh = (%v, %q), want refusal with a note", ok, note)
+	}
+	if got, _ := resolveImageMode("auto"); got != imageModeANSI {
+		t.Fatalf("auto over ssh+tmux = %v, want ansi", got)
+	}
+}
+
 func TestResolveImageModeInsideTmux(t *testing.T) {
 	t.Setenv("ZELLIJ", "")
+	// Cleared so the assertions below fail for the reason they claim even
+	// when the suite itself runs over ssh.
+	t.Setenv("SSH_CONNECTION", "")
+	t.Setenv("SSH_TTY", "")
+	t.Setenv("SSH_CLIENT", "")
 	// A bogus socket path makes every tmux server query fail, which must
 	// downgrade auto mode to ansi rather than error or claim native.
 	t.Setenv("TMUX", "/nonexistent/socket,999999,0")

--- a/internal/timeline/tmux_test.go
+++ b/internal/timeline/tmux_test.go
@@ -1,0 +1,57 @@
+package timeline
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTmuxWrapOutsideTmuxIsIdentity(t *testing.T) {
+	t.Setenv("TMUX", "")
+	seq := "\x1b_Ga=p,U=1,i=7\x1b\\"
+	if got := tmuxWrap(seq); got != seq {
+		t.Fatalf("expected identity outside tmux, got %q", got)
+	}
+}
+
+func TestTmuxWrapDoublesEscapes(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux-0/default,123,0")
+	got := tmuxWrap("\x1b_Gq=2\x1b\\")
+	want := "\x1bPtmux;\x1b\x1b_Gq=2\x1b\x1b\\\x1b\\"
+	if got != want {
+		t.Fatalf("wrapped sequence = %q, want %q", got, want)
+	}
+	if !strings.HasPrefix(got, "\x1bPtmux;") || !strings.HasSuffix(got, "\x1b\\") {
+		t.Fatalf("missing DCS wrapper: %q", got)
+	}
+}
+
+func TestTmuxOptionEnabled(t *testing.T) {
+	cases := map[string]bool{
+		"allow-passthrough on\n":  true,
+		"allow-passthrough all\n": true,
+		"allow-passthrough off\n": false,
+		"on\n":                    true,
+		"":                        false,
+	}
+	for output, want := range cases {
+		if got := tmuxOptionEnabled(output); got != want {
+			t.Errorf("tmuxOptionEnabled(%q) = %v, want %v", output, got, want)
+		}
+	}
+}
+
+func TestResolveImageModeInsideTmux(t *testing.T) {
+	t.Setenv("ZELLIJ", "")
+	// A bogus socket path makes every tmux server query fail, which must
+	// downgrade auto mode to ansi rather than error or claim native.
+	t.Setenv("TMUX", "/nonexistent/socket,999999,0")
+	if got, note := resolveImageMode("auto"); got != imageModeANSI || note == "" {
+		t.Fatalf("auto in unverifiable tmux = %v (%q), want ansi with note", got, note)
+	}
+	if got, _ := resolveImageMode("native"); got != imageModeNative {
+		t.Fatalf("explicit native must bypass the tmux checks")
+	}
+	if got, _ := resolveImageMode("off"); got != imageModeOff {
+		t.Fatalf("off must stay off inside tmux")
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -201,7 +201,11 @@ func beginPost(text string, attachments []media.Attachment) tea.Cmd {
 			}
 			uploads := make([]api.Upload, 0, len(attachments))
 			for _, a := range attachments {
-				uploads = append(uploads, api.Upload{Filename: a.Name, ContentType: a.MIME, Data: a.Data})
+				upload := api.Upload{Filename: a.Name, ContentType: a.MIME, Data: a.Data}
+				if a.IsVideo() {
+					upload.Path = a.Path
+				}
+				uploads = append(uploads, upload)
 			}
 			client := api.NewWebClient(cfg)
 			id, err := client.PostTweet(ctx, text, "", uploads, func(event api.PostEvent) {
@@ -232,15 +236,28 @@ func (m *Model) addAttachment(a media.Attachment) {
 		m.toast = fmt.Sprintf("Maximum of %d images", media.MaxAttachments)
 		return
 	}
+	// X allows one video per post, never mixed with images.
+	if a.IsVideo() && len(m.attachments) > 0 {
+		m.toast = "A video must be the only attachment"
+		return
+	}
+	if !a.IsVideo() && len(m.attachments) > 0 && m.attachments[0].IsVideo() {
+		m.toast = "Images can't join a video post"
+		return
+	}
 	for _, existing := range m.attachments {
 		if existing.ID == a.ID {
-			m.toast = "That image is already attached"
+			m.toast = "That file is already attached"
 			return
 		}
 	}
 	m.attachments = append(m.attachments, a)
 	m.selected = len(m.attachments) - 1
 	m.resize()
+	if a.IsVideo() {
+		m.toast = fmt.Sprintf("Attached %s · %s · %s", a.Name, a.Format, media.HumanBytes(int(a.Size)))
+		return
+	}
 	m.toast = fmt.Sprintf("Attached %s · %s · %dx%d · %s", a.Name, a.Format, a.Width, a.Height, media.HumanBytes(int(a.Size)))
 }
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -159,7 +159,7 @@ func (m Model) viewAttachments(width int) string {
 		}
 		name := truncateRunes(a.Name, available)
 		meta := fmt.Sprintf("%s · %dx%d · %s", a.Format, a.Width, a.Height, media.HumanBytes(int(a.Size)))
-		if width < 52 {
+		if width < 52 || a.IsVideo() {
 			meta = fmt.Sprintf("%s · %s", a.Format, media.HumanBytes(int(a.Size)))
 		}
 		rows = append(rows, style.Render(prefix+name+"  "+meta))
@@ -178,6 +178,12 @@ func (m Model) viewPosting() string {
 		switch m.postStage.Stage {
 		case api.PostStageUploading:
 			stage = fmt.Sprintf("sending pic %d of %d…", m.postStage.Current, m.postStage.Total)
+			if m.postStage.TotalBytes > 0 {
+				percent := m.postStage.TransferredBytes * 100 / m.postStage.TotalBytes
+				stage = fmt.Sprintf("sending %s… %d%%", m.postStage.Name, percent)
+			}
+		case api.PostStageProcessing:
+			stage = "X is processing your video…"
 		case api.PostStageDiscovering:
 			stage = "finding the way to X…"
 		case api.PostStagePublishing:

--- a/pkg/api/upload.go
+++ b/pkg/api/upload.go
@@ -32,7 +32,11 @@ const (
 // needsChunkedUpload picks the INIT/APPEND/FINALIZE flow for video (which the
 // simple endpoint rejects), file-backed uploads, and oversized buffers.
 func (u Upload) needsChunkedUpload() bool {
-	return u.Path != "" || strings.HasPrefix(u.ContentType, "video/") || len(u.Data) > chunkedUploadThreshold
+	return u.Path != "" || u.isVideo() || len(u.Data) > chunkedUploadThreshold
+}
+
+func (u Upload) isVideo() bool {
+	return strings.HasPrefix(u.ContentType, "video/")
 }
 
 // mediaCategory tells X's pipeline how to transcode and validate the upload;

--- a/pkg/api/upload.go
+++ b/pkg/api/upload.go
@@ -101,6 +101,9 @@ func (c *WebClient) uploadMediaChunked(ctx context.Context, upload Upload, progr
 		return "", fmt.Errorf("initialize upload: %w", err)
 	}
 
+	// INIT already declared total_bytes; capping the reader keeps a file that
+	// grows mid-upload from appending more than the server expects.
+	reader = io.LimitReader(reader, total)
 	buffer := make([]byte, uploadChunkSize)
 	var sent int64
 	for segment := 0; sent < total; segment++ {

--- a/pkg/api/upload.go
+++ b/pkg/api/upload.go
@@ -1,0 +1,310 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	uploadEndpoint = "https://upload.twitter.com/1.1/media/upload.json"
+	// uploadChunkSize keeps every APPEND under X's 5 MB segment ceiling.
+	uploadChunkSize = 4 << 20
+	// chunkedUploadThreshold routes larger-than-simple-upload media (15 MB
+	// GIFs, for one) through the chunked flow even when they are not video.
+	chunkedUploadThreshold = 5 << 20
+	// maxProcessingWait bounds the FINALIZE→STATUS poll; X transcodes most
+	// tweet-length videos well inside this.
+	maxProcessingWait = 5 * time.Minute
+)
+
+// needsChunkedUpload picks the INIT/APPEND/FINALIZE flow for video (which the
+// simple endpoint rejects), file-backed uploads, and oversized buffers.
+func (u Upload) needsChunkedUpload() bool {
+	return u.Path != "" || strings.HasPrefix(u.ContentType, "video/") || len(u.Data) > chunkedUploadThreshold
+}
+
+// mediaCategory tells X's pipeline how to transcode and validate the upload;
+// omitting it makes video FINALIZE fail.
+func mediaCategory(contentType string) string {
+	switch {
+	case strings.HasPrefix(contentType, "video/"):
+		return "tweet_video"
+	case contentType == "image/gif":
+		return "tweet_gif"
+	default:
+		return "tweet_image"
+	}
+}
+
+type processingInfo struct {
+	State          string `json:"state"`
+	CheckAfterSecs int    `json:"check_after_secs"`
+	ProgressPct    int    `json:"progress_percent"`
+	Error          struct {
+		Name    string `json:"name"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+type uploadStatusResponse struct {
+	MediaIDString  string          `json:"media_id_string"`
+	ProcessingInfo *processingInfo `json:"processing_info"`
+}
+
+// uploadMediaChunked uploads one attachment through the chunked media
+// endpoint and waits for server-side processing so the returned media id is
+// attachable. progress (optional) reports transmitted bytes.
+func (c *WebClient) uploadMediaChunked(ctx context.Context, upload Upload, progress func(sent, total int64)) (string, error) {
+	var reader io.Reader
+	var total int64
+	if upload.Path != "" {
+		file, err := os.Open(upload.Path)
+		if err != nil {
+			return "", fmt.Errorf("open media: %w", err)
+		}
+		defer file.Close()
+		info, err := file.Stat()
+		if err != nil {
+			return "", fmt.Errorf("read media: %w", err)
+		}
+		reader, total = file, info.Size()
+	} else {
+		reader, total = bytes.NewReader(upload.Data), int64(len(upload.Data))
+	}
+	if total <= 0 {
+		return "", fmt.Errorf("empty media")
+	}
+	contentType := upload.ContentType
+	if contentType == "" {
+		return "", fmt.Errorf("media content type is required for chunked upload")
+	}
+
+	mediaID, err := c.uploadCommand(ctx, url.Values{
+		"command":        {"INIT"},
+		"total_bytes":    {strconv.FormatInt(total, 10)},
+		"media_type":     {contentType},
+		"media_category": {mediaCategory(contentType)},
+	})
+	if err != nil {
+		return "", fmt.Errorf("initialize upload: %w", err)
+	}
+
+	buffer := make([]byte, uploadChunkSize)
+	var sent int64
+	for segment := 0; sent < total; segment++ {
+		n, readErr := io.ReadFull(reader, buffer)
+		if readErr == io.ErrUnexpectedEOF || readErr == io.EOF {
+			readErr = nil
+		}
+		if readErr != nil {
+			return "", fmt.Errorf("read media: %w", readErr)
+		}
+		if n == 0 {
+			return "", fmt.Errorf("media truncated at %d of %d bytes", sent, total)
+		}
+		if err := c.uploadAppend(ctx, mediaID, segment, upload.Filename, buffer[:n]); err != nil {
+			return "", fmt.Errorf("upload segment %d: %w", segment+1, err)
+		}
+		sent += int64(n)
+		if progress != nil {
+			progress(sent, total)
+		}
+	}
+
+	status, err := c.uploadFinalize(ctx, mediaID)
+	if err != nil {
+		return "", fmt.Errorf("finalize upload: %w", err)
+	}
+	return c.awaitProcessing(ctx, mediaID, status)
+}
+
+// awaitProcessing polls STATUS until X finishes transcoding. Images finish
+// synchronously (no processing_info); video usually returns pending.
+func (c *WebClient) awaitProcessing(ctx context.Context, mediaID string, status *uploadStatusResponse) (string, error) {
+	deadline := time.Now().Add(maxProcessingWait)
+	info := status.ProcessingInfo
+	for {
+		if info == nil || info.State == "succeeded" {
+			return mediaID, nil
+		}
+		if info.State == "failed" {
+			message := info.Error.Message
+			if message == "" {
+				message = info.Error.Name
+			}
+			if message == "" {
+				message = "media processing failed"
+			}
+			return "", fmt.Errorf("X could not process this media: %s", message)
+		}
+		wait := time.Duration(info.CheckAfterSecs) * time.Second
+		if wait <= 0 {
+			wait = time.Second
+		}
+		if wait > 15*time.Second {
+			wait = 15 * time.Second
+		}
+		if time.Now().Add(wait).After(deadline) {
+			return "", fmt.Errorf("media processing did not finish within %s", maxProcessingWait)
+		}
+		select {
+		case <-ctx.Done():
+			return "", classifyTransportError(ctx.Err())
+		case <-time.After(wait):
+		}
+		next, err := c.uploadStatus(ctx, mediaID)
+		if err != nil {
+			return "", fmt.Errorf("check media processing: %w", err)
+		}
+		info = next.ProcessingInfo
+	}
+}
+
+// uploadCommand posts a form-encoded INIT or FINALIZE and returns the media
+// id from the response.
+func (c *WebClient) uploadCommand(ctx context.Context, form url.Values) (string, error) {
+	body := form.Encode()
+	res, err := c.send(ctx, func() (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, uploadEndpoint, strings.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		c.setHeaders(req)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		return req, nil
+	}, true, 4<<20)
+	if err != nil {
+		return "", err
+	}
+	parsed, err := decodeUploadResponse(res)
+	if err != nil {
+		return "", err
+	}
+	if parsed.MediaIDString == "" {
+		return "", fmt.Errorf("upload returned no media id: %s", truncate(res.body))
+	}
+	return parsed.MediaIDString, nil
+}
+
+// uploadAppend sends one media segment. Retrying a segment is safe: X keys
+// segments by index, so a duplicate APPEND overwrites identical bytes.
+func (c *WebClient) uploadAppend(ctx context.Context, mediaID string, segment int, filename string, chunk []byte) error {
+	name := filepath.Base(filename)
+	if name == "." || name == "" {
+		name = "media"
+	}
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	for field, value := range map[string]string{
+		"command":       "APPEND",
+		"media_id":      mediaID,
+		"segment_index": strconv.Itoa(segment),
+	} {
+		if err := w.WriteField(field, value); err != nil {
+			return err
+		}
+	}
+	header := make(textproto.MIMEHeader)
+	header.Set("Content-Disposition", multipart.FileContentDisposition("media", name))
+	header.Set("Content-Type", "application/octet-stream")
+	part, err := w.CreatePart(header)
+	if err != nil {
+		return err
+	}
+	if _, err := part.Write(chunk); err != nil {
+		return err
+	}
+	if err := w.Close(); err != nil {
+		return err
+	}
+
+	formBody := buf.Bytes()
+	res, err := c.send(ctx, func() (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, uploadEndpoint, bytes.NewReader(formBody))
+		if err != nil {
+			return nil, err
+		}
+		c.setHeaders(req)
+		req.Header.Set("Content-Type", w.FormDataContentType())
+		return req, nil
+	}, true, 1<<20)
+	if err != nil {
+		return err
+	}
+	// APPEND answers 204 with an empty body on success.
+	if err := statusToError(res.status, res.header); err != nil {
+		return err
+	}
+	if isTransientStatus(res.status) {
+		return &ServiceUnavailableError{Status: res.status}
+	}
+	if res.status < http.StatusOK || res.status >= http.StatusMultipleChoices {
+		return fmt.Errorf("upload HTTP %d: %s", res.status, truncate(res.body))
+	}
+	return nil
+}
+
+func (c *WebClient) uploadFinalize(ctx context.Context, mediaID string) (*uploadStatusResponse, error) {
+	body := url.Values{"command": {"FINALIZE"}, "media_id": {mediaID}}.Encode()
+	res, err := c.send(ctx, func() (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, uploadEndpoint, strings.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		c.setHeaders(req)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		return req, nil
+	}, true, 4<<20)
+	if err != nil {
+		return nil, err
+	}
+	return decodeUploadResponse(res)
+}
+
+func (c *WebClient) uploadStatus(ctx context.Context, mediaID string) (*uploadStatusResponse, error) {
+	statusURL := uploadEndpoint + "?" + url.Values{"command": {"STATUS"}, "media_id": {mediaID}}.Encode()
+	res, err := c.send(ctx, func() (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, statusURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		c.setHeaders(req)
+		req.Header.Del("Content-Type")
+		return req, nil
+	}, true, 4<<20)
+	if err != nil {
+		return nil, err
+	}
+	return decodeUploadResponse(res)
+}
+
+func decodeUploadResponse(res *httpResult) (*uploadStatusResponse, error) {
+	if err := statusToError(res.status, res.header); err != nil {
+		return nil, err
+	}
+	if isTransientStatus(res.status) {
+		return nil, &ServiceUnavailableError{Status: res.status}
+	}
+	if res.status < http.StatusOK || res.status >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("upload HTTP %d: %s", res.status, truncate(res.body))
+	}
+	var parsed uploadStatusResponse
+	if len(res.body) > 0 {
+		if err := json.Unmarshal(res.body, &parsed); err != nil {
+			return nil, fmt.Errorf("decode upload response: %w", err)
+		}
+	}
+	return &parsed, nil
+}

--- a/pkg/api/upload.go
+++ b/pkg/api/upload.go
@@ -145,9 +145,9 @@ func (c *WebClient) awaitProcessing(ctx context.Context, mediaID string, status 
 				message = info.Error.Name
 			}
 			if message == "" {
-				message = "media processing failed"
+				message = "no reason given"
 			}
-			return "", fmt.Errorf("X could not process this media: %s", message)
+			return "", fmt.Errorf("media processing failed: %s", message)
 		}
 		wait := time.Duration(info.CheckAfterSecs) * time.Second
 		if wait <= 0 {

--- a/pkg/api/upload_test.go
+++ b/pkg/api/upload_test.go
@@ -1,0 +1,151 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNeedsChunkedUpload(t *testing.T) {
+	cases := []struct {
+		upload Upload
+		want   bool
+	}{
+		{Upload{ContentType: "image/png", Data: []byte("x")}, false},
+		{Upload{ContentType: "video/mp4", Path: "/tmp/a.mp4"}, true},
+		{Upload{ContentType: "video/mp4", Data: []byte("x")}, true},
+		{Upload{ContentType: "image/gif", Data: make([]byte, chunkedUploadThreshold+1)}, true},
+	}
+	for _, c := range cases {
+		if got := c.upload.needsChunkedUpload(); got != c.want {
+			t.Errorf("needsChunkedUpload(%q path=%q len=%d) = %v, want %v",
+				c.upload.ContentType, c.upload.Path, len(c.upload.Data), got, c.want)
+		}
+	}
+}
+
+func TestMediaCategory(t *testing.T) {
+	cases := map[string]string{
+		"video/mp4":       "tweet_video",
+		"video/quicktime": "tweet_video",
+		"image/gif":       "tweet_gif",
+		"image/png":       "tweet_image",
+	}
+	for contentType, want := range cases {
+		if got := mediaCategory(contentType); got != want {
+			t.Errorf("mediaCategory(%q) = %q, want %q", contentType, got, want)
+		}
+	}
+}
+
+// TestPostTweetChunkedVideo walks the full INIT/APPEND/FINALIZE/STATUS flow
+// for a file-backed video large enough to need two segments, then confirms
+// the media id lands in CreateTweet.
+func TestPostTweetChunkedVideo(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "clip.mp4")
+	payload := bytes.Repeat([]byte("v"), uploadChunkSize+512)
+	if err := os.WriteFile(path, payload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var commands []string
+	var appended int
+	statusPolls := 0
+	var graphQLBody []byte
+	client := &WebClient{authToken: "auth", ct0: "csrf", queryID: "qid"}
+	client.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var body []byte
+		if req.Body != nil {
+			body, _ = io.ReadAll(req.Body)
+		}
+		if !strings.Contains(req.URL.Path, "media/upload") {
+			graphQLBody = body
+			return response(http.StatusOK, `{"data":{"create_tweet":{"tweet_results":{"result":{"rest_id":"77"}}}}}`), nil
+		}
+		switch {
+		case req.Method == http.MethodGet:
+			commands = append(commands, "STATUS")
+			statusPolls++
+			state := `"in_progress","check_after_secs":0`
+			if statusPolls >= 2 {
+				state = `"succeeded"`
+			}
+			return response(http.StatusOK, `{"media_id_string":"555","processing_info":{"state":`+state+`}}`), nil
+		case strings.Contains(string(body), "INIT"):
+			commands = append(commands, "INIT")
+			text := string(body)
+			if !strings.Contains(text, "tweet_video") || !strings.Contains(text, "video%2Fmp4") {
+				t.Errorf("INIT missing category or media type: %s", text)
+			}
+			return response(http.StatusAccepted, `{"media_id_string":"555"}`), nil
+		case strings.Contains(string(body), "APPEND"):
+			commands = append(commands, "APPEND")
+			appended += len(body)
+			return response(http.StatusNoContent, ""), nil
+		case strings.Contains(string(body), "FINALIZE"):
+			commands = append(commands, "FINALIZE")
+			return response(http.StatusOK, `{"media_id_string":"555","processing_info":{"state":"pending","check_after_secs":0}}`), nil
+		}
+		t.Errorf("unexpected upload request: %s", body)
+		return response(http.StatusBadRequest, ""), nil
+	})}
+
+	var events []PostEvent
+	id, err := client.PostTweet(context.Background(), "clip", "", []Upload{
+		{Filename: "clip.mp4", ContentType: "video/mp4", Path: path},
+	}, func(event PostEvent) { events = append(events, event) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != "77" {
+		t.Fatalf("id = %q", id)
+	}
+	sequence := strings.Join(commands, " ")
+	if !strings.HasPrefix(sequence, "INIT APPEND APPEND FINALIZE STATUS") {
+		t.Fatalf("unexpected upload sequence: %s", sequence)
+	}
+	if appended < len(payload) {
+		t.Fatalf("segments carried %d bytes, want at least %d", appended, len(payload))
+	}
+	if !strings.Contains(string(graphQLBody), `"media_id":"555"`) {
+		t.Fatalf("CreateTweet missing media id: %s", graphQLBody)
+	}
+	var sawBytes, sawProcessing bool
+	for _, event := range events {
+		if event.Stage == PostStageUploading && event.TotalBytes == int64(len(payload)) && event.TransferredBytes > 0 {
+			sawBytes = true
+		}
+		if event.Stage == PostStageProcessing {
+			sawProcessing = true
+		}
+	}
+	if !sawBytes || !sawProcessing {
+		t.Fatalf("missing byte progress or processing events: %+v", events)
+	}
+}
+
+func TestChunkedUploadProcessingFailure(t *testing.T) {
+	client := &WebClient{authToken: "auth", ct0: "csrf"}
+	client.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(req.Body)
+		switch {
+		case strings.Contains(string(body), "INIT"):
+			return response(http.StatusOK, `{"media_id_string":"9"}`), nil
+		case strings.Contains(string(body), "APPEND"):
+			return response(http.StatusNoContent, ""), nil
+		default:
+			return response(http.StatusOK, `{"media_id_string":"9","processing_info":{"state":"failed","error":{"message":"InvalidMedia: unsupported codec"}}}`), nil
+		}
+	})}
+	_, err := client.uploadMediaChunked(context.Background(), Upload{
+		Filename: "bad.mp4", ContentType: "video/mp4", Data: []byte("not really video"),
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), "unsupported codec") {
+		t.Fatalf("expected processing failure with server message, got %v", err)
+	}
+}

--- a/pkg/api/web.go
+++ b/pkg/api/web.go
@@ -458,15 +458,22 @@ func (c *WebClient) PostTweet(ctx context.Context, text, replyToID string, uploa
 		return "", fmt.Errorf("no session; run 'xeet auth' first")
 	}
 	if len(uploads) > 4 {
-		return "", fmt.Errorf("a post can have at most 4 images")
+		return "", fmt.Errorf("a post can have at most 4 attachments")
 	}
 	if text == "" && len(uploads) == 0 {
-		return "", fmt.Errorf("post has no text or images")
+		return "", fmt.Errorf("post has no text or media")
 	}
+	videos := 0
 	for i, upload := range uploads {
 		if len(upload.Data) == 0 && upload.Path == "" {
 			return "", fmt.Errorf("attachment %d is empty", i+1)
 		}
+		if upload.isVideo() {
+			videos++
+		}
+	}
+	if videos > 0 && len(uploads) > 1 {
+		return "", fmt.Errorf("a video must be the only attachment")
 	}
 	vars := newCreateTweetVariables(text)
 	for i, upload := range uploads {

--- a/pkg/api/web.go
+++ b/pkg/api/web.go
@@ -42,17 +42,21 @@ type LoginResult struct {
 	LastUsedAt   time.Time
 }
 
-// Upload is one image to upload and attach to a post.
+// Upload is one media item to upload and attach to a post. Images travel in
+// Data; large media (video) sets Path instead and streams from disk through
+// the chunked endpoint.
 type Upload struct {
 	Filename    string
 	ContentType string
 	Data        []byte
+	Path        string
 }
 
 type PostStage string
 
 const (
 	PostStageUploading   PostStage = "uploading"
+	PostStageProcessing  PostStage = "processing"
 	PostStageDiscovering PostStage = "discovering"
 	PostStagePublishing  PostStage = "publishing"
 	PostStageReconciling PostStage = "reconciling"
@@ -60,11 +64,15 @@ const (
 )
 
 // PostEvent reports coarse posting progress. The callback is optional.
+// Chunked uploads additionally fill the byte counters so UIs can show a
+// percentage while a video transfers.
 type PostEvent struct {
-	Stage   PostStage
-	Current int
-	Total   int
-	Name    string
+	Stage            PostStage
+	Current          int
+	Total            int
+	Name             string
+	TransferredBytes int64
+	TotalBytes       int64
 }
 
 type ProgressFunc func(PostEvent)
@@ -443,7 +451,7 @@ func newCreateTweetVariables(text string) createTweetVariables {
 }
 
 // PostTweet posts through the web GraphQL endpoint and returns the created id.
-// Images are uploaded first and attached to the same CreateTweet operation.
+// Media is uploaded first and attached to the same CreateTweet operation.
 func (c *WebClient) PostTweet(ctx context.Context, text, replyToID string, uploads []Upload, progress ProgressFunc) (string, error) {
 	c.lastDiagnostic = ""
 	if c.authToken == "" || c.ct0 == "" {
@@ -456,14 +464,30 @@ func (c *WebClient) PostTweet(ctx context.Context, text, replyToID string, uploa
 		return "", fmt.Errorf("post has no text or images")
 	}
 	for i, upload := range uploads {
-		if len(upload.Data) == 0 {
-			return "", fmt.Errorf("image %d is empty", i+1)
+		if len(upload.Data) == 0 && upload.Path == "" {
+			return "", fmt.Errorf("attachment %d is empty", i+1)
 		}
 	}
 	vars := newCreateTweetVariables(text)
 	for i, upload := range uploads {
 		emitProgress(progress, PostEvent{Stage: PostStageUploading, Current: i + 1, Total: len(uploads), Name: upload.Filename})
-		mediaID, err := c.uploadMedia(ctx, upload)
+		var mediaID string
+		var err error
+		if upload.needsChunkedUpload() {
+			mediaID, err = c.uploadMediaChunked(ctx, upload, func(sent, total int64) {
+				stage := PostStageUploading
+				if sent == total {
+					// The transfer is done; anything after this is X transcoding.
+					stage = PostStageProcessing
+				}
+				emitProgress(progress, PostEvent{
+					Stage: stage, Current: i + 1, Total: len(uploads), Name: upload.Filename,
+					TransferredBytes: sent, TotalBytes: total,
+				})
+			})
+		} else {
+			mediaID, err = c.uploadMedia(ctx, upload)
+		}
 		if err != nil {
 			return "", fmt.Errorf("upload %q: %w", upload.Filename, err)
 		}

--- a/pkg/api/web_test.go
+++ b/pkg/api/web_test.go
@@ -103,6 +103,20 @@ func TestPostTweetValidatesContent(t *testing.T) {
 	}
 }
 
+// TestPostTweetRejectsMixedVideoAndImages enforces "one video per post,
+// never mixed with images" at the API boundary, not just in the callers
+// (TUI, cmd/post.go) that happen to check it today.
+func TestPostTweetRejectsMixedVideoAndImages(t *testing.T) {
+	client := &WebClient{authToken: "auth", ct0: "csrf"}
+	uploads := []Upload{
+		{ContentType: "video/mp4", Data: []byte("v")},
+		{ContentType: "image/png", Data: []byte("i")},
+	}
+	if _, err := client.PostTweet(context.Background(), "x", "", uploads, nil); err == nil {
+		t.Fatal("video mixed with an image should fail")
+	}
+}
+
 func TestCreateTweetReplyPayload(t *testing.T) {
 	vars := createTweetVariables{
 		TweetText:             "re",


### PR DESCRIPTION
Add tmux-aware Kitty graphics passthrough (DCS-wrapped escapes) with capability checks and tests.
Implement INIT/APPEND/FINALIZE/STATUS chunked media uploads (4 MiB segments) with byte-level progress and processing wait.
Update CLI/TUI/media sniffing/docs to support “up to 4 images OR 1 video” behavior and show upload progress.