### PR TITLE
Nix dev shell and package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ coverage.out
 tmp/
 temp/
 debug*
+
+# Nix build outputs
+result
+result-*

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ timeline with inline images, reply, like, done.
 works on macos and linux. windows isn't supported, open an issue if you
 want it.
 
+**with nix**:
+
+```bash
+nix profile install github:melqtx/xeet   # install
+nix run github:melqtx/xeet               # or just try it
+```
+
 **with go** (1.26+):
 
 ```bash
@@ -46,6 +53,9 @@ git clone https://github.com/melqtx/xeet.git
 cd xeet
 make install   # builds and installs to /usr/local/bin/
 ```
+
+hacking on it? `nix-shell` (or `nix develop`) gets you go, gopls, and
+staticcheck; `make dev` runs fmt, vet, build, and tests.
 
 **or grab a release**: download the archive for your platform from
 [releases](https://github.com/melqtx/xeet/releases), check it against

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildGoModule
+, installShellFiles
+, xclip
+, wl-clipboard
+, makeWrapper
+, stdenv
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "xeet";
+  version = "0.1.8";
+
+  src = lib.cleanSource ./.;
+
+  vendorHash = "sha256-/Qy+oPK4BzNMl2xqVwNKdEzZ9N3zTpSzzmLCTKNV8z0=";
+
+  # main.go reads these through -X; without them the binary reports "dev".
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+    "-X main.commit=nix"
+    "-X main.buildTime=unknown"
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # Clipboard attachments shell out to xclip/wl-clipboard on Linux; put them
+  # on PATH so a nix-installed xeet works outside a dev shell. macOS uses the
+  # system pasteboard and needs nothing.
+  postInstall = lib.optionalString stdenv.isLinux ''
+    wrapProgram $out/bin/xeet \
+      --prefix PATH : ${lib.makeBinPath [ xclip wl-clipboard ]}
+  '';
+
+  meta = {
+    description = "Post to and read X from the terminal, using your browser session";
+    homepage = "https://github.com/melqtx/xeet";
+    license = lib.licenses.mit;
+    mainProgram = "xeet";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1784796856,
+        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  description = "Post to and read X from the terminal, using your browser session";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      # xeet targets macos and linux; enumerate the systems directly rather
+      # than pulling in flake-utils for one helper.
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = f:
+        nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      packages = forAllSystems (pkgs: {
+        default = pkgs.callPackage ./default.nix { };
+      });
+
+      devShells = forAllSystems (pkgs: {
+        default = import ./shell.nix { inherit pkgs; };
+      });
+
+      checks = forAllSystems (pkgs: {
+        default = pkgs.callPackage ./default.nix { };
+      });
+    };
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/melqtx/xeet
 
-go 1.26.5
+go 1.26.4
 
 require (
 	github.com/browserutils/kooky v0.2.10

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/melqtx/xeet
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/browserutils/kooky v0.2.10

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,27 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+pkgs.mkShell {
+  name = "xeet";
+
+  packages = with pkgs; [
+    go
+    gopls
+    go-tools # staticcheck, which CI runs
+    gnumake
+    git
+  ] ++ lib.optionals stdenv.isLinux [
+    # Clipboard attachments shell out to these at runtime; macOS uses the
+    # system pasteboard instead.
+    xclip
+    wl-clipboard
+  ];
+
+  shellHook = ''
+    # go.mod may pin a patch release newer than the one in nixpkgs. Leaving
+    # GOTOOLCHAIN on auto lets the go command fetch the exact toolchain
+    # instead of refusing to build.
+    export GOTOOLCHAIN=auto
+    export GOPATH="''${GOPATH:-$HOME/go}"
+    export PATH="$GOPATH/bin:$PATH"
+  '';
+}

--- a/shell.nix
+++ b/shell.nix
@@ -17,9 +17,10 @@ pkgs.mkShell {
   ];
 
   shellHook = ''
-    # go.mod may pin a patch release newer than the one in nixpkgs. Leaving
-    # GOTOOLCHAIN on auto lets the go command fetch the exact toolchain
-    # instead of refusing to build.
+    # An older nixpkgs channel may carry a go patch release behind go.mod's;
+    # the pinned version matters because it usually carries stdlib security
+    # fixes. Leaving GOTOOLCHAIN on auto lets the go command fetch the exact
+    # toolchain rather than silently building against an older one.
     export GOTOOLCHAIN=auto
     export GOPATH="''${GOPATH:-$HOME/go}"
     export PATH="$GOPATH/bin:$PATH"


### PR DESCRIPTION
`shell.nix` for hacking on xeet (go, gopls, staticcheck), plus `flake.nix` + `default.nix` so it installs with `nix profile install github:melqtx/xeet`. README updated.

The install command only works once this is on main.