### PR TITLE
stop using a deprecated goreleaser archive field

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,7 +26,7 @@ builds:
 
 archives:
   - id: archives
-    builds:
+    ids:
       - xeet
     name_template: >-
       {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}


### PR DESCRIPTION
`goreleaser check` fails on `archives.builds` — v2 replaced it with `archives.ids`. It still builds today, but the release workflow floats on `~> v2`, so the first v2.x that drops the field breaks a release with no warning. Wanted this in before tagging v0.1.9.

Verified with goreleaser 2.17.0: check passes, and `--snapshot` builds all four targets, archives them with LICENSE/README, and stamps the ldflags correctly.