### PR TITLE
fix review findings: context wiring, timeline split, nix ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,24 @@ jobs:
           go run github.com/google/go-licenses@v1.6.0 check ./...
           --allowed_licenses=Apache-2.0,MIT,BSD-2-Clause,BSD-3-Clause,ISC,MPL-2.0
 
+  nix:
+    name: nix package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      # Builds the flake package, which is what `nix profile install
+      # github:melqtx/xeet` runs. It fails if default.nix's vendorHash no
+      # longer matches go.mod/go.sum, so a dependency bump cannot silently
+      # break installation.
+      - name: Build the flake package
+        run: nix build .#default --print-build-logs
+
   cross-compile:
     name: cross (${{ matrix.goos }}/${{ matrix.goarch }})
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ GOTEST := $(GOCMD) test
 GOGET := $(GOCMD) get
 GOMOD := $(GOCMD) mod
 
+# Keep in step with .github/workflows/ci.yml
+STATICCHECK_VERSION := v0.7.0
+
 # Directories
 DIST_DIR := dist
 BUILD_DIR := build
@@ -97,15 +100,11 @@ vet:
 	@echo "Vetting code..."
 	$(GOCMD) vet ./...
 
-# Lint code (requires golangci-lint)
+# Lint code with the same staticcheck version CI runs
 .PHONY: lint
 lint:
 	@echo "Linting code..."
-	@if command -v golangci-lint >/dev/null 2>&1; then \
-		golangci-lint run; \
-	else \
-		echo "golangci-lint not found. Install with: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b \$$(go env GOPATH)/bin v1.54.2"; \
-	fi
+	$(GOCMD) run honnef.co/go/tools/cmd/staticcheck@$(STATICCHECK_VERSION) ./...
 
 # Tidy dependencies
 .PHONY: tidy
@@ -133,11 +132,7 @@ dev-setup:
 	@echo "Setting up development environment..."
 	$(GOMOD) download
 	$(GOMOD) tidy
-	@if ! command -v golangci-lint >/dev/null 2>&1; then \
-		echo "Installing golangci-lint..."; \
-		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.54.2; \
-	fi
-	@echo "Development environment ready!"
+	@echo "Development environment ready! (nix-shell also provides go, gopls, and staticcheck)"
 
 # Create release (for GitHub Actions)
 .PHONY: release

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -62,8 +62,7 @@ func runAuth(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(cmd.Context(), 45*time.Second)
 	defer cancel()
 	client := api.NewWebClient(&candidate)
-	handle, err := client.Verify(ctx)
-	if err != nil {
+	if err := client.Verify(ctx); err != nil {
 		return fmt.Errorf("session found in %s but X rejected verification: %w", browser, err)
 	}
 	client.ApplyRefreshedQueryIDs(&candidate)
@@ -75,10 +74,6 @@ func runAuth(cmd *cobra.Command, args []string) error {
 	if result.Profile != "" {
 		source = fmt.Sprintf("%s profile %q", browser, result.Profile)
 	}
-	if handle != "" {
-		fmt.Printf("✓ Connected as @%s via %s. Run `xeet` for your timeline or `xeet --compose` to post.\n", handle, source)
-	} else {
-		fmt.Printf("✓ Connected via %s. Run `xeet` for your timeline or `xeet --compose` to post.\n", source)
-	}
+	fmt.Printf("✓ Connected via %s. Run `xeet` for your timeline or `xeet --compose` to post.\n", source)
 	return nil
 }

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -72,7 +72,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 
 	ctx, cancel := context.WithTimeout(cmd.Context(), 45*time.Second)
 	defer cancel()
-	if _, err := api.NewWebClient(cfg).Verify(ctx); err != nil {
+	if err := api.NewWebClient(cfg).Verify(ctx); err != nil {
 		return fmt.Errorf("verification failed: %w", err)
 	}
 	fmt.Fprintln(cmd.OutOrStdout(), "verification: authenticated timeline read succeeded")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,12 +48,20 @@ func init() {
 
 func runRoot(cmd *cobra.Command, args []string) error {
 	configMgr, err := config.NewConfigManager()
-	if err == nil {
-		if cfg, loadErr := configMgr.Load(); loadErr == nil && cfg.AuthToken == "" {
-			fmt.Println("Welcome to xeet! First, connect your X account:")
-			fmt.Println("  xeet auth")
-			return nil
-		}
+	if err != nil {
+		return err
+	}
+	// A load failure here (an incomplete keyring pair, an unreadable config)
+	// carries its own recovery advice. Falling through to the timeline would
+	// bury it under a generic fetch error.
+	cfg, err := configMgr.Load()
+	if err != nil {
+		return err
+	}
+	if cfg.AuthToken == "" {
+		fmt.Println("Welcome to xeet! First, connect your X account:")
+		fmt.Println("  xeet auth")
+		return nil
 	}
 
 	if err := applyConfiguredTheme(rootTheme); err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,7 +68,7 @@ func runRoot(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if composeOnly {
-		return tui.Run()
+		return tui.Run(cmd.Context())
 	}
 	imageMode := "auto"
 	if barebones {

--- a/cmd/timeline.go
+++ b/cmd/timeline.go
@@ -45,6 +45,8 @@ func runTimeline(ctx context.Context, imageMode string, following bool) error {
 		if err != nil {
 			return err
 		}
+		// An interrupt has to stop the loop rather than reopen the alt screen
+		// or start an interactive browser prompt against a dead context.
 		if ctx.Err() != nil {
 			return nil
 		}
@@ -52,6 +54,9 @@ func runTimeline(ctx context.Context, imageMode string, following bool) error {
 		case timeline.ActionCompose:
 			if err := tui.Run(ctx); err != nil {
 				return err
+			}
+			if ctx.Err() != nil {
+				return nil
 			}
 		case timeline.ActionAuthenticate:
 			authInvocation := &cobra.Command{}

--- a/cmd/timeline.go
+++ b/cmd/timeline.go
@@ -61,8 +61,17 @@ func runTimeline(ctx context.Context, imageMode string, following bool) error {
 		case timeline.ActionAuthenticate:
 			authInvocation := &cobra.Command{}
 			authInvocation.SetContext(ctx)
+			// An interrupt surfaces here as an error: the browser picker
+			// reports its own cancellation and verification fails on the dead
+			// context. Neither is worth printing as a failure.
 			if err := runAuth(authInvocation, nil); err != nil {
+				if ctx.Err() != nil {
+					return nil
+				}
 				return err
+			}
+			if ctx.Err() != nil {
+				return nil
 			}
 		default:
 			return nil

--- a/cmd/timeline.go
+++ b/cmd/timeline.go
@@ -41,13 +41,16 @@ func runTimeline(ctx context.Context, imageMode string, following bool) error {
 		return fmt.Errorf("invalid --images value %q (use auto, native, ansi, or off)", imageMode)
 	}
 	for {
-		action, err := timeline.Run(imageMode, following)
+		action, err := timeline.Run(ctx, imageMode, following)
 		if err != nil {
 			return err
 		}
+		if ctx.Err() != nil {
+			return nil
+		}
 		switch action.Kind {
 		case timeline.ActionCompose:
-			if err := tui.Run(); err != nil {
+			if err := tui.Run(ctx); err != nil {
 				return err
 			}
 		case timeline.ActionAuthenticate:

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildGoModule
-, xclip
 , wl-clipboard
+, xorg
 , makeWrapper
 , stdenv
 }:
@@ -29,12 +29,17 @@ buildGoModule (finalAttrs: {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  # Clipboard attachments shell out to xclip/wl-clipboard on Linux; put them
-  # on PATH so a nix-installed xeet works outside a dev shell. macOS uses the
-  # system pasteboard and needs nothing.
+  # golang.design/x/clipboard talks to X11 through cgo, so the linux build
+  # needs Xlib to compile at all. Without it the package built on darwin and
+  # failed on linux.
+  buildInputs = lib.optionals stdenv.isLinux [ xorg.libX11 ];
+
+  # On wayland the clipboard shells out to wl-paste/wl-copy, so keep those on
+  # PATH for an installed xeet. X11 goes through the linked Xlib above, and
+  # macOS uses the system pasteboard.
   postInstall = lib.optionalString stdenv.isLinux ''
     wrapProgram $out/bin/xeet \
-      --prefix PATH : ${lib.makeBinPath [ xclip wl-clipboard ]}
+      --prefix PATH : ${lib.makeBinPath [ wl-clipboard ]}
   '';
 
   meta = {

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,5 @@
 { lib
 , buildGoModule
-, installShellFiles
 , xclip
 , wl-clipboard
 , makeWrapper
@@ -9,10 +8,14 @@
 
 buildGoModule (finalAttrs: {
   pname = "xeet";
+  # Keep in step with the latest release tag.
   version = "0.1.8";
 
   src = lib.cleanSource ./.;
 
+  # Regenerate whenever go.mod or go.sum changes (including on dependabot
+  # bumps): set this to lib.fakeHash, run `nix build .#default`, and copy the
+  # hash nix reports. CI's nix job fails when it goes stale.
   vendorHash = "sha256-/Qy+oPK4BzNMl2xqVwNKdEzZ9N3zTpSzzmLCTKNV8z0=";
 
   # main.go reads these through -X; without them the binary reports "dev".

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildGoModule
 , wl-clipboard
-, xorg
+, libx11
 , makeWrapper
 , stdenv
 }:
@@ -29,17 +29,20 @@ buildGoModule (finalAttrs: {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  # golang.design/x/clipboard talks to X11 through cgo, so the linux build
-  # needs Xlib to compile at all. Without it the package built on darwin and
-  # failed on linux.
-  buildInputs = lib.optionals stdenv.isLinux [ xorg.libX11 ];
+  # golang.design/x/clipboard compiles X11 through cgo, so the linux build
+  # needs Xlib's headers. Without them the package built on darwin and failed
+  # on linux.
+  buildInputs = lib.optionals stdenv.isLinux [ libx11 ];
 
-  # On wayland the clipboard shells out to wl-paste/wl-copy, so keep those on
-  # PATH for an installed xeet. X11 goes through the linked Xlib above, and
-  # macOS uses the system pasteboard.
+  # The clipboard links only -ldl and dlopens "libX11.so" at runtime, so
+  # nothing records libx11 in the binary's rpath and the lookup would fail on
+  # a machine without X11 in the default loader paths. LD_LIBRARY_PATH points
+  # it at the unversioned symlink in libx11's lib directory. Wayland shells
+  # out to wl-paste/wl-copy instead; macOS uses the system pasteboard.
   postInstall = lib.optionalString stdenv.isLinux ''
     wrapProgram $out/bin/xeet \
-      --prefix PATH : ${lib.makeBinPath [ wl-clipboard ]}
+      --prefix PATH : ${lib.makeBinPath [ wl-clipboard ]} \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libx11 ]}
   '';
 
   meta = {

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -274,32 +274,6 @@ func fetchPageSeq(parent context.Context, following bool, cursor string, more bo
 	}
 }
 
-func fetchThread(parent context.Context, tweetID, cursor string, more bool, seq int) tea.Cmd {
-	return func() tea.Msg {
-		mgr, err := config.NewConfigManager()
-		if err != nil {
-			return threadMsg{rootID: tweetID, seq: seq, err: err, more: more}
-		}
-		cfg, err := mgr.Load()
-		if err != nil {
-			return threadMsg{rootID: tweetID, seq: seq, err: err, more: more}
-		}
-		ctx, cancel := context.WithTimeout(parent, 40*time.Second)
-		defer cancel()
-		client := api.NewWebClient(cfg)
-		page, err := client.FetchTweetDetail(ctx, tweetID, cursor, 40)
-		if client.ApplyRefreshedQueryIDs(cfg) {
-			_ = mgr.Save(cfg)
-		}
-		return threadMsg{rootID: tweetID, seq: seq, page: page, err: err, more: more}
-	}
-}
-
-func (m *Model) requestThread(cursor string, more bool) tea.Cmd {
-	m.threadSeq++
-	return fetchThread(m.requestContext(), m.threadRootID, cursor, more, m.threadSeq)
-}
-
 func setLike(parent context.Context, tweetID string, liked bool) tea.Cmd {
 	return func() tea.Msg {
 		mgr, err := config.NewConfigManager()
@@ -318,27 +292,6 @@ func setLike(parent context.Context, tweetID string, liked bool) tea.Cmd {
 			_ = mgr.Save(cfg)
 		}
 		return likeMsg{id: tweetID, liked: liked, err: err}
-	}
-}
-
-func sendReply(parent context.Context, tweetID, text string) tea.Cmd {
-	return func() tea.Msg {
-		mgr, err := config.NewConfigManager()
-		if err != nil {
-			return replyResultMsg{err: err}
-		}
-		cfg, err := mgr.Load()
-		if err != nil {
-			return replyResultMsg{err: err}
-		}
-		ctx, cancel := context.WithTimeout(parent, 40*time.Second)
-		defer cancel()
-		client := api.NewWebClient(cfg)
-		id, err := client.PostTweet(ctx, text, tweetID, nil, nil)
-		if client.ApplyRefreshedQueryIDs(cfg) {
-			_ = mgr.Save(cfg)
-		}
-		return replyResultMsg{id: id, err: err}
 	}
 }
 
@@ -451,28 +404,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, m.showToast(msg.message)
 	case previewMsg:
-		m.previews[msg.postID] = previewState{
-			content: msg.content, nativePath: msg.nativePath, nativeData: msg.nativeData, imageID: msg.imageID,
-			columns: msg.columns, rows: msg.rows, err: msg.err,
-		}
-		m.evictDistantPreviews()
-		m.syncViewport()
-		m.ensureSelectedVisible()
-		return m, m.imageRepaint()
+		return m, m.applyPreview(msg)
 	case likeMsg:
-		delete(m.liking, msg.id)
-		var toast tea.Cmd
-		if msg.err != nil {
-			m.applyLike(msg.id, !msg.liked)
-			toast = m.showToast("couldn't update like")
-		} else if msg.liked {
-			toast = m.showToast("liked ♥")
-		} else {
-			toast = m.showToast("like removed")
-		}
-		m.syncViewport()
-		m.ensureSelectedVisible()
-		return m, toast
+		return m, m.applyLikeResult(msg)
 	}
 
 	key, ok := msg.(tea.KeyMsg)
@@ -559,47 +493,118 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, m.imageRepaint()
 		}
 	case "o":
-		if post, ok := m.currentPost(); ok {
-			return m, openURL(postURL(post))
-		}
+		return m, m.openSelected()
 	case "A":
-		if post, ok := m.currentPost(); ok && len(post.Media) > 0 {
-			m.altText = true
-			m.altTextScroll = 0
-			return m, m.imageRepaint()
-		}
+		return m, m.showAltText()
 	case "i":
-		if post, ok := m.currentPost(); ok && len(post.Media) > 0 {
-			if m.imageMode == imageModeOff {
-				return m, m.showToast("image previews are off (--images)")
-			}
-			m.zoom = true
-			if zoom := m.requestZoom(); zoom != nil {
-				return m, m.imageRepaint(tea.Batch(m.spinner.Tick, zoom))
-			}
-			return m, m.imageRepaint()
-		}
+		return m, m.zoomSelected()
 	case "l":
-		if post, ok := m.currentPost(); ok && !m.liking[post.ID] {
-			liked := !post.Liked
-			m.liking[post.ID] = true
-			m.applyLike(post.ID, liked)
-			m.syncViewport()
-			m.ensureSelectedVisible()
-			return m, setLike(m.requestContext(), post.ID, liked)
-		}
+		return m, m.toggleSelectedLike()
 	case "y":
-		if post, ok := m.currentPost(); ok {
-			if !m.clipboardOK {
-				return m, m.showToast("clipboard unavailable")
-			}
-			if err := clip.WriteText(postURL(post)); err != nil {
-				return m, m.showToast("clipboard unavailable; open the post with o")
-			}
-			return m, m.showToast("link copied")
-		}
+		return m, m.copySelectedLink()
 	}
 	return m, nil
+}
+
+// The handlers below back both the feed and a thread. Both lists render the
+// same post blocks and react to results the same way, so keeping one copy
+// stops the two modes from drifting apart.
+
+// settleLike clears the in-flight marker and rolls an optimistic like back if
+// the request failed.
+func (m *Model) settleLike(msg likeMsg) {
+	delete(m.liking, msg.id)
+	if msg.err != nil {
+		m.applyLike(msg.id, !msg.liked)
+	}
+}
+
+func (m *Model) applyLikeResult(msg likeMsg) tea.Cmd {
+	m.settleLike(msg)
+	toast := "like removed"
+	switch {
+	case msg.err != nil:
+		toast = "couldn't update like"
+	case msg.liked:
+		toast = "liked ♥"
+	}
+	cmd := m.showToast(toast)
+	m.syncViewport()
+	m.ensureSelectedVisible()
+	return cmd
+}
+
+func (m *Model) storePreview(msg previewMsg) {
+	m.previews[msg.postID] = previewState{
+		content: msg.content, nativePath: msg.nativePath, nativeData: msg.nativeData, imageID: msg.imageID,
+		columns: msg.columns, rows: msg.rows, err: msg.err,
+	}
+}
+
+func (m *Model) applyPreview(msg previewMsg) tea.Cmd {
+	m.storePreview(msg)
+	m.evictDistantPreviews()
+	m.syncViewport()
+	m.ensureSelectedVisible()
+	return m.imageRepaint()
+}
+
+func (m *Model) openSelected() tea.Cmd {
+	post, ok := m.currentPost()
+	if !ok {
+		return nil
+	}
+	return openURL(postURL(post))
+}
+
+func (m *Model) showAltText() tea.Cmd {
+	if post, ok := m.currentPost(); !ok || len(post.Media) == 0 {
+		return nil
+	}
+	m.altText = true
+	m.altTextScroll = 0
+	return m.imageRepaint()
+}
+
+func (m *Model) zoomSelected() tea.Cmd {
+	if post, ok := m.currentPost(); !ok || len(post.Media) == 0 {
+		return nil
+	}
+	if m.imageMode == imageModeOff {
+		return m.showToast("image previews are off (--images)")
+	}
+	m.zoom = true
+	if zoom := m.requestZoom(); zoom != nil {
+		return m.imageRepaint(tea.Batch(m.spinner.Tick, zoom))
+	}
+	return m.imageRepaint()
+}
+
+func (m *Model) toggleSelectedLike() tea.Cmd {
+	post, ok := m.currentPost()
+	if !ok || m.liking[post.ID] {
+		return nil
+	}
+	liked := !post.Liked
+	m.liking[post.ID] = true
+	m.applyLike(post.ID, liked)
+	m.syncViewport()
+	m.ensureSelectedVisible()
+	return setLike(m.requestContext(), post.ID, liked)
+}
+
+func (m *Model) copySelectedLink() tea.Cmd {
+	post, ok := m.currentPost()
+	if !ok {
+		return nil
+	}
+	if !m.clipboardOK {
+		return m.showToast("clipboard unavailable")
+	}
+	if err := clip.WriteText(postURL(post)); err != nil {
+		return m.showToast("clipboard unavailable; open the post with o")
+	}
+	return m.showToast("link copied")
 }
 
 func (m *Model) moveAltText(delta int) {
@@ -719,415 +724,6 @@ func (m Model) applyFeedPage(msg pageMsg) (tea.Model, tea.Cmd) {
 		return m, m.imageRepaint(m.requestPreviews(), toast)
 	}
 	return m, toast
-}
-
-func (m Model) beginReply(post api.TimelinePost) (tea.Model, tea.Cmd) {
-	m.replyReturn = m.mode
-	m.mode = modeReply
-	m.replyPost = post
-	m.replyErr = nil
-	m.replyNotice = ""
-	m.replyEditor.Reset()
-	m.resize()
-	return m, m.imageRepaint(m.replyEditor.Focus())
-}
-
-func (m Model) applyThreadPage(msg threadMsg, repaint bool) (tea.Model, tea.Cmd) {
-	if msg.rootID != m.threadRootID || msg.seq != m.threadSeq {
-		return m, nil
-	}
-	m.threadLoading = false
-	m.threadMore = false
-	if msg.err != nil {
-		m.threadErr = msg.err
-		return m, nil
-	}
-	m.threadErr = nil
-	selectedID := ""
-	if m.selected >= 0 && m.selected < len(m.threadPosts) {
-		selectedID = m.threadPosts[m.selected].ID
-	}
-	seen := map[string]bool{}
-	var merged []api.ConversationPost
-	if msg.more {
-		merged = append(merged, m.threadPosts...)
-		for _, post := range merged {
-			seen[post.ID] = true
-		}
-	}
-	for _, post := range m.resolveConversationPosts(msg.page) {
-		if !seen[post.ID] {
-			merged = append(merged, post)
-			seen[post.ID] = true
-		}
-	}
-	// X can omit the focal post from a refresh while still returning replies.
-	// The conversation must always keep its root: without it a refresh would
-	// silently turn the thread into a list of orphaned replies.
-	if !seen[m.threadRootID] {
-		if root, ok := m.threadRootPost(); ok {
-			merged = append([]api.ConversationPost{root}, merged...)
-		}
-	}
-	m.threadPosts = merged
-	m.normalizeThreadDepths()
-	m.threadCursor = msg.page.Cursor
-	m.selected = indexOfConversationPost(m.threadPosts, selectedID)
-	if m.selected < 0 {
-		m.selected = 0
-	}
-	if repaint {
-		m.syncViewport()
-		m.ensureSelectedVisible()
-		return m, m.imageRepaint(m.requestPreviews())
-	}
-	return m, nil
-}
-
-func (m Model) threadRootPost() (api.ConversationPost, bool) {
-	for _, post := range m.threadPosts {
-		if post.ID == m.threadRootID {
-			post.Depth = 0
-			return post, true
-		}
-	}
-	return api.ConversationPost{}, false
-}
-
-func (m Model) resolveConversationPosts(page *api.ConversationPage) []api.ConversationPost {
-	resolved := append([]api.ConversationPost(nil), page.Posts...)
-	depths := make(map[string]int, len(m.threadPosts)+len(resolved))
-	for _, post := range m.threadPosts {
-		depths[post.ID] = post.Depth
-	}
-	for _, post := range resolved {
-		depths[post.ID] = post.Depth
-	}
-	pending := append([]api.TimelinePost(nil), page.Unresolved...)
-	for len(pending) > 0 {
-		progress := false
-		next := pending[:0]
-		for _, post := range pending {
-			parentDepth, ok := depths[post.InReplyToID]
-			if !ok {
-				next = append(next, post)
-				continue
-			}
-			depth := parentDepth + 1
-			resolved = append(resolved, api.ConversationPost{TimelinePost: post, Depth: depth})
-			depths[post.ID] = depth
-			progress = true
-		}
-		if !progress {
-			break
-		}
-		pending = next
-	}
-	return resolved
-}
-
-func (m *Model) normalizeThreadDepths() {
-	byID := make(map[string]api.ConversationPost, len(m.threadPosts))
-	for _, post := range m.threadPosts {
-		byID[post.ID] = post
-	}
-	for i := range m.threadPosts {
-		if m.threadPosts[i].ID == m.threadRootID {
-			m.threadPosts[i].Depth = 0
-			continue
-		}
-		depth := 1
-		parent := m.threadPosts[i].InReplyToID
-		visited := map[string]bool{m.threadPosts[i].ID: true}
-		for parent != "" && parent != m.threadRootID && !visited[parent] {
-			visited[parent] = true
-			ancestor, ok := byID[parent]
-			if !ok {
-				break
-			}
-			parent = ancestor.InReplyToID
-			depth++
-		}
-		m.threadPosts[i].Depth = depth
-	}
-}
-
-func (m Model) updateThread(msg tea.Msg) (tea.Model, tea.Cmd) {
-	switch msg := msg.(type) {
-	case spinner.TickMsg:
-		if m.threadLoading || m.threadMore || m.zoomLoading() {
-			var cmd tea.Cmd
-			m.spinner, cmd = m.spinner.Update(msg)
-			return m, cmd
-		}
-	case pageMsg:
-		return m.applyFeedPage(msg)
-	case threadMsg:
-		return m.applyThreadPage(msg, true)
-	case likeMsg:
-		delete(m.liking, msg.id)
-		var toast tea.Cmd
-		if msg.err != nil {
-			m.applyLike(msg.id, !msg.liked)
-			toast = m.showToast("couldn't update like")
-		} else if msg.liked {
-			toast = m.showToast("liked ♥")
-		} else {
-			toast = m.showToast("like removed")
-		}
-		m.syncViewport()
-		m.ensureSelectedVisible()
-		return m, toast
-	case previewMsg:
-		m.previews[msg.postID] = previewState{
-			content: msg.content, nativePath: msg.nativePath, nativeData: msg.nativeData, imageID: msg.imageID,
-			columns: msg.columns, rows: msg.rows, err: msg.err,
-		}
-		m.evictDistantPreviews()
-		m.syncViewport()
-		m.ensureSelectedVisible()
-		return m, m.imageRepaint()
-	case actionMsg:
-		if msg.err != nil {
-			return m, m.showToast(msg.err.Error())
-		}
-		return m, m.showToast(msg.message)
-	}
-
-	key, ok := msg.(tea.KeyMsg)
-	if !ok {
-		return m, nil
-	}
-	switch key.String() {
-	case "q", "ctrl+c":
-		return m, tea.Quit
-	case "esc":
-		m.mode = modeFeed
-		m.selected = m.feedSelected
-		m.threadSeq++
-		m.threadRootID = ""
-		m.expanded = false
-		m.threadLoading = false
-		m.threadMore = false
-		// An expired session affects every request, not just this thread.
-		// Hand the error to the feed so its reconnect flow stays reachable.
-		if errors.Is(m.threadErr, api.ErrSessionExpired) {
-			m.err = m.threadErr
-		}
-		m.threadErr = nil
-		m.syncViewport()
-		m.ensureSelectedVisible()
-		return m, m.imageRepaint()
-	case "a":
-		if errors.Is(m.threadErr, api.ErrSessionExpired) {
-			m.action = Action{Kind: ActionAuthenticate}
-			return m, tea.Quit
-		}
-	case "ctrl+l":
-		m.syncViewport()
-		return m, func() tea.Msg { return tea.ClearScreen() }
-	case "?", "f1":
-		m.help = true
-		return m, m.imageRepaint()
-	case "j", "down":
-		m.moveThreadSelection(m.selected + 1)
-		return m, m.imageRepaint(m.requestPreviews(), m.maybeLoadMoreThread())
-	case "k", "up":
-		m.moveThreadSelection(m.selected - 1)
-		return m, m.imageRepaint(m.requestPreviews())
-	case "ctrl+d":
-		m.moveThreadSelection(m.selected + 5)
-		return m, m.imageRepaint(m.requestPreviews(), m.maybeLoadMoreThread())
-	case "ctrl+u":
-		m.moveThreadSelection(m.selected - 5)
-		return m, m.imageRepaint(m.requestPreviews())
-	case "g", "home":
-		m.moveThreadSelection(0)
-		return m, m.imageRepaint(m.requestPreviews())
-	case "G", "end":
-		m.moveThreadSelection(len(m.threadPosts) - 1)
-		return m, m.imageRepaint(m.requestPreviews(), m.maybeLoadMoreThread())
-	case "R", "ctrl+r":
-		m.threadLoading = true
-		m.threadMore = false
-		m.threadErr = nil
-		return m, m.imageRepaint(tea.Batch(m.spinner.Tick, m.requestThread("", false)))
-	case "r":
-		if post, ok := m.currentPost(); ok {
-			return m.beginReply(post)
-		}
-	case "enter", " ", "e":
-		m.expanded = !m.expanded
-		m.syncViewport()
-		m.ensureSelectedVisible()
-		return m, m.imageRepaint()
-	case "o":
-		if post, ok := m.currentPost(); ok {
-			return m, openURL(postURL(post))
-		}
-	case "A":
-		if post, ok := m.currentPost(); ok && len(post.Media) > 0 {
-			m.altText = true
-			m.altTextScroll = 0
-			return m, m.imageRepaint()
-		}
-	case "i":
-		if post, ok := m.currentPost(); ok && len(post.Media) > 0 {
-			if m.imageMode == imageModeOff {
-				return m, m.showToast("image previews are off (--images)")
-			}
-			m.zoom = true
-			return m, m.imageRepaint(tea.Batch(m.spinner.Tick, m.requestZoom()))
-		}
-	case "l":
-		if post, ok := m.currentPost(); ok && !m.liking[post.ID] {
-			liked := !post.Liked
-			m.liking[post.ID] = true
-			m.applyLike(post.ID, liked)
-			m.syncViewport()
-			return m, setLike(m.requestContext(), post.ID, liked)
-		}
-	case "y":
-		if post, ok := m.currentPost(); ok {
-			if !m.clipboardOK {
-				return m, m.showToast("clipboard unavailable")
-			}
-			if err := clip.WriteText(postURL(post)); err != nil {
-				return m, m.showToast("clipboard unavailable; open the post with o")
-			}
-			return m, m.showToast("link copied")
-		}
-	}
-	return m, nil
-}
-
-func (m *Model) moveThreadSelection(target int) {
-	if len(m.threadPosts) == 0 {
-		return
-	}
-	m.selected = max(0, min(len(m.threadPosts)-1, target))
-	m.expanded = false
-	m.toast = ""
-	m.syncViewport()
-	m.ensureSelectedVisible()
-}
-
-func (m *Model) maybeLoadMoreThread() tea.Cmd {
-	if len(m.threadPosts) > 0 && m.selected >= len(m.threadPosts)-5 && m.threadCursor != "" && !m.threadLoading && !m.threadMore {
-		m.threadMore = true
-		return tea.Batch(m.spinner.Tick, m.requestThread(m.threadCursor, true))
-	}
-	return nil
-}
-
-func (m Model) updateReply(msg tea.Msg) (tea.Model, tea.Cmd) {
-	switch msg := msg.(type) {
-	case threadMsg:
-		if m.replyReturn != modeThread {
-			return m, nil
-		}
-		return m.applyThreadPage(msg, false)
-	case pageMsg:
-		return m.applyFeedPage(msg)
-	case likeMsg:
-		delete(m.liking, msg.id)
-		if msg.err != nil {
-			m.applyLike(msg.id, !msg.liked)
-		}
-		return m, nil
-	case previewMsg:
-		m.previews[msg.postID] = previewState{
-			content: msg.content, nativePath: msg.nativePath, nativeData: msg.nativeData, imageID: msg.imageID,
-			columns: msg.columns, rows: msg.rows, err: msg.err,
-		}
-		return m, nil
-	case spinner.TickMsg:
-		if m.replyPosting {
-			var cmd tea.Cmd
-			m.spinner, cmd = m.spinner.Update(msg)
-			return m, cmd
-		}
-	case replyResultMsg:
-		m.replyPosting = false
-		if msg.err != nil {
-			m.replyErr = msg.err
-			m.replyNotice = ""
-			return m, m.replyEditor.Focus()
-		}
-		m.mode = m.replyReturn
-		m.replyEditor.Blur()
-		m.replyEditor.Reset()
-		toast := m.showToast("reply sent ♥")
-		m.syncViewport()
-		m.ensureSelectedVisible()
-		if m.mode == modeThread {
-			m.threadLoading = true
-			m.threadMore = false
-			return m, m.imageRepaint(tea.Batch(toast, m.spinner.Tick, m.requestThread("", false)))
-		}
-		return m, m.imageRepaint(toast)
-	case replyBrowserMsg:
-		if msg.err != nil {
-			m.replyErr = fmt.Errorf("couldn't open X: %w", msg.err)
-			m.replyNotice = ""
-			return m, nil
-		}
-		m.replyErr = nil
-		m.replyNotice = "opened reply in X"
-		return m, nil
-	}
-	key, ok := msg.(tea.KeyMsg)
-	if ok {
-		if m.replyPosting {
-			return m, nil
-		}
-		switch key.String() {
-		case "b":
-			if canOpenReplyInX(m.replyErr) {
-				return m, openReplyInX(m.replyPost.ID, m.replyEditor.Value())
-			}
-		case "esc", "ctrl+c":
-			m.mode = m.replyReturn
-			m.replyEditor.Blur()
-			m.replyErr = nil
-			m.replyNotice = ""
-			m.syncViewport()
-			return m, m.imageRepaint(m.requestPreviews())
-		case "enter":
-			if strings.TrimSpace(m.replyEditor.Value()) == "" {
-				m.replyErr = fmt.Errorf("write a reply first")
-				return m, nil
-			}
-			m.replyPosting = true
-			m.replyErr = nil
-			m.replyNotice = ""
-			m.replyEditor.Blur()
-			return m, tea.Batch(m.spinner.Tick, sendReply(m.requestContext(), m.replyPost.ID, m.replyEditor.Value()))
-		case "alt+enter", "ctrl+j":
-			m.replyEditor.InsertString("\n")
-			return m, nil
-		}
-	}
-	var cmd tea.Cmd
-	m.replyEditor, cmd = m.replyEditor.Update(msg)
-	return m, cmd
-}
-
-func canOpenReplyInX(err error) bool {
-	var automated *api.AutomationBlockedError
-	if errors.As(err, &automated) {
-		return true
-	}
-	var restricted *api.PostingRestrictedError
-	if errors.As(err, &restricted) {
-		return true
-	}
-	var recent *api.RecentlyPostedError
-	if errors.As(err, &recent) {
-		return true
-	}
-	var ambiguous *api.AmbiguousPostError
-	return errors.As(err, &ambiguous)
 }
 
 func (m Model) imageRepaint(cmds ...tea.Cmd) tea.Cmd {
@@ -1256,18 +852,6 @@ func (m *Model) applyLike(id string, liked bool) {
 	for i := range m.threadPosts {
 		apply(&m.threadPosts[i].TimelinePost)
 	}
-}
-
-func indexOfConversationPost(posts []api.ConversationPost, id string) int {
-	if id == "" {
-		return 0
-	}
-	for i := range posts {
-		if posts[i].ID == id {
-			return i
-		}
-	}
-	return -1
 }
 
 func indexOfPost(posts []api.TimelinePost, id string) int {

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -58,6 +58,10 @@ const (
 )
 
 type Model struct {
+	// ctx bounds every request this model starts. It carries the process's
+	// interrupt signal, so a SIGINT or SIGTERM cancels in-flight fetches
+	// instead of leaving them to run out their own timeouts.
+	ctx           context.Context
 	width, height int
 	imageMode     imageMode
 	imageNote     string
@@ -195,18 +199,29 @@ func NewWithImageMode(requested string) Model {
 	editor.SetHeight(6)
 	mode, note := resolveImageMode(requested)
 	return Model{
+		ctx:   context.Background(),
 		width: 80, height: 24, imageMode: mode, imageNote: note, loading: true,
 		liking: map[string]bool{}, previews: map[string]previewState{},
 		spinner: s, viewport: vp, replyEditor: editor,
 	}
 }
 
-func (m Model) Init() tea.Cmd {
-	return tea.Batch(m.spinner.Tick, fetchPageSeq(m.following, "", false, m.feedSeq), clockTick())
+// requestContext is the parent for every fetch. Models built directly in
+// tests may leave ctx nil.
+func (m Model) requestContext() context.Context {
+	if m.ctx == nil {
+		return context.Background()
+	}
+	return m.ctx
 }
 
-func Run(images string, following bool) (Action, error) {
+func (m Model) Init() tea.Cmd {
+	return tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.following, "", false, m.feedSeq), clockTick())
+}
+
+func Run(ctx context.Context, images string, following bool) (Action, error) {
 	m := NewWithImageMode(images)
+	m.ctx = ctx
 	m.following = following
 	// Auto-detected native mode is a claim, not a capability: multiplexers
 	// like cmux inherit ghostty's TERM without reliably rendering graphics.
@@ -220,7 +235,12 @@ func Run(images string, following bool) (Action, error) {
 		}
 	}
 	m.clipboardOK = clip.Init() == nil
-	result, err := tea.NewProgram(m, tea.WithAltScreen()).Run()
+	result, err := tea.NewProgram(m, tea.WithAltScreen(), tea.WithContext(ctx)).Run()
+	if errors.Is(err, tea.ErrProgramKilled) {
+		// An interrupt reached the program through ctx. That is an ordinary
+		// exit, not a failure worth reporting.
+		return Action{}, nil
+	}
 	if err != nil {
 		return Action{}, err
 	}
@@ -229,7 +249,7 @@ func Run(images string, following bool) (Action, error) {
 	return final.action, nil
 }
 
-func fetchPageSeq(following bool, cursor string, more bool, seq int) tea.Cmd {
+func fetchPageSeq(parent context.Context, following bool, cursor string, more bool, seq int) tea.Cmd {
 	return func() tea.Msg {
 		mgr, err := config.NewConfigManager()
 		if err != nil {
@@ -239,7 +259,7 @@ func fetchPageSeq(following bool, cursor string, more bool, seq int) tea.Cmd {
 		if err != nil {
 			return pageMsg{err: err, more: more, seq: seq}
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+		ctx, cancel := context.WithTimeout(parent, 40*time.Second)
 		defer cancel()
 		client := api.NewWebClient(cfg)
 		fetch := client.FetchHomeTimeline
@@ -254,7 +274,7 @@ func fetchPageSeq(following bool, cursor string, more bool, seq int) tea.Cmd {
 	}
 }
 
-func fetchThread(tweetID, cursor string, more bool, seq int) tea.Cmd {
+func fetchThread(parent context.Context, tweetID, cursor string, more bool, seq int) tea.Cmd {
 	return func() tea.Msg {
 		mgr, err := config.NewConfigManager()
 		if err != nil {
@@ -264,7 +284,7 @@ func fetchThread(tweetID, cursor string, more bool, seq int) tea.Cmd {
 		if err != nil {
 			return threadMsg{rootID: tweetID, seq: seq, err: err, more: more}
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+		ctx, cancel := context.WithTimeout(parent, 40*time.Second)
 		defer cancel()
 		client := api.NewWebClient(cfg)
 		page, err := client.FetchTweetDetail(ctx, tweetID, cursor, 40)
@@ -277,10 +297,10 @@ func fetchThread(tweetID, cursor string, more bool, seq int) tea.Cmd {
 
 func (m *Model) requestThread(cursor string, more bool) tea.Cmd {
 	m.threadSeq++
-	return fetchThread(m.threadRootID, cursor, more, m.threadSeq)
+	return fetchThread(m.requestContext(), m.threadRootID, cursor, more, m.threadSeq)
 }
 
-func setLike(tweetID string, liked bool) tea.Cmd {
+func setLike(parent context.Context, tweetID string, liked bool) tea.Cmd {
 	return func() tea.Msg {
 		mgr, err := config.NewConfigManager()
 		if err != nil {
@@ -290,7 +310,7 @@ func setLike(tweetID string, liked bool) tea.Cmd {
 		if err != nil {
 			return likeMsg{id: tweetID, liked: liked, err: err}
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		ctx, cancel := context.WithTimeout(parent, 30*time.Second)
 		defer cancel()
 		client := api.NewWebClient(cfg)
 		err = client.SetTweetLiked(ctx, tweetID, liked)
@@ -301,7 +321,7 @@ func setLike(tweetID string, liked bool) tea.Cmd {
 	}
 }
 
-func sendReply(tweetID, text string) tea.Cmd {
+func sendReply(parent context.Context, tweetID, text string) tea.Cmd {
 	return func() tea.Msg {
 		mgr, err := config.NewConfigManager()
 		if err != nil {
@@ -311,7 +331,7 @@ func sendReply(tweetID, text string) tea.Cmd {
 		if err != nil {
 			return replyResultMsg{err: err}
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+		ctx, cancel := context.WithTimeout(parent, 40*time.Second)
 		defer cancel()
 		client := api.NewWebClient(cfg)
 		id, err := client.PostTweet(ctx, text, tweetID, nil, nil)
@@ -503,7 +523,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.refreshing = true
 		}
 		m.err = nil
-		return m, m.imageRepaint(tea.Batch(m.spinner.Tick, fetchPageSeq(m.following, "", false, m.feedSeq)))
+		return m, m.imageRepaint(tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.following, "", false, m.feedSeq)))
 	case "r":
 		if post, ok := m.currentPost(); ok {
 			return m.beginReply(post)
@@ -566,7 +586,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.applyLike(post.ID, liked)
 			m.syncViewport()
 			m.ensureSelectedVisible()
-			return m, setLike(post.ID, liked)
+			return m, setLike(m.requestContext(), post.ID, liked)
 		}
 	case "y":
 		if post, ok := m.currentPost(); ok {
@@ -614,13 +634,13 @@ func (m Model) switchFeed() (tea.Model, tea.Cmd) {
 	m.err = nil
 	m.viewport.YOffset = 0
 	m.syncViewport()
-	return m, m.imageRepaint(tea.Batch(m.spinner.Tick, fetchPageSeq(m.following, "", false, m.feedSeq)))
+	return m, m.imageRepaint(tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.following, "", false, m.feedSeq)))
 }
 
 func (m *Model) maybeLoadMore() tea.Cmd {
 	if len(m.posts) > 0 && m.selected >= len(m.posts)-5 && m.cursor != "" && !m.loadingMore {
 		m.loadingMore = true
-		return tea.Batch(m.spinner.Tick, fetchPageSeq(m.following, m.cursor, true, m.feedSeq))
+		return tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.following, m.cursor, true, m.feedSeq))
 	}
 	return nil
 }
@@ -965,7 +985,7 @@ func (m Model) updateThread(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.liking[post.ID] = true
 			m.applyLike(post.ID, liked)
 			m.syncViewport()
-			return m, setLike(post.ID, liked)
+			return m, setLike(m.requestContext(), post.ID, liked)
 		}
 	case "y":
 		if post, ok := m.currentPost(); ok {
@@ -1082,7 +1102,7 @@ func (m Model) updateReply(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.replyErr = nil
 			m.replyNotice = ""
 			m.replyEditor.Blur()
-			return m, tea.Batch(m.spinner.Tick, sendReply(m.replyPost.ID, m.replyEditor.Value()))
+			return m, tea.Batch(m.spinner.Tick, sendReply(m.requestContext(), m.replyPost.ID, m.replyEditor.Value()))
 		case "alt+enter", "ctrl+j":
 			m.replyEditor.InsertString("\n")
 			return m, nil

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -236,17 +236,20 @@ func Run(ctx context.Context, images string, following bool) (Action, error) {
 	}
 	m.clipboardOK = clip.Init() == nil
 	result, err := tea.NewProgram(m, tea.WithAltScreen(), tea.WithContext(ctx)).Run()
+	// Native previews leave PNGs in the temp directory, so they get cleaned up
+	// on every exit path, including an interrupt.
+	if final, ok := result.(Model); ok {
+		final.cleanupPreviews()
+		if err == nil {
+			return final.action, nil
+		}
+	}
 	if errors.Is(err, tea.ErrProgramKilled) {
 		// An interrupt reached the program through ctx. That is an ordinary
 		// exit, not a failure worth reporting.
 		return Action{}, nil
 	}
-	if err != nil {
-		return Action{}, err
-	}
-	final := result.(Model)
-	final.cleanupPreviews()
-	return final.action, nil
+	return Action{}, err
 }
 
 func fetchPageSeq(parent context.Context, following bool, cursor string, more bool, seq int) tea.Cmd {

--- a/internal/timeline/model_test.go
+++ b/internal/timeline/model_test.go
@@ -1,6 +1,7 @@
 package timeline
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -651,5 +652,23 @@ func TestViewIsFixedHeightAndDoesNotDuplicateRows(t *testing.T) {
 		if lines := strings.Count(view, "\n") + 1; lines != size.height {
 			t.Fatalf("%dx%d: view has %d lines", size.width, size.height, lines)
 		}
+	}
+}
+
+func TestRequestContextCarriesCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	m := New()
+	m.ctx = ctx
+	if m.requestContext().Err() != nil {
+		t.Fatal("live context reported as cancelled")
+	}
+	cancel()
+	if !errors.Is(m.requestContext().Err(), context.Canceled) {
+		t.Fatal("cancelling the parent did not reach the model's request context")
+	}
+
+	// A zero-value Model (built directly by a test) must still be usable.
+	if (Model{}).requestContext() == nil {
+		t.Fatal("zero-value model has no request context")
 	}
 }

--- a/internal/timeline/preview.go
+++ b/internal/timeline/preview.go
@@ -150,7 +150,7 @@ func (m *Model) requestPreviews() tea.Cmd {
 		if i == m.selected {
 			selectedChanged = true
 		}
-		cmds = append(cmds, fetchPreview(post.ID, post.Media[0], width, rows, m.imageMode))
+		cmds = append(cmds, fetchPreview(m.requestContext(), post.ID, post.Media[0], width, rows, m.imageMode))
 	}
 	if selectedChanged {
 		m.syncViewport()
@@ -182,7 +182,7 @@ func (m *Model) requestZoom() tea.Cmd {
 		width = min(width, len(kittyDiacritics))
 		rows = min(rows, len(kittyDiacritics))
 	}
-	return fetchPreview(key, post.Media[0], width, rows, m.imageMode)
+	return fetchPreview(m.requestContext(), key, post.Media[0], width, rows, m.imageMode)
 }
 
 func (m Model) zoomLoading() bool {
@@ -248,7 +248,11 @@ func abs(value int) int {
 	return value
 }
 
-func fetchPreview(postID string, media api.TimelineMedia, width, maxRows int, mode imageMode) tea.Cmd {
+// fetchPreview hangs its timeout off the model's context so a download in
+// flight when the program stops cannot write a native PNG after
+// cleanupPreviews has already run, which would strand it in the temp dir for
+// the rest of a compose handoff.
+func fetchPreview(parent context.Context, postID string, media api.TimelineMedia, width, maxRows int, mode imageMode) tea.Cmd {
 	return func() tea.Msg {
 		parsed, err := url.Parse(previewMediaURL(media.URL, mode))
 		if err != nil {
@@ -257,7 +261,7 @@ func fetchPreview(postID string, media api.TimelineMedia, width, maxRows int, mo
 		if err := validateMediaURL(parsed); err != nil {
 			return previewMsg{postID: postID, err: err}
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		ctx, cancel := context.WithTimeout(parent, 20*time.Second)
 		defer cancel()
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
 		if err != nil {

--- a/internal/timeline/reply.go
+++ b/internal/timeline/reply.go
@@ -1,0 +1,155 @@
+package timeline
+
+// Reply mode: the small composer that opens over the feed or a thread with r.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/melqtx/xeet/pkg/api"
+	"github.com/melqtx/xeet/pkg/config"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func sendReply(parent context.Context, tweetID, text string) tea.Cmd {
+	return func() tea.Msg {
+		mgr, err := config.NewConfigManager()
+		if err != nil {
+			return replyResultMsg{err: err}
+		}
+		cfg, err := mgr.Load()
+		if err != nil {
+			return replyResultMsg{err: err}
+		}
+		ctx, cancel := context.WithTimeout(parent, 40*time.Second)
+		defer cancel()
+		client := api.NewWebClient(cfg)
+		id, err := client.PostTweet(ctx, text, tweetID, nil, nil)
+		if client.ApplyRefreshedQueryIDs(cfg) {
+			_ = mgr.Save(cfg)
+		}
+		return replyResultMsg{id: id, err: err}
+	}
+}
+
+func (m Model) beginReply(post api.TimelinePost) (tea.Model, tea.Cmd) {
+	m.replyReturn = m.mode
+	m.mode = modeReply
+	m.replyPost = post
+	m.replyErr = nil
+	m.replyNotice = ""
+	m.replyEditor.Reset()
+	m.resize()
+	return m, m.imageRepaint(m.replyEditor.Focus())
+}
+
+func (m Model) updateReply(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case threadMsg:
+		if m.replyReturn != modeThread {
+			return m, nil
+		}
+		return m.applyThreadPage(msg, false)
+	case pageMsg:
+		return m.applyFeedPage(msg)
+	case likeMsg:
+		// The composer covers the feed, so a like settles silently here: no
+		// toast, and no re-render of a list nobody can see.
+		m.settleLike(msg)
+		return m, nil
+	case previewMsg:
+		m.storePreview(msg)
+		return m, nil
+	case spinner.TickMsg:
+		if m.replyPosting {
+			var cmd tea.Cmd
+			m.spinner, cmd = m.spinner.Update(msg)
+			return m, cmd
+		}
+	case replyResultMsg:
+		m.replyPosting = false
+		if msg.err != nil {
+			m.replyErr = msg.err
+			m.replyNotice = ""
+			return m, m.replyEditor.Focus()
+		}
+		m.mode = m.replyReturn
+		m.replyEditor.Blur()
+		m.replyEditor.Reset()
+		toast := m.showToast("reply sent ♥")
+		m.syncViewport()
+		m.ensureSelectedVisible()
+		if m.mode == modeThread {
+			m.threadLoading = true
+			m.threadMore = false
+			return m, m.imageRepaint(tea.Batch(toast, m.spinner.Tick, m.requestThread("", false)))
+		}
+		return m, m.imageRepaint(toast)
+	case replyBrowserMsg:
+		if msg.err != nil {
+			m.replyErr = fmt.Errorf("couldn't open X: %w", msg.err)
+			m.replyNotice = ""
+			return m, nil
+		}
+		m.replyErr = nil
+		m.replyNotice = "opened reply in X"
+		return m, nil
+	}
+	key, ok := msg.(tea.KeyMsg)
+	if ok {
+		if m.replyPosting {
+			return m, nil
+		}
+		switch key.String() {
+		case "b":
+			if canOpenReplyInX(m.replyErr) {
+				return m, openReplyInX(m.replyPost.ID, m.replyEditor.Value())
+			}
+		case "esc", "ctrl+c":
+			m.mode = m.replyReturn
+			m.replyEditor.Blur()
+			m.replyErr = nil
+			m.replyNotice = ""
+			m.syncViewport()
+			return m, m.imageRepaint(m.requestPreviews())
+		case "enter":
+			if strings.TrimSpace(m.replyEditor.Value()) == "" {
+				m.replyErr = fmt.Errorf("write a reply first")
+				return m, nil
+			}
+			m.replyPosting = true
+			m.replyErr = nil
+			m.replyNotice = ""
+			m.replyEditor.Blur()
+			return m, tea.Batch(m.spinner.Tick, sendReply(m.requestContext(), m.replyPost.ID, m.replyEditor.Value()))
+		case "alt+enter", "ctrl+j":
+			m.replyEditor.InsertString("\n")
+			return m, nil
+		}
+	}
+	var cmd tea.Cmd
+	m.replyEditor, cmd = m.replyEditor.Update(msg)
+	return m, cmd
+}
+
+func canOpenReplyInX(err error) bool {
+	var automated *api.AutomationBlockedError
+	if errors.As(err, &automated) {
+		return true
+	}
+	var restricted *api.PostingRestrictedError
+	if errors.As(err, &restricted) {
+		return true
+	}
+	var recent *api.RecentlyPostedError
+	if errors.As(err, &recent) {
+		return true
+	}
+	var ambiguous *api.AmbiguousPostError
+	return errors.As(err, &ambiguous)
+}

--- a/internal/timeline/thread.go
+++ b/internal/timeline/thread.go
@@ -1,0 +1,299 @@
+package timeline
+
+// Thread mode: the conversation opened with enter from the feed. It reuses the
+// feed's rendering and post actions; what lives here is the reply tree itself
+// -- fetching a TweetDetail page, resolving each reply's depth, and moving
+// through the result.
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/melqtx/xeet/pkg/api"
+	"github.com/melqtx/xeet/pkg/config"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func fetchThread(parent context.Context, tweetID, cursor string, more bool, seq int) tea.Cmd {
+	return func() tea.Msg {
+		mgr, err := config.NewConfigManager()
+		if err != nil {
+			return threadMsg{rootID: tweetID, seq: seq, err: err, more: more}
+		}
+		cfg, err := mgr.Load()
+		if err != nil {
+			return threadMsg{rootID: tweetID, seq: seq, err: err, more: more}
+		}
+		ctx, cancel := context.WithTimeout(parent, 40*time.Second)
+		defer cancel()
+		client := api.NewWebClient(cfg)
+		page, err := client.FetchTweetDetail(ctx, tweetID, cursor, 40)
+		if client.ApplyRefreshedQueryIDs(cfg) {
+			_ = mgr.Save(cfg)
+		}
+		return threadMsg{rootID: tweetID, seq: seq, page: page, err: err, more: more}
+	}
+}
+
+func (m *Model) requestThread(cursor string, more bool) tea.Cmd {
+	m.threadSeq++
+	return fetchThread(m.requestContext(), m.threadRootID, cursor, more, m.threadSeq)
+}
+
+func (m Model) applyThreadPage(msg threadMsg, repaint bool) (tea.Model, tea.Cmd) {
+	if msg.rootID != m.threadRootID || msg.seq != m.threadSeq {
+		return m, nil
+	}
+	m.threadLoading = false
+	m.threadMore = false
+	if msg.err != nil {
+		m.threadErr = msg.err
+		return m, nil
+	}
+	m.threadErr = nil
+	selectedID := ""
+	if m.selected >= 0 && m.selected < len(m.threadPosts) {
+		selectedID = m.threadPosts[m.selected].ID
+	}
+	seen := map[string]bool{}
+	var merged []api.ConversationPost
+	if msg.more {
+		merged = append(merged, m.threadPosts...)
+		for _, post := range merged {
+			seen[post.ID] = true
+		}
+	}
+	for _, post := range m.resolveConversationPosts(msg.page) {
+		if !seen[post.ID] {
+			merged = append(merged, post)
+			seen[post.ID] = true
+		}
+	}
+	// X can omit the focal post from a refresh while still returning replies.
+	// The conversation must always keep its root: without it a refresh would
+	// silently turn the thread into a list of orphaned replies.
+	if !seen[m.threadRootID] {
+		if root, ok := m.threadRootPost(); ok {
+			merged = append([]api.ConversationPost{root}, merged...)
+		}
+	}
+	m.threadPosts = merged
+	m.normalizeThreadDepths()
+	m.threadCursor = msg.page.Cursor
+	m.selected = indexOfConversationPost(m.threadPosts, selectedID)
+	if m.selected < 0 {
+		m.selected = 0
+	}
+	if repaint {
+		m.syncViewport()
+		m.ensureSelectedVisible()
+		return m, m.imageRepaint(m.requestPreviews())
+	}
+	return m, nil
+}
+
+func (m Model) threadRootPost() (api.ConversationPost, bool) {
+	for _, post := range m.threadPosts {
+		if post.ID == m.threadRootID {
+			post.Depth = 0
+			return post, true
+		}
+	}
+	return api.ConversationPost{}, false
+}
+
+func (m Model) resolveConversationPosts(page *api.ConversationPage) []api.ConversationPost {
+	resolved := append([]api.ConversationPost(nil), page.Posts...)
+	depths := make(map[string]int, len(m.threadPosts)+len(resolved))
+	for _, post := range m.threadPosts {
+		depths[post.ID] = post.Depth
+	}
+	for _, post := range resolved {
+		depths[post.ID] = post.Depth
+	}
+	pending := append([]api.TimelinePost(nil), page.Unresolved...)
+	for len(pending) > 0 {
+		progress := false
+		next := pending[:0]
+		for _, post := range pending {
+			parentDepth, ok := depths[post.InReplyToID]
+			if !ok {
+				next = append(next, post)
+				continue
+			}
+			depth := parentDepth + 1
+			resolved = append(resolved, api.ConversationPost{TimelinePost: post, Depth: depth})
+			depths[post.ID] = depth
+			progress = true
+		}
+		if !progress {
+			break
+		}
+		pending = next
+	}
+	return resolved
+}
+
+func (m *Model) normalizeThreadDepths() {
+	byID := make(map[string]api.ConversationPost, len(m.threadPosts))
+	for _, post := range m.threadPosts {
+		byID[post.ID] = post
+	}
+	for i := range m.threadPosts {
+		if m.threadPosts[i].ID == m.threadRootID {
+			m.threadPosts[i].Depth = 0
+			continue
+		}
+		depth := 1
+		parent := m.threadPosts[i].InReplyToID
+		visited := map[string]bool{m.threadPosts[i].ID: true}
+		for parent != "" && parent != m.threadRootID && !visited[parent] {
+			visited[parent] = true
+			ancestor, ok := byID[parent]
+			if !ok {
+				break
+			}
+			parent = ancestor.InReplyToID
+			depth++
+		}
+		m.threadPosts[i].Depth = depth
+	}
+}
+
+func (m Model) updateThread(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case spinner.TickMsg:
+		if m.threadLoading || m.threadMore || m.zoomLoading() {
+			var cmd tea.Cmd
+			m.spinner, cmd = m.spinner.Update(msg)
+			return m, cmd
+		}
+	case pageMsg:
+		return m.applyFeedPage(msg)
+	case threadMsg:
+		return m.applyThreadPage(msg, true)
+	case likeMsg:
+		return m, m.applyLikeResult(msg)
+	case previewMsg:
+		return m, m.applyPreview(msg)
+	case actionMsg:
+		if msg.err != nil {
+			return m, m.showToast(msg.err.Error())
+		}
+		return m, m.showToast(msg.message)
+	}
+
+	key, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+	switch key.String() {
+	case "q", "ctrl+c":
+		return m, tea.Quit
+	case "esc":
+		m.mode = modeFeed
+		m.selected = m.feedSelected
+		m.threadSeq++
+		m.threadRootID = ""
+		m.expanded = false
+		m.threadLoading = false
+		m.threadMore = false
+		// An expired session affects every request, not just this thread.
+		// Hand the error to the feed so its reconnect flow stays reachable.
+		if errors.Is(m.threadErr, api.ErrSessionExpired) {
+			m.err = m.threadErr
+		}
+		m.threadErr = nil
+		m.syncViewport()
+		m.ensureSelectedVisible()
+		return m, m.imageRepaint()
+	case "a":
+		if errors.Is(m.threadErr, api.ErrSessionExpired) {
+			m.action = Action{Kind: ActionAuthenticate}
+			return m, tea.Quit
+		}
+	case "ctrl+l":
+		m.syncViewport()
+		return m, func() tea.Msg { return tea.ClearScreen() }
+	case "?", "f1":
+		m.help = true
+		return m, m.imageRepaint()
+	case "j", "down":
+		m.moveThreadSelection(m.selected + 1)
+		return m, m.imageRepaint(m.requestPreviews(), m.maybeLoadMoreThread())
+	case "k", "up":
+		m.moveThreadSelection(m.selected - 1)
+		return m, m.imageRepaint(m.requestPreviews())
+	case "ctrl+d":
+		m.moveThreadSelection(m.selected + 5)
+		return m, m.imageRepaint(m.requestPreviews(), m.maybeLoadMoreThread())
+	case "ctrl+u":
+		m.moveThreadSelection(m.selected - 5)
+		return m, m.imageRepaint(m.requestPreviews())
+	case "g", "home":
+		m.moveThreadSelection(0)
+		return m, m.imageRepaint(m.requestPreviews())
+	case "G", "end":
+		m.moveThreadSelection(len(m.threadPosts) - 1)
+		return m, m.imageRepaint(m.requestPreviews(), m.maybeLoadMoreThread())
+	case "R", "ctrl+r":
+		m.threadLoading = true
+		m.threadMore = false
+		m.threadErr = nil
+		return m, m.imageRepaint(tea.Batch(m.spinner.Tick, m.requestThread("", false)))
+	case "r":
+		if post, ok := m.currentPost(); ok {
+			return m.beginReply(post)
+		}
+	case "enter", " ", "e":
+		m.expanded = !m.expanded
+		m.syncViewport()
+		m.ensureSelectedVisible()
+		return m, m.imageRepaint()
+	case "o":
+		return m, m.openSelected()
+	case "A":
+		return m, m.showAltText()
+	case "i":
+		return m, m.zoomSelected()
+	case "l":
+		return m, m.toggleSelectedLike()
+	case "y":
+		return m, m.copySelectedLink()
+	}
+	return m, nil
+}
+
+func (m *Model) moveThreadSelection(target int) {
+	if len(m.threadPosts) == 0 {
+		return
+	}
+	m.selected = max(0, min(len(m.threadPosts)-1, target))
+	m.expanded = false
+	m.toast = ""
+	m.syncViewport()
+	m.ensureSelectedVisible()
+}
+
+func (m *Model) maybeLoadMoreThread() tea.Cmd {
+	if len(m.threadPosts) > 0 && m.selected >= len(m.threadPosts)-5 && m.threadCursor != "" && !m.threadLoading && !m.threadMore {
+		m.threadMore = true
+		return tea.Batch(m.spinner.Tick, m.requestThread(m.threadCursor, true))
+	}
+	return nil
+}
+
+func indexOfConversationPost(posts []api.ConversationPost, id string) int {
+	if id == "" {
+		return 0
+	}
+	for i := range posts {
+		if posts[i].ID == id {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -61,6 +62,9 @@ func (c systemClipboard) ReadText() string {
 }
 
 type Model struct {
+	// ctx is the parent of the posting request, so an interrupt cancels an
+	// upload in flight rather than detaching it from the program.
+	ctx            context.Context
 	width, height  int
 	screen         screen
 	dialog         dialog
@@ -111,17 +115,30 @@ func newWithDraftStore(clip clipboardReader, drafts draftStore) Model {
 	s := spinner.New()
 	s.Spinner = spinner.Dot
 
-	return Model{width: 72, height: 22, editor: editor, pathInput: path, spinner: s, clipboard: clip, drafts: drafts}
+	return Model{
+		ctx: context.Background(), width: 72, height: 22,
+		editor: editor, pathInput: path, spinner: s, clipboard: clip, drafts: drafts,
+	}
 }
 
 func (m Model) Init() tea.Cmd { return textarea.Blink }
 
-func Run() error {
+// requestContext is the parent for the posting request. Models built directly
+// in tests may leave ctx nil.
+func (m Model) requestContext() context.Context {
+	if m.ctx == nil {
+		return context.Background()
+	}
+	return m.ctx
+}
+
+func Run(ctx context.Context) error {
 	store, err := newFileDraftStore()
 	if err != nil {
 		return fmt.Errorf("initialize draft recovery: %w", err)
 	}
 	m := newWithDraftStore(systemClipboard{initErr: clip.Init()}, store)
+	m.ctx = ctx
 	text, attachments, restoreErr := store.Load()
 	if text != "" || len(attachments) > 0 {
 		m.editor.SetValue(text)
@@ -132,7 +149,12 @@ func Run() error {
 	if restoreErr != nil {
 		m.toast = restoreErr.Error()
 	}
-	_, err = tea.NewProgram(m, tea.WithAltScreen()).Run()
+	_, err = tea.NewProgram(m, tea.WithAltScreen(), tea.WithContext(ctx)).Run()
+	if errors.Is(err, tea.ErrProgramKilled) {
+		// An interrupt reached the program through ctx; the draft is already
+		// autosaved, so this is an ordinary exit.
+		return nil
+	}
 	return err
 }
 
@@ -176,10 +198,10 @@ func loadAttachment(path string) tea.Cmd {
 	return func() tea.Msg { a, err := media.FromPath(path); return attachmentMsg{attachment: a, err: err} }
 }
 
-func beginPost(text string, attachments []media.Attachment) tea.Cmd {
+func beginPost(parent context.Context, text string, attachments []media.Attachment) tea.Cmd {
 	return func() tea.Msg {
 		events := make(chan tea.Msg, 8)
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(parent)
 		go func() {
 			defer cancel()
 			mgr, err := config.NewConfigManager()

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -149,7 +149,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.cancelling = false
 			m.editor.Blur()
 			attachments := append([]media.Attachment(nil), m.attachments...)
-			return m, beginPost(m.editor.Value(), attachments)
+			return m, beginPost(m.requestContext(), m.editor.Value(), attachments)
 		case "alt+enter", "ctrl+j":
 			if m.focus == focusEditor {
 				m.editor.InsertString("\n")

--- a/pkg/api/errors_test.go
+++ b/pkg/api/errors_test.go
@@ -17,11 +17,11 @@ import (
 
 func newTestClient(handler func(*http.Request) (*http.Response, error)) *WebClient {
 	return &WebClient{
-		authToken:  "auth",
-		ct0:        "csrf",
-		queryID:    "qid",
-		retryDelay: time.Millisecond,
-		httpClient: &http.Client{Transport: roundTripFunc(handler)},
+		authToken:     "auth",
+		ct0:           "csrf",
+		operationQIDs: map[string]string{"CreateTweet": "qid"},
+		retryDelay:    time.Millisecond,
+		httpClient:    &http.Client{Transport: roundTripFunc(handler)},
 	}
 }
 
@@ -348,7 +348,7 @@ func TestVerifySessionExpired(t *testing.T) {
 		attempts++
 		return response(http.StatusUnauthorized, `{}`), nil
 	})
-	_, err := client.Verify(context.Background())
+	err := client.Verify(context.Background())
 	if !errors.Is(err, ErrSessionExpired) {
 		t.Fatalf("got %v, want ErrSessionExpired", err)
 	}
@@ -366,12 +366,11 @@ func TestVerifyRetriesTransientFailure(t *testing.T) {
 		}
 		return response(http.StatusOK, `{"data":{"home":{"instructions":[]}}}`), nil
 	})
-	handle, err := client.Verify(context.Background())
-	if err != nil {
+	if err := client.Verify(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	if handle != "" || attempts != 2 {
-		t.Fatalf("handle=%q attempts=%d", handle, attempts)
+	if attempts != 2 {
+		t.Fatalf("attempts=%d, want 2", attempts)
 	}
 }
 
@@ -379,7 +378,7 @@ func TestVerifyRejectsMalformedTimeline(t *testing.T) {
 	client := newTestClient(func(req *http.Request) (*http.Response, error) {
 		return response(http.StatusOK, `{}`), nil
 	})
-	if _, err := client.Verify(context.Background()); err == nil {
+	if err := client.Verify(context.Background()); err == nil {
 		t.Fatal("expected malformed verification response to fail")
 	}
 }
@@ -415,8 +414,12 @@ func TestPostTweetRefreshesRotatedQueryID(t *testing.T) {
 	if id != "99" || attempts != 2 || len(operations) != 1 || operations[0] != "CreateTweet" {
 		t.Fatalf("id=%q attempts=%d operations=%v", id, attempts, operations)
 	}
-	if !client.Refreshed() || client.QueryID() != "fresh" {
-		t.Fatalf("refreshed=%v qid=%q", client.Refreshed(), client.QueryID())
+	if client.createTweetQueryID() != "fresh" {
+		t.Fatalf("client kept qid %q after rotation", client.createTweetQueryID())
+	}
+	cfg := &config.Config{}
+	if !client.ApplyRefreshedQueryIDs(cfg) || cfg.CreateTweetQID != "fresh" {
+		t.Fatalf("refreshed id was not handed back for persistence: %q", cfg.CreateTweetQID)
 	}
 }
 

--- a/pkg/api/upload_test.go
+++ b/pkg/api/upload_test.go
@@ -57,7 +57,7 @@ func TestPostTweetChunkedVideo(t *testing.T) {
 	var appended int
 	statusPolls := 0
 	var graphQLBody []byte
-	client := &WebClient{authToken: "auth", ct0: "csrf", queryID: "qid"}
+	client := &WebClient{authToken: "auth", ct0: "csrf", operationQIDs: map[string]string{"CreateTweet": "qid"}}
 	client.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		var body []byte
 		if req.Body != nil {

--- a/pkg/api/verify_live_test.go
+++ b/pkg/api/verify_live_test.go
@@ -25,7 +25,7 @@ func TestVerifyLive(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 	defer cancel()
-	if _, err := NewWebClient(cfg).Verify(ctx); err != nil {
+	if err := NewWebClient(cfg).Verify(ctx); err != nil {
 		t.Fatal(err)
 	}
 	t.Log("session verification succeeded")

--- a/pkg/api/web.go
+++ b/pkg/api/web.go
@@ -83,8 +83,6 @@ type WebClient struct {
 	httpClient          *http.Client
 	authToken           string
 	ct0                 string
-	queryID             string
-	refreshed           bool // CreateTweet was re-discovered; retained for API compatibility
 	operationQIDs       map[string]string
 	refreshedOperations map[string]string
 	retryDelay          time.Duration // base backoff between transient retries; tests shrink it
@@ -195,7 +193,6 @@ func NewWebClient(cfg *config.Config) *WebClient {
 		httpClient:          &http.Client{Timeout: 30 * time.Second},
 		authToken:           cfg.AuthToken,
 		ct0:                 cfg.CT0,
-		queryID:             qid,
 		operationQIDs:       operationQIDs,
 		refreshedOperations: map[string]string{},
 		reconcileDelay:      1500 * time.Millisecond,
@@ -206,9 +203,11 @@ func NewWebClient(cfg *config.Config) *WebClient {
 	return client
 }
 
-// QueryID returns the CreateTweet query id currently in use (possibly one that
-// was auto-discovered this session).
-func (c *WebClient) QueryID() string { return c.queryID }
+// createTweetQueryID is the CreateTweet id currently in use: the cached or
+// default one, or a fresher id discovered after a rotation this session.
+func (c *WebClient) createTweetQueryID() string {
+	return c.operationQIDs["CreateTweet"]
+}
 
 func (c *WebClient) discoverOperation(ctx context.Context, operation string) (string, error) {
 	var (
@@ -231,16 +230,8 @@ func (c *WebClient) discoverOperation(ctx context.Context, operation string) (st
 	}
 	c.operationQIDs[operation] = qid
 	c.refreshedOperations[operation] = qid
-	if operation == "CreateTweet" {
-		c.queryID = qid
-		c.refreshed = true
-	}
 	return qid, nil
 }
-
-// Refreshed reports whether the query id was re-discovered this session, so the
-// caller knows to persist QueryID() back to the config.
-func (c *WebClient) Refreshed() bool { return c.refreshed }
 
 // ApplyRefreshedQueryIDs copies operation ids discovered by this client into
 // cfg. It reports whether there is anything for the caller to persist.
@@ -509,7 +500,7 @@ func (c *WebClient) PostTweet(ctx context.Context, text, replyToID string, uploa
 		return "", err
 	}
 	attemptedAt := time.Now()
-	res, err := c.doCreateTweet(ctx, vars, c.queryID)
+	res, err := c.doCreateTweet(ctx, vars, c.createTweetQueryID())
 	if err != nil {
 		return c.finishAmbiguousCreate(
 			ctx, text, replyToID, len(uploads), attemptedAt,
@@ -527,8 +518,6 @@ func (c *WebClient) PostTweet(ctx context.Context, text, replyToID string, uploa
 				"Grab it manually: open x.com, post a tweet, in DevTools > Network find the 'CreateTweet' request,\n"+
 				"copy the id in its URL, then run:  xeet setqid <id>", derr)
 		}
-		c.queryID = fresh
-		c.refreshed = true
 		attemptedAt = time.Now()
 		res, err = c.doCreateTweet(ctx, vars, fresh)
 		if err != nil {
@@ -658,16 +647,14 @@ func (c *WebClient) uploadMedia(ctx context.Context, upload Upload) (string, err
 }
 
 // Verify confirms the session cookies with a non-mutating authenticated
-// timeline read. Account identity is handled separately by FetchViewer; the
-// returned string is retained for compatibility and is empty on success.
-func (c *WebClient) Verify(ctx context.Context) (string, error) {
+// timeline read. Account identity is a separate question, answered by
+// FetchViewer.
+func (c *WebClient) Verify(ctx context.Context) error {
 	if c.authToken == "" || c.ct0 == "" {
-		return "", fmt.Errorf("web session not configured")
+		return fmt.Errorf("web session not configured")
 	}
-	if _, err := c.FetchHomeTimeline(ctx, "", 1); err != nil {
-		return "", err
-	}
-	return "", nil
+	_, err := c.FetchHomeTimeline(ctx, "", 1)
+	return err
 }
 
 func truncate(b []byte) string {

--- a/pkg/api/web_test.go
+++ b/pkg/api/web_test.go
@@ -56,7 +56,7 @@ func response(status int, body string) *http.Response {
 func TestPostTweetUploadsMultipleImages(t *testing.T) {
 	uploadCount := 0
 	var graphQLBody []byte
-	client := &WebClient{authToken: "auth", ct0: "csrf", queryID: "qid"}
+	client := &WebClient{authToken: "auth", ct0: "csrf", operationQIDs: map[string]string{"CreateTweet": "qid"}}
 	client.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		body, _ := io.ReadAll(req.Body)
 		if strings.Contains(req.URL.Path, "media/upload") {

--- a/shell.nix
+++ b/shell.nix
@@ -10,11 +10,14 @@ pkgs.mkShell {
     gnumake
     git
   ] ++ lib.optionals stdenv.isLinux [
-    # Clipboard attachments shell out to these at runtime; macOS uses the
+    # The wayland clipboard shells out to these at runtime; macOS uses the
     # system pasteboard instead.
-    xclip
     wl-clipboard
   ];
+
+  # `go build` on linux compiles the cgo clipboard, which needs Xlib's
+  # headers. Without them the dev shell cannot build the project at all.
+  buildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.libx11 ];
 
   shellHook = ''
     # An older nixpkgs channel may carry a go patch release behind go.mod's;


### PR DESCRIPTION
picks up the issues from the codebase review.

wires main.go's signal context through both tuis, so an interrupt cancels in-flight requests instead of leaving them to their own timeouts. splits the timeline model (1327 -> 908 lines) and folds the like/preview/post-action handlers that feed and thread mode each kept a copy of. adds a nix job to ci so a dependency bump that invalidates vendorHash can't silently break nix installs. drops the unused Refreshed/QueryID accessors and the always-empty string Verify returned. surfaces config load failures in the root command instead of falling through to the timeline. points make lint at the same staticcheck version ci runs.

build, vet, race tests, staticcheck, and nix build all pass.