### PR TITLE
unbreak the nix build and report a real version

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ nix profile install github:melqtx/xeet   # install
 nix run github:melqtx/xeet               # or just try it
 ```
 
-**with go** (1.26+):
+**with go** (1.26.5+, for the patched tls stack):
 
 ```bash
 go install github.com/melqtx/xeet@latest

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"runtime/debug"
 
 	"github.com/melqtx/xeet/internal/tui"
 	"github.com/melqtx/xeet/pkg/config"
@@ -42,10 +43,42 @@ func ExecuteContext(ctx context.Context) error {
 	return rootCmd.ExecuteContext(ctx)
 }
 
+// SetVersion records the build information main.go received through -X. Only
+// goreleaser and the nix package set those, so `go install github.com/melqtx/
+// xeet@latest` would otherwise report "dev" forever. Fall back to the data the
+// go tool stamps into every binary: the module version for `go install`, and
+// the VCS revision/time for a plain `go build` in a checkout.
 func SetVersion(version, commit, buildTime string) {
 	appVersion = version
 	appCommit = commit
 	appBuildTime = buildTime
+
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+
+	// A checkout built without -X reports "(devel)", which is no more useful
+	// than "dev"; the VCS revision below covers that case instead.
+	if unset(appVersion) && info.Main.Version != "" && info.Main.Version != "(devel)" {
+		appVersion = info.Main.Version
+	}
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			if unset(appCommit) {
+				appCommit = setting.Value
+			}
+		case "vcs.time":
+			if unset(appBuildTime) {
+				appBuildTime = setting.Value
+			}
+		}
+	}
+}
+
+func unset(value string) bool {
+	return value == "" || value == "dev" || value == "unknown"
 }
 
 func init() {

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,32 @@
+package cmd
+
+import "testing"
+
+func TestUnsetTreatsPlaceholdersAsMissing(t *testing.T) {
+	for _, value := range []string{"", "dev", "unknown"} {
+		if !unset(value) {
+			t.Fatalf("unset(%q) = false, want true", value)
+		}
+	}
+	for _, value := range []string{"v0.1.9", "0.1.9", "nix", "abc123"} {
+		if unset(value) {
+			t.Fatalf("unset(%q) = true, want false", value)
+		}
+	}
+}
+
+// goreleaser and the nix package stamp real values through -X; the build-info
+// fallback must never overwrite them with what the go tool inferred.
+func TestSetVersionKeepsStampedValues(t *testing.T) {
+	t.Cleanup(func() { SetVersion("dev", "unknown", "unknown") })
+
+	SetVersion("0.1.9", "deadbeef", "2026-07-25T00:00:00Z")
+	if appVersion != "0.1.9" || appCommit != "deadbeef" || appBuildTime != "2026-07-25T00:00:00Z" {
+		t.Fatalf("stamped values overwritten: version=%q commit=%q built=%q",
+			appVersion, appCommit, appBuildTime)
+	}
+}
+
+// The placeholder-replacement path isn't covered here: a test binary carries
+// no vcs.* build settings and reports "(devel)", so there is nothing for the
+// fallback to read. It's verified against a real build instead.

--- a/default.nix
+++ b/default.nix
@@ -9,14 +9,14 @@
 buildGoModule (finalAttrs: {
   pname = "xeet";
   # Keep in step with the latest release tag.
-  version = "0.1.8";
+  version = "0.1.9";
 
   src = lib.cleanSource ./.;
 
   # Regenerate whenever go.mod or go.sum changes (including on dependabot
   # bumps): set this to lib.fakeHash, run `nix build .#default`, and copy the
   # hash nix reports. CI's nix job fails when it goes stale.
-  vendorHash = "sha256-gwprri6z2If6rEqdY179WvfEE/az+JsaAaFLihIlqCM=";
+  vendorHash = "sha256-Hij56rK+qINQYCjGdLUgM/5N7e0XAfh/zvcOYDs6gek=";
 
   # main.go reads these through -X; without them the binary reports "dev".
   ldflags = [

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,10 @@
 module github.com/melqtx/xeet
 
+// The patch version is deliberate, not incidental: go1.26.5 is the release
+// that fixes GO-2026-5856 (an Encrypted Client Hello privacy leak in
+// crypto/tls) along with GO-2026-5039 and GO-2026-5037. Relaxing this to
+// "go 1.26" lets an older toolchain build xeet against a vulnerable TLS
+// stack, and CI's govulncheck job fails when it happens.
 go 1.26.5
 
 require (


### PR DESCRIPTION
The dependabot go.mod bump staled default.nix's vendorHash, so `nix build .#default` fails on main right now — that's the CI nix job and the `nix profile install` path the README leads with. Regenerated the hash, bumped the package to 0.1.9.

`go install` builds reported "xeet dev" since only goreleaser and nix set the -X ldflags. SetVersion now falls back to the build info the go tool stamps into every binary; stamped values still win.

Also kept go 1.26.5 and wrote down why — it's the release fixing GO-2026-5856, an ECH privacy leak in crypto/tls. Relaxing it to "go 1.26" turns govulncheck red. README says 1.26.5+ to match.

Verified locally: build, vet, test -race, staticcheck, govulncheck, go-licenses, nix build, gofmt all pass.