### PR TITLE
bookmarks and search feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ then just:
 xeet                                  # browse your timeline, images and all
 xeet --following                      # start on the following feed
 xeet --bookmarks                      # start on your bookmarks
+xeet search "go tui"                  # search posts and browse results
 xeet --barebones                      # text-only feed
 xeet --compose                        # skip the feed, open the composer
 xeet post "hello from my shell"       # one-shot post
@@ -158,6 +159,7 @@ come back next time.
 | `j` / `k` / arrows | move (`ctrl+d`/`ctrl+u` jumps five) |
 | `f` | switch between the for you and following feeds |
 | `b` | switch between bookmarks and the for you feed |
+| `/` | search posts |
 | `enter` | open the post's replies |
 | `e` / `space` | read a truncated post in full |
 | `i` | zoom the post's image to the whole terminal |
@@ -170,9 +172,11 @@ come back next time.
 | `R` | refresh in place, new posts stack on top, you keep your spot |
 | `?` | key guide + which image renderer is active and why |
 
-more posts load automatically near the bottom. inside a conversation,
-`j`/`k` moves through replies, `r` replies to the selected item, `R`
-reloads, and `esc` drops you back exactly where you were in the timeline.
+more posts load automatically near the bottom; search results are just
+another feed, so like, reply, and thread all work there too. inside a
+conversation, `j`/`k` moves through replies, `r` replies to the selected
+item, `R` reloads, and `esc` drops you back exactly where you were in the
+timeline.
 
 **themes**
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ then just:
 ```bash
 xeet                                  # browse your timeline, images and all
 xeet --following                      # start on the following feed
+xeet --bookmarks                      # start on your bookmarks
 xeet --barebones                      # text-only feed
 xeet --compose                        # skip the feed, open the composer
 xeet post "hello from my shell"       # one-shot post
@@ -156,6 +157,7 @@ come back next time.
 |---|---|
 | `j` / `k` / arrows | move (`ctrl+d`/`ctrl+u` jumps five) |
 | `f` | switch between the for you and following feeds |
+| `b` | switch between bookmarks and the for you feed |
 | `enter` | open the post's replies |
 | `e` / `space` | read a truncated post in full |
 | `i` | zoom the post's image to the whole terminal |

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -20,7 +20,7 @@ var commandGroups = []struct {
 	names []string
 }{
 	{"start here", []string{"auth", "whoami", "doctor", "logout"}},
-	{"every day", []string{"timeline", "post", "theme"}},
+	{"every day", []string{"timeline", "search", "post", "theme"}},
 	{"extras", []string{"version", "inspect-har", "completion", "help"}},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,7 @@ var (
 	barebones     bool
 	composeOnly   bool
 	rootFollowing bool
+	rootBookmarks bool
 	rootTheme     string
 )
 
@@ -28,6 +29,7 @@ var rootCmd = &cobra.Command{
 	Short: "Terminal interface for browsing and posting to X.com",
 	Example: `  xeet                         # your timeline, with inline images
   xeet --following             # the Following feed instead of For You
+  xeet --bookmarks             # your saved posts
   xeet --compose               # just the composer
   xeet post "hello, terminal"  # post without opening anything
   xeet theme                   # pick a color theme, with a preview`,
@@ -87,9 +89,12 @@ func init() {
 	rootCmd.Flags().BoolVar(&barebones, "barebones", false, "open a text-only timeline without image previews")
 	rootCmd.Flags().BoolVar(&composeOnly, "compose", false, "open only the post composer")
 	rootCmd.Flags().BoolVar(&rootFollowing, "following", false, "start on the Following feed instead of For You")
+	rootCmd.Flags().BoolVar(&rootBookmarks, "bookmarks", false, "start on your bookmarks feed")
 	rootCmd.Flags().StringVar(&rootTheme, "theme", "", "color theme for this run (see 'xeet theme')")
 	rootCmd.MarkFlagsMutuallyExclusive("barebones", "compose")
 	rootCmd.MarkFlagsMutuallyExclusive("compose", "following")
+	rootCmd.MarkFlagsMutuallyExclusive("following", "bookmarks")
+	rootCmd.MarkFlagsMutuallyExclusive("compose", "bookmarks")
 }
 
 func runRoot(cmd *cobra.Command, args []string) error {
@@ -122,6 +127,9 @@ func runRoot(cmd *cobra.Command, args []string) error {
 	feed := timeline.FeedForYou
 	if rootFollowing {
 		feed = timeline.FeedFollowing
+	}
+	if rootBookmarks {
+		feed = timeline.FeedBookmarks
 	}
 	return runTimeline(cmd.Context(), imageMode, feed)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -131,7 +131,7 @@ func runRoot(cmd *cobra.Command, args []string) error {
 	if rootBookmarks {
 		feed = timeline.FeedBookmarks
 	}
-	return runTimeline(cmd.Context(), imageMode, feed)
+	return runTimeline(cmd.Context(), imageMode, feed, "")
 }
 
 // printFirstRun greets someone who has not connected an account yet. It is the

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"runtime/debug"
 
+	"github.com/melqtx/xeet/internal/timeline"
 	"github.com/melqtx/xeet/internal/tui"
 	"github.com/melqtx/xeet/pkg/config"
 
@@ -118,7 +119,11 @@ func runRoot(cmd *cobra.Command, args []string) error {
 	if barebones {
 		imageMode = "off"
 	}
-	return runTimeline(cmd.Context(), imageMode, rootFollowing)
+	feed := timeline.FeedForYou
+	if rootFollowing {
+		feed = timeline.FeedFollowing
+	}
+	return runTimeline(cmd.Context(), imageMode, feed)
 }
 
 // printFirstRun greets someone who has not connected an account yet. It is the

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"github.com/melqtx/xeet/internal/timeline"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	searchImageMode string
+	searchTheme     string
+)
+
+var searchCmd = &cobra.Command{
+	Use:   "search [query]",
+	Short: "search posts and browse results",
+	Example: `  xeet search "go tui"  # search now and browse results
+  xeet search           # open the search prompt`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := applyConfiguredTheme(searchTheme); err != nil {
+			return err
+		}
+		query := ""
+		if len(args) == 1 {
+			query = args[0]
+		}
+		return runTimeline(cmd.Context(), searchImageMode, timeline.FeedSearch, query)
+	},
+}
+
+func init() {
+	searchCmd.Flags().StringVar(&searchImageMode, "images", "auto", "image mode: auto, native, ansi, or off")
+	searchCmd.Flags().StringVar(&searchTheme, "theme", "", "color theme for this run (see 'xeet theme')")
+	rootCmd.AddCommand(searchCmd)
+}

--- a/cmd/timeline.go
+++ b/cmd/timeline.go
@@ -13,6 +13,7 @@ import (
 var (
 	timelineImageMode string
 	timelineFollowing bool
+	timelineBookmarks bool
 	timelineTheme     string
 )
 
@@ -21,6 +22,7 @@ var timelineCmd = &cobra.Command{
 	Short: "browse your home timeline",
 	Example: `  xeet timeline                # same as plain 'xeet'
   xeet timeline --following    # the Following feed
+  xeet timeline --bookmarks    # your saved posts
   xeet timeline --images off   # text only, no previews`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := applyConfiguredTheme(timelineTheme); err != nil {
@@ -30,6 +32,9 @@ var timelineCmd = &cobra.Command{
 		if timelineFollowing {
 			feed = timeline.FeedFollowing
 		}
+		if timelineBookmarks {
+			feed = timeline.FeedBookmarks
+		}
 		return runTimeline(cmd.Context(), timelineImageMode, feed)
 	},
 }
@@ -37,7 +42,9 @@ var timelineCmd = &cobra.Command{
 func init() {
 	timelineCmd.Flags().StringVar(&timelineImageMode, "images", "auto", "image mode: auto, native, ansi, or off")
 	timelineCmd.Flags().BoolVar(&timelineFollowing, "following", false, "start on the Following feed instead of For You")
+	timelineCmd.Flags().BoolVar(&timelineBookmarks, "bookmarks", false, "start on your bookmarks feed")
 	timelineCmd.Flags().StringVar(&timelineTheme, "theme", "", "color theme for this run (see 'xeet theme')")
+	timelineCmd.MarkFlagsMutuallyExclusive("following", "bookmarks")
 	rootCmd.AddCommand(timelineCmd)
 }
 

--- a/cmd/timeline.go
+++ b/cmd/timeline.go
@@ -26,7 +26,11 @@ var timelineCmd = &cobra.Command{
 		if err := applyConfiguredTheme(timelineTheme); err != nil {
 			return err
 		}
-		return runTimeline(cmd.Context(), timelineImageMode, timelineFollowing)
+		feed := timeline.FeedForYou
+		if timelineFollowing {
+			feed = timeline.FeedFollowing
+		}
+		return runTimeline(cmd.Context(), timelineImageMode, feed)
 	},
 }
 
@@ -37,14 +41,14 @@ func init() {
 	rootCmd.AddCommand(timelineCmd)
 }
 
-func runTimeline(ctx context.Context, imageMode string, following bool) error {
+func runTimeline(ctx context.Context, imageMode string, feed timeline.FeedKind) error {
 	switch imageMode {
 	case "auto", "native", "ansi", "off":
 	default:
 		return fmt.Errorf("invalid --images value %q (use auto, native, ansi, or off)", imageMode)
 	}
 	for {
-		action, err := timeline.Run(ctx, imageMode, following)
+		action, err := timeline.Run(ctx, imageMode, feed)
 		if err != nil {
 			return err
 		}

--- a/cmd/timeline.go
+++ b/cmd/timeline.go
@@ -35,7 +35,7 @@ var timelineCmd = &cobra.Command{
 		if timelineBookmarks {
 			feed = timeline.FeedBookmarks
 		}
-		return runTimeline(cmd.Context(), timelineImageMode, feed)
+		return runTimeline(cmd.Context(), timelineImageMode, feed, "")
 	},
 }
 
@@ -48,14 +48,14 @@ func init() {
 	rootCmd.AddCommand(timelineCmd)
 }
 
-func runTimeline(ctx context.Context, imageMode string, feed timeline.FeedKind) error {
+func runTimeline(ctx context.Context, imageMode string, feed timeline.FeedKind, query string) error {
 	switch imageMode {
 	case "auto", "native", "ansi", "off":
 	default:
 		return fmt.Errorf("invalid --images value %q (use auto, native, ansi, or off)", imageMode)
 	}
 	for {
-		action, err := timeline.Run(ctx, imageMode, feed)
+		action, err := timeline.Run(ctx, imageMode, feed, query)
 		if err != nil {
 			return err
 		}

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textarea"
+	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -56,6 +57,7 @@ const (
 	FeedForYou FeedKind = iota
 	FeedFollowing
 	FeedBookmarks
+	FeedSearch
 )
 
 type mode int
@@ -64,6 +66,7 @@ const (
 	modeFeed mode = iota
 	modeThread
 	modeReply
+	modeSearch
 )
 
 type Model struct {
@@ -75,6 +78,7 @@ type Model struct {
 	imageMode     imageMode
 	imageNote     string
 	feed          FeedKind
+	searchQuery   string
 	feedSeq       int
 	posts         []api.TimelinePost
 	cursor        string
@@ -115,6 +119,8 @@ type Model struct {
 	replyPosting  bool
 	replyErr      error
 	replyNotice   string
+	searchInput   textinput.Model
+	searchReturn  mode
 }
 
 type pageMsg struct {
@@ -206,12 +212,15 @@ func NewWithImageMode(requested string) Model {
 	editor.ShowLineNumbers = false
 	editor.SetWidth(60)
 	editor.SetHeight(6)
+	search := textinput.New()
+	search.Placeholder = "search"
+	search.CharLimit = 512
 	mode, note := resolveImageMode(requested)
 	return Model{
 		ctx:   context.Background(),
 		width: 80, height: 24, imageMode: mode, imageNote: note, loading: true,
 		liking: map[string]bool{}, previews: map[string]previewState{},
-		spinner: s, viewport: vp, replyEditor: editor,
+		spinner: s, viewport: vp, replyEditor: editor, searchInput: search,
 	}
 }
 
@@ -225,13 +234,21 @@ func (m Model) requestContext() context.Context {
 }
 
 func (m Model) Init() tea.Cmd {
-	return tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.feed, "", false, m.feedSeq), clockTick())
+	if m.feed == FeedSearch && m.searchQuery == "" {
+		return tea.Batch(m.searchInput.Focus(), clockTick())
+	}
+	return tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.feed, m.searchQuery, "", false, m.feedSeq), clockTick())
 }
 
-func Run(ctx context.Context, images string, feed FeedKind) (Action, error) {
+func Run(ctx context.Context, images string, feed FeedKind, query string) (Action, error) {
 	m := NewWithImageMode(images)
 	m.ctx = ctx
 	m.feed = feed
+	m.searchQuery = query
+	if feed == FeedSearch && query == "" {
+		m.loading = false
+		m.beginSearch()
+	}
 	// Auto-detected native mode is a claim, not a capability: multiplexers
 	// like cmux inherit ghostty's TERM without reliably rendering graphics.
 	// Confirm with the terminal itself; --images native skips the probe.
@@ -261,7 +278,7 @@ func Run(ctx context.Context, images string, feed FeedKind) (Action, error) {
 	return Action{}, err
 }
 
-func fetchPageSeq(parent context.Context, feed FeedKind, cursor string, more bool, seq int) tea.Cmd {
+func fetchPageSeq(parent context.Context, feed FeedKind, query, cursor string, more bool, seq int) tea.Cmd {
 	return func() tea.Msg {
 		mgr, err := config.NewConfigManager()
 		if err != nil {
@@ -280,6 +297,11 @@ func fetchPageSeq(parent context.Context, feed FeedKind, cursor string, more boo
 			fetch = client.FetchFollowingTimeline
 		case FeedBookmarks:
 			fetch = client.FetchBookmarks
+		case FeedSearch:
+			q := query
+			fetch = func(ctx context.Context, cursor string, count int) (*api.TimelinePage, error) {
+				return client.FetchSearchTimeline(ctx, q, cursor, count)
+			}
 		}
 		page, err := fetch(ctx, cursor, 30)
 		if client.ApplyRefreshedQueryIDs(cfg) {
@@ -397,10 +419,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 	}
-	if m.mode == modeReply {
+	switch m.mode {
+	case modeReply:
 		return m.updateReply(msg)
-	}
-	if m.mode == modeThread {
+	case modeSearch:
+		return m.updateSearch(msg)
+	case modeThread:
 		return m.updateThread(msg)
 	}
 
@@ -470,6 +494,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, m.setFeed(FeedForYou)
 		}
 		return m, m.setFeed(FeedBookmarks)
+	case "/":
+		return m, m.beginSearch()
 	case "R", "ctrl+r":
 		if len(m.posts) == 0 {
 			m.loading = true
@@ -477,7 +503,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.refreshing = true
 		}
 		m.err = nil
-		return m, m.imageRepaint(tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.feed, "", false, m.feedSeq)))
+		return m, m.imageRepaint(tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.feed, m.searchQuery, "", false, m.feedSeq)))
 	case "r":
 		if post, ok := m.currentPost(); ok {
 			return m.beginReply(post)
@@ -659,7 +685,7 @@ func (m *Model) setFeed(kind FeedKind) tea.Cmd {
 	m.err = nil
 	m.viewport.YOffset = 0
 	m.syncViewport()
-	return m.imageRepaint(tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.feed, "", false, m.feedSeq)))
+	return m.imageRepaint(tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.feed, m.searchQuery, "", false, m.feedSeq)))
 }
 
 // switchFeed keeps the f-key semantics: toggle For You <-> Following.
@@ -674,7 +700,7 @@ func (m *Model) switchFeed() tea.Cmd {
 func (m *Model) maybeLoadMore() tea.Cmd {
 	if len(m.posts) > 0 && m.selected >= len(m.posts)-5 && m.cursor != "" && !m.loadingMore {
 		m.loadingMore = true
-		return tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.feed, m.cursor, true, m.feedSeq))
+		return tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.feed, m.searchQuery, m.cursor, true, m.feedSeq))
 	}
 	return nil
 }
@@ -693,7 +719,9 @@ func (m Model) applyFeedPage(msg pageMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	m.err = nil
-	threadContext := m.mode == modeThread || (m.mode == modeReply && m.replyReturn == modeThread)
+	threadContext := m.mode == modeThread ||
+		(m.mode == modeReply && m.replyReturn == modeThread) ||
+		(m.mode == modeSearch && m.searchReturn == modeThread)
 	feedIndex := m.selected
 	if threadContext {
 		feedIndex = m.feedSelected
@@ -799,6 +827,7 @@ func (m *Model) resize() {
 	m.viewport.Height = viewportHeight
 	m.replyEditor.SetWidth(max(20, w-6))
 	m.replyEditor.SetHeight(min(7, max(3, m.height-16)))
+	m.searchInput.Width = max(20, w-6)
 	m.syncViewport()
 	m.ensureSelectedVisible()
 }

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -49,6 +49,14 @@ const (
 
 type Action struct{ Kind ActionKind }
 
+// FeedKind identifies which timeline the feed pane is showing.
+type FeedKind int
+
+const (
+	FeedForYou FeedKind = iota
+	FeedFollowing
+)
+
 type mode int
 
 const (
@@ -65,7 +73,7 @@ type Model struct {
 	width, height int
 	imageMode     imageMode
 	imageNote     string
-	following     bool
+	feed          FeedKind
 	feedSeq       int
 	posts         []api.TimelinePost
 	cursor        string
@@ -216,13 +224,13 @@ func (m Model) requestContext() context.Context {
 }
 
 func (m Model) Init() tea.Cmd {
-	return tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.following, "", false, m.feedSeq), clockTick())
+	return tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.feed, "", false, m.feedSeq), clockTick())
 }
 
-func Run(ctx context.Context, images string, following bool) (Action, error) {
+func Run(ctx context.Context, images string, feed FeedKind) (Action, error) {
 	m := NewWithImageMode(images)
 	m.ctx = ctx
-	m.following = following
+	m.feed = feed
 	// Auto-detected native mode is a claim, not a capability: multiplexers
 	// like cmux inherit ghostty's TERM without reliably rendering graphics.
 	// Confirm with the terminal itself; --images native skips the probe.
@@ -252,7 +260,7 @@ func Run(ctx context.Context, images string, following bool) (Action, error) {
 	return Action{}, err
 }
 
-func fetchPageSeq(parent context.Context, following bool, cursor string, more bool, seq int) tea.Cmd {
+func fetchPageSeq(parent context.Context, feed FeedKind, cursor string, more bool, seq int) tea.Cmd {
 	return func() tea.Msg {
 		mgr, err := config.NewConfigManager()
 		if err != nil {
@@ -266,7 +274,7 @@ func fetchPageSeq(parent context.Context, following bool, cursor string, more bo
 		defer cancel()
 		client := api.NewWebClient(cfg)
 		fetch := client.FetchHomeTimeline
-		if following {
+		if feed == FeedFollowing {
 			fetch = client.FetchFollowingTimeline
 		}
 		page, err := fetch(ctx, cursor, 30)
@@ -452,7 +460,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.syncViewport()
 		return m, func() tea.Msg { return tea.ClearScreen() }
 	case "f":
-		return m.switchFeed()
+		return m, m.switchFeed()
 	case "R", "ctrl+r":
 		if len(m.posts) == 0 {
 			m.loading = true
@@ -460,7 +468,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.refreshing = true
 		}
 		m.err = nil
-		return m, m.imageRepaint(tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.following, "", false, m.feedSeq)))
+		return m, m.imageRepaint(tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.feed, "", false, m.feedSeq)))
 	case "r":
 		if post, ok := m.currentPost(); ok {
 			return m.beginReply(post)
@@ -628,9 +636,9 @@ func (m *Model) moveSelection(target int) {
 	m.ensureSelectedVisible()
 }
 
-// switchFeed flips between the For You and Following feeds in place.
-func (m Model) switchFeed() (tea.Model, tea.Cmd) {
-	m.following = !m.following
+// setFeed resets feed state and kicks off a fresh first page for kind.
+func (m *Model) setFeed(kind FeedKind) tea.Cmd {
+	m.feed = kind
 	m.feedSeq++
 	m.posts = nil
 	m.cursor = ""
@@ -642,13 +650,22 @@ func (m Model) switchFeed() (tea.Model, tea.Cmd) {
 	m.err = nil
 	m.viewport.YOffset = 0
 	m.syncViewport()
-	return m, m.imageRepaint(tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.following, "", false, m.feedSeq)))
+	return m.imageRepaint(tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.feed, "", false, m.feedSeq)))
+}
+
+// switchFeed keeps the f-key semantics: toggle For You <-> Following.
+// From any other feed kind it returns to For You.
+func (m *Model) switchFeed() tea.Cmd {
+	if m.feed == FeedForYou {
+		return m.setFeed(FeedFollowing)
+	}
+	return m.setFeed(FeedForYou)
 }
 
 func (m *Model) maybeLoadMore() tea.Cmd {
 	if len(m.posts) > 0 && m.selected >= len(m.posts)-5 && m.cursor != "" && !m.loadingMore {
 		m.loadingMore = true
-		return tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.following, m.cursor, true, m.feedSeq))
+		return tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.feed, m.cursor, true, m.feedSeq))
 	}
 	return nil
 }

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -55,6 +55,7 @@ type FeedKind int
 const (
 	FeedForYou FeedKind = iota
 	FeedFollowing
+	FeedBookmarks
 )
 
 type mode int
@@ -274,8 +275,11 @@ func fetchPageSeq(parent context.Context, feed FeedKind, cursor string, more boo
 		defer cancel()
 		client := api.NewWebClient(cfg)
 		fetch := client.FetchHomeTimeline
-		if feed == FeedFollowing {
+		switch feed {
+		case FeedFollowing:
 			fetch = client.FetchFollowingTimeline
+		case FeedBookmarks:
+			fetch = client.FetchBookmarks
 		}
 		page, err := fetch(ctx, cursor, 30)
 		if client.ApplyRefreshedQueryIDs(cfg) {
@@ -461,6 +465,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, func() tea.Msg { return tea.ClearScreen() }
 	case "f":
 		return m, m.switchFeed()
+	case "b":
+		if m.feed == FeedBookmarks {
+			return m, m.setFeed(FeedForYou)
+		}
+		return m, m.setFeed(FeedBookmarks)
 	case "R", "ctrl+r":
 		if len(m.posts) == 0 {
 			m.loading = true

--- a/internal/timeline/search.go
+++ b/internal/timeline/search.go
@@ -1,0 +1,67 @@
+package timeline
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func (m *Model) beginSearch() tea.Cmd {
+	m.searchReturn = m.mode
+	m.searchInput.SetValue(m.searchQuery)
+	m.mode = modeSearch
+	return m.imageRepaint(m.searchInput.Focus())
+}
+
+func (m Model) cancelSearch() (tea.Model, tea.Cmd) {
+	m.mode = m.searchReturn
+	m.searchInput.Blur()
+	m.syncViewport()
+	m.ensureSelectedVisible()
+	return m, m.imageRepaint(m.requestPreviews())
+}
+
+func (m Model) updateSearch(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case threadMsg:
+		if m.searchReturn != modeThread {
+			return m, nil
+		}
+		return m.applyThreadPage(msg, false)
+	case pageMsg:
+		return m.applyFeedPage(msg)
+	case likeMsg:
+		m.settleLike(msg)
+		return m, nil
+	case previewMsg:
+		m.storePreview(msg)
+		return m, nil
+	case spinner.TickMsg:
+		if m.loading || m.loadingMore || m.refreshing || m.threadLoading || m.threadMore {
+			var cmd tea.Cmd
+			m.spinner, cmd = m.spinner.Update(msg)
+			return m, cmd
+		}
+	}
+
+	if key, ok := msg.(tea.KeyMsg); ok {
+		switch key.String() {
+		case "esc":
+			return m.cancelSearch()
+		case "enter":
+			query := strings.TrimSpace(m.searchInput.Value())
+			if query == "" {
+				return m.cancelSearch()
+			}
+			m.searchQuery = query
+			m.searchInput.Blur()
+			m.mode = modeFeed
+			return m, m.setFeed(FeedSearch)
+		}
+	}
+
+	var cmd tea.Cmd
+	m.searchInput, cmd = m.searchInput.Update(msg)
+	return m, cmd
+}

--- a/internal/timeline/search_test.go
+++ b/internal/timeline/search_test.go
@@ -1,0 +1,170 @@
+package timeline
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/melqtx/xeet/pkg/api"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+)
+
+func TestSearchPromptOpensFromFeedWithPreviousQuery(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.loading = false
+	m.feed = FeedBookmarks
+	m.searchQuery = "from:alice cats"
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m = next.(Model)
+
+	if cmd == nil || m.mode != modeSearch || m.searchReturn != modeFeed {
+		t.Fatalf("search prompt did not open from feed: mode=%v return=%v cmd=%v", m.mode, m.searchReturn, cmd)
+	}
+	if m.feed != FeedBookmarks {
+		t.Fatalf("opening search changed the feed to %v; it should stay until a query is submitted", m.feed)
+	}
+	if got := m.searchInput.Value(); got != "from:alice cats" || !m.searchInput.Focused() {
+		t.Fatalf("search input was not pre-filled and focused: value=%q focused=%v", got, m.searchInput.Focused())
+	}
+}
+
+func TestSearchPromptOpensFromThreadAndEscRestoresThread(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.loading = false
+	m.feed = FeedFollowing
+	m.searchQuery = "original"
+	m.mode = modeThread
+	m.threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}}}
+	m.syncViewport()
+
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m.searchInput.SetValue("edited but cancelled")
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyEsc})
+
+	if m.mode != modeThread || m.feed != FeedFollowing {
+		t.Fatalf("esc did not restore the thread without changing feed: mode=%v feed=%v", m.mode, m.feed)
+	}
+	if m.searchQuery != "original" || m.searchInput.Focused() {
+		t.Fatalf("esc changed the query or kept focus: query=%q focused=%v", m.searchQuery, m.searchInput.Focused())
+	}
+}
+
+func TestEmptySearchSubmissionCancelsExactlyLikeEsc(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.loading = false
+	m.feed = FeedBookmarks
+	m.searchQuery = "keep me"
+	m.mode = modeThread
+	m.threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}}}
+	m.syncViewport()
+
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m.searchInput.SetValue(" \t ")
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if m.mode != modeThread || m.feed != FeedBookmarks || m.searchQuery != "keep me" {
+		t.Fatalf("empty enter did not cancel: mode=%v feed=%v query=%q", m.mode, m.feed, m.searchQuery)
+	}
+	if m.searchInput.Focused() {
+		t.Fatal("empty enter left the search input focused")
+	}
+}
+
+func TestNonEmptySearchSubmissionLeavesThreadForSearchFeed(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.loading = false
+	m.feed = FeedBookmarks
+	m.feedSeq = 4
+	m.posts = []api.TimelinePost{{ID: "old", Text: "old"}}
+	m.mode = modeThread
+	m.threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}}}
+	m.syncViewport()
+
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m.searchInput.SetValue("  golang tui  ")
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+
+	if cmd == nil || m.mode != modeFeed || m.feed != FeedSearch {
+		t.Fatalf("search did not become a feed: mode=%v feed=%v cmd=%v", m.mode, m.feed, cmd)
+	}
+	if m.searchQuery != "golang tui" || m.feedSeq != 5 {
+		t.Fatalf("search query or stale-page sequence is wrong: query=%q seq=%d", m.searchQuery, m.feedSeq)
+	}
+	if len(m.posts) != 0 || !m.loading || m.searchInput.Focused() {
+		t.Fatalf("search feed was not reset for its first page: posts=%d loading=%v focused=%v", len(m.posts), m.loading, m.searchInput.Focused())
+	}
+}
+
+func TestSearchPromptKeepsThreadSelectionDuringBackgroundFeedPage(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.loading = false
+	m.posts = []api.TimelinePost{{ID: "a", Text: "a"}, {ID: "root", Text: "root"}}
+	m.feedSelected = 1
+	m.mode = modeThread
+	m.threadPosts = []api.ConversationPost{
+		{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}},
+		{TimelinePost: api.TimelinePost{ID: "reply", Text: "reply"}, Depth: 1},
+	}
+	m.selected = 1
+	m.syncViewport()
+
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m = update(t, m, pageMsg{page: &api.TimelinePage{Posts: []api.TimelinePost{{ID: "new", Text: "new"}}}})
+
+	if m.mode != modeSearch || m.selected != 1 || m.feedSelected != 2 {
+		t.Fatalf("background feed page corrupted selections: mode=%v thread=%d feed=%d", m.mode, m.selected, m.feedSelected)
+	}
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyEsc})
+	if m.mode != modeThread || m.threadPosts[m.selected].ID != "reply" {
+		t.Fatalf("cancel did not reveal the same thread selection: mode=%v selected=%d", m.mode, m.selected)
+	}
+}
+
+func TestRefreshSearchFeedKeepsQuery(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.loading = false
+	m.feed = FeedSearch
+	m.searchQuery = "golang tui"
+	m.posts = []api.TimelinePost{{ID: "result", Text: "result"}}
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'R'}})
+	m = next.(Model)
+
+	if cmd == nil || !m.refreshing || m.feed != FeedSearch || m.searchQuery != "golang tui" {
+		t.Fatalf("R did not refresh the same search: refreshing=%v feed=%v query=%q cmd=%v", m.refreshing, m.feed, m.searchQuery, cmd)
+	}
+}
+
+func TestSearchViewAndHeaderExposeQueryWithinWidth(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.width = 42
+	m.height = 15
+	m.loading = false
+	m.feed = FeedSearch
+	m.searchQuery = strings.Repeat("long query ", 10)
+	m.beginSearch()
+
+	view := m.View()
+	for _, want := range []string{"search", "enter: search", "esc: cancel"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("search prompt missing %q:\n%s", want, view)
+		}
+	}
+
+	m.mode = modeFeed
+	header := m.header(m.contentWidth())
+	if width := maxLineWidth(header); width > m.contentWidth() {
+		t.Fatalf("search header width=%d exceeds content width=%d:\n%s", width, m.contentWidth(), header)
+	}
+}
+
+func maxLineWidth(value string) int {
+	width := 0
+	for _, line := range strings.Split(value, "\n") {
+		width = max(width, ansi.StringWidth(line))
+	}
+	return width
+}

--- a/internal/timeline/thread.go
+++ b/internal/timeline/thread.go
@@ -248,6 +248,8 @@ func (m Model) updateThread(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if post, ok := m.currentPost(); ok {
 			return m.beginReply(post)
 		}
+	case "/":
+		return m, m.beginSearch()
 	case "enter", " ", "e":
 		m.expanded = !m.expanded
 		m.syncViewport()

--- a/internal/timeline/view.go
+++ b/internal/timeline/view.go
@@ -75,6 +75,8 @@ func (m Model) header(width int) string {
 		status = "for you"
 	case FeedFollowing:
 		status = "following"
+	case FeedBookmarks:
+		status = "bookmarks"
 	}
 	if m.mode == modeThread {
 		status = "replies"
@@ -675,12 +677,12 @@ func (m Model) viewHelp() string {
 	if w > 54 {
 		w = 54
 	}
-	keys := "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nf           for you / following\nl           like / unlike\nr           reply\nR           refresh\nenter       open replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\nP           new post\ng / G       top / bottom\nctrl+l      redraw screen\nq           quit"
+	keys := "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nf           for you / following\nb           bookmarks / for you\nl           like / unlike\nr           reply\nR           refresh\nenter       open replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\nP           new post\ng / G       top / bottom\nctrl+l      redraw screen\nq           quit"
 	if m.mode == modeThread {
 		keys = "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nl           like / unlike\nr           reply to selected\nR           refresh replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\ng / G       top / bottom\nctrl+l      redraw screen\nesc         back to timeline\nq           quit"
 	}
 	if m.height < 25 {
-		keys = "\n\nj/k move · g/G ends · f feed\nl like · r reply · y copy\nenter replies · e read · i zoom · A alt text\nR refresh · o browser\nP compose · ctrl+l redraw\nq quit"
+		keys = "\n\nj/k move · g/G ends · f feed\nl like · r reply · y copy\nenter replies · e read · i zoom · A alt text\nR refresh · o browser\nP compose · ctrl+l redraw\nb bookmarks · q quit"
 		if m.mode == modeThread {
 			keys = "\n\nj/k move · g/G ends\nl like · r reply · y copy\ne read · i zoom · A alt text\nR refresh · o browser\nesc back · q quit"
 		}

--- a/internal/timeline/view.go
+++ b/internal/timeline/view.go
@@ -70,7 +70,10 @@ func (m Model) contentWidth() int {
 
 func (m Model) header(width int) string {
 	status := "for you"
-	if m.following {
+	switch m.feed {
+	case FeedForYou:
+		status = "for you"
+	case FeedFollowing:
 		status = "following"
 	}
 	if m.mode == modeThread {

--- a/internal/timeline/view.go
+++ b/internal/timeline/view.go
@@ -25,6 +25,9 @@ func (m Model) View() string {
 	if m.zoom {
 		return m.viewZoom()
 	}
+	if m.mode == modeSearch {
+		return m.viewSearch()
+	}
 	if m.mode == modeReply {
 		return m.viewReply()
 	}
@@ -77,6 +80,8 @@ func (m Model) header(width int) string {
 		status = "following"
 	case FeedBookmarks:
 		status = "bookmarks"
+	case FeedSearch:
+		status = truncateRunes("search: "+m.searchQuery, max(9, width-12))
 	}
 	if m.mode == modeThread {
 		status = "replies"
@@ -565,6 +570,16 @@ func (m Model) viewReply() string {
 	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, content)
 }
 
+func (m Model) viewSearch() string {
+	w := m.contentWidth()
+	title := lipgloss.NewStyle().Foreground(pink).Bold(true).Render("search")
+	input := lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(blue).
+		Padding(0, 1).Width(w - 4).Render(m.searchInput.View())
+	hint := lipgloss.NewStyle().Foreground(muted).Render("enter: search · esc: cancel")
+	content := title + "\n\n" + input + "\n\n" + hint
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, content)
+}
+
 func (m Model) viewZoom() string {
 	post, ok := m.currentPost()
 	if !ok || len(post.Media) == 0 {
@@ -677,14 +692,14 @@ func (m Model) viewHelp() string {
 	if w > 54 {
 		w = 54
 	}
-	keys := "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nf           for you / following\nb           bookmarks / for you\nl           like / unlike\nr           reply\nR           refresh\nenter       open replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\nP           new post\ng / G       top / bottom\nctrl+l      redraw screen\nq           quit"
+	keys := "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nf           for you / following\nb           bookmarks / for you\n/           search\nl           like / unlike\nr           reply\nR           refresh\nenter       open replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\nP           new post\ng / G       top / bottom\nctrl+l      redraw screen\nq           quit"
 	if m.mode == modeThread {
-		keys = "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nl           like / unlike\nr           reply to selected\nR           refresh replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\ng / G       top / bottom\nctrl+l      redraw screen\nesc         back to timeline\nq           quit"
+		keys = "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\n/           search\nl           like / unlike\nr           reply to selected\nR           refresh replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\ng / G       top / bottom\nctrl+l      redraw screen\nesc         back to timeline\nq           quit"
 	}
 	if m.height < 25 {
-		keys = "\n\nj/k move · g/G ends · f feed\nl like · r reply · y copy\nenter replies · e read · i zoom · A alt text\nR refresh · o browser\nP compose · ctrl+l redraw\nb bookmarks · q quit"
+		keys = "\n\nj/k move · g/G ends · f feed\nl like · r reply · y copy\nenter replies · e read · i zoom · A alt text\nR refresh · o browser\nP new · / search · ^L redraw\nb bookmarks · q quit"
 		if m.mode == modeThread {
-			keys = "\n\nj/k move · g/G ends\nl like · r reply · y copy\ne read · i zoom · A alt text\nR refresh · o browser\nesc back · q quit"
+			keys = "\n\nj/k move · g/G ends\nl like · r reply · y copy\ne read · i zoom · A alt text\nR refresh · o browser · / search\nesc back · q quit"
 		}
 	}
 	images := "images: " + string(m.imageMode)

--- a/pkg/api/bookmarks.go
+++ b/pkg/api/bookmarks.go
@@ -6,10 +6,8 @@ const bookmarksOperation = "Bookmarks"
 
 // FetchBookmarks returns a page of the authenticated user's bookmarks.
 func (c *WebClient) FetchBookmarks(ctx context.Context, cursor string, count int) (*TimelinePage, error) {
-	return c.fetchTimelineOp(ctx, bookmarksOperation, "", "XEET_BOOKMARKS_QID", count,
+	return c.fetchTimelineOp(ctx, bookmarksOperation, "", "XEET_BOOKMARKS_QID", count, false,
 		func(count int) map[string]any {
-			// TODO(human): verify this minimal variable set against a fresh HAR
-			// because the sandbox cannot exercise the live endpoint.
 			variables := map[string]any{
 				"count":                  count,
 				"includePromotedContent": false,

--- a/pkg/api/bookmarks.go
+++ b/pkg/api/bookmarks.go
@@ -1,0 +1,22 @@
+package api
+
+import "context"
+
+const bookmarksOperation = "Bookmarks"
+
+// FetchBookmarks returns a page of the authenticated user's bookmarks.
+func (c *WebClient) FetchBookmarks(ctx context.Context, cursor string, count int) (*TimelinePage, error) {
+	return c.fetchTimelineOp(ctx, bookmarksOperation, "", "XEET_BOOKMARKS_QID", count,
+		func(count int) map[string]any {
+			// TODO(human): verify this minimal variable set against a fresh HAR
+			// because the sandbox cannot exercise the live endpoint.
+			variables := map[string]any{
+				"count":                  count,
+				"includePromotedContent": false,
+			}
+			if cursor != "" {
+				variables["cursor"] = cursor
+			}
+			return variables
+		})
+}

--- a/pkg/api/bookmarks_live_test.go
+++ b/pkg/api/bookmarks_live_test.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/melqtx/xeet/pkg/config"
+)
+
+func TestBookmarksLive(t *testing.T) {
+	if os.Getenv("XEET_LIVE_BOOKMARKS") != "1" {
+		t.Skip("set XEET_LIVE_BOOKMARKS=1 to run")
+	}
+	mgr, err := config.NewConfigManager()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := mgr.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+	defer cancel()
+	client := NewWebClient(cfg)
+	first, err := client.FetchBookmarks(ctx, "", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("first page: %d posts; cursor=%t", len(first.Posts), first.Cursor != "")
+	if len(first.Posts) == 0 {
+		t.Fatal("bookmarks returned no posts; the account has bookmarks, so an empty page means the variables or the parser are wrong")
+	}
+	if first.Cursor == "" {
+		t.Fatal("no bottom cursor; pagination would dead-end after the first page")
+	}
+
+	second, err := client.FetchBookmarks(ctx, first.Cursor, 10)
+	if err != nil {
+		t.Fatalf("second page with cursor %q: %v", first.Cursor, err)
+	}
+	t.Logf("second page: %d posts", len(second.Posts))
+	if len(second.Posts) > 0 && second.Posts[0].ID == first.Posts[0].ID {
+		t.Fatal("cursor did not advance; the second page repeats the first")
+	}
+
+	// A discovered id that never reaches the config is not an error the caller
+	// can see: it just silently re-discovers on every launch.
+	if cfg.BookmarksQID == "" {
+		if !client.ApplyRefreshedQueryIDs(cfg) {
+			t.Fatal("discovered a query id to reach the endpoint but nothing was staged for persistence")
+		}
+		if cfg.BookmarksQID == "" {
+			t.Fatal("ApplyRefreshedQueryIDs reported work but left BookmarksQID empty")
+		}
+		t.Logf("discovered bookmarks query id staged for persistence (len=%d)", len(cfg.BookmarksQID))
+	}
+}

--- a/pkg/api/bookmarks_test.go
+++ b/pkg/api/bookmarks_test.go
@@ -1,0 +1,213 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/melqtx/xeet/pkg/config"
+)
+
+const bookmarksFixture = `{
+  "data": {
+    "bookmark_timeline_v2": {
+      "timeline": {
+        "instructions": [{
+          "type": "TimelineAddEntries",
+          "entries": [
+            {
+              "entryId": "tweet-1",
+              "content": {
+                "entryType": "TimelineTimelineItem",
+                "itemContent": {
+                  "tweet_results": {
+                    "result": {
+                      "rest_id": "1",
+                      "legacy": {"full_text": "saved post"},
+                      "core": {
+                        "user_results": {
+                          "result": {
+                            "core": {"name": "Alice", "screen_name": "alice"}
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "entryId": "cursor-bottom-1",
+              "content": {
+                "entryType": "TimelineTimelineCursor",
+                "cursorType": "Bottom",
+                "value": "CURSOR_B1"
+              }
+            }
+          ]
+        }]
+      }
+    }
+  }
+}`
+
+func TestFetchBookmarksParsesPostsAndBottomCursorWithSpecifiedFirstPageVariables(t *testing.T) {
+	client := configuredBookmarksTestClient(t, func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/i/api/graphql/bookmarks-qid/Bookmarks" {
+			t.Fatalf("path = %q, want Bookmarks GraphQL path", req.URL.Path)
+		}
+		variables := decodeBookmarkVariables(t, req)
+		if variables["count"] != float64(25) {
+			t.Fatalf("variables.count = %#v, want 25", variables["count"])
+		}
+		if promoted, ok := variables["includePromotedContent"].(bool); !ok || promoted {
+			t.Fatalf("variables.includePromotedContent = %#v, want false", variables["includePromotedContent"])
+		}
+		if _, ok := variables["cursor"]; ok {
+			t.Fatalf("first-page variables unexpectedly contain cursor: %#v", variables)
+		}
+		return response(http.StatusOK, bookmarksFixture), nil
+	})
+
+	page, err := client.FetchBookmarks(context.Background(), "", 25)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Posts) != 1 || page.Posts[0].ID != "1" || page.Posts[0].Text != "saved post" {
+		t.Fatalf("posts = %+v", page.Posts)
+	}
+	if page.Cursor != "CURSOR_B1" {
+		t.Fatalf("cursor = %q, want CURSOR_B1", page.Cursor)
+	}
+}
+
+func TestFetchBookmarksPassesCursorThroughToGraphQLVariables(t *testing.T) {
+	client := configuredBookmarksTestClient(t, func(req *http.Request) (*http.Response, error) {
+		variables := decodeBookmarkVariables(t, req)
+		if variables["cursor"] != "abc" {
+			t.Fatalf("variables.cursor = %#v, want abc", variables["cursor"])
+		}
+		return response(http.StatusOK, bookmarksFixture), nil
+	})
+
+	if _, err := client.FetchBookmarks(context.Background(), "abc", 30); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFetchBookmarksClampsInvalidCountsToThirty(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		count int
+	}{
+		{name: "zero", count: 0},
+		{name: "over-maximum", count: 500},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			client := configuredBookmarksTestClient(t, func(req *http.Request) (*http.Response, error) {
+				variables := decodeBookmarkVariables(t, req)
+				if variables["count"] != float64(30) {
+					t.Fatalf("variables.count = %#v, want 30", variables["count"])
+				}
+				return response(http.StatusOK, bookmarksFixture), nil
+			})
+
+			if _, err := client.FetchBookmarks(context.Background(), "", test.count); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestFetchBookmarksDiscoversMissingQueryIDBeforeFirstRequestAndExposesItForPersistence(t *testing.T) {
+	requests := 0
+	client := NewWebClient(&config.Config{AuthToken: "auth", CT0: "csrf"})
+	client.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if !strings.Contains(req.URL.Path, "/fresh-bookmarks/Bookmarks") {
+			t.Fatalf("path = %q", req.URL.Path)
+		}
+		return response(http.StatusOK, bookmarksFixture), nil
+	})}
+	client.discover = func(_ context.Context, auth, ct0, operation string) (string, error) {
+		if auth != "auth" || ct0 != "csrf" || operation != bookmarksOperation {
+			t.Fatalf("discovery args = auth:%q ct0:%q operation:%q", auth, ct0, operation)
+		}
+		return "fresh-bookmarks", nil
+	}
+
+	if _, err := client.FetchBookmarks(context.Background(), "", 30); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{}
+	if requests != 1 || !client.ApplyRefreshedQueryIDs(cfg) || cfg.BookmarksQID != "fresh-bookmarks" {
+		t.Fatalf("requests=%d config=%+v", requests, cfg)
+	}
+}
+
+func TestFetchBookmarksRebuildsIdenticalVariablesAfterQueryIDRefresh(t *testing.T) {
+	var requests []map[string]any
+	client := configuredBookmarksTestClient(t, func(req *http.Request) (*http.Response, error) {
+		requests = append(requests, decodeBookmarkVariables(t, req))
+		if len(requests) == 1 {
+			return response(http.StatusNotFound, `{}`), nil
+		}
+		if !strings.Contains(req.URL.Path, "/fresh-bookmarks/Bookmarks") {
+			t.Fatalf("refreshed path = %q", req.URL.Path)
+		}
+		return response(http.StatusOK, bookmarksFixture), nil
+	})
+	client.discover = func(context.Context, string, string, string) (string, error) {
+		return "fresh-bookmarks", nil
+	}
+
+	if _, err := client.FetchBookmarks(context.Background(), "abc", 25); err != nil {
+		t.Fatal(err)
+	}
+	if len(requests) != 2 || !reflect.DeepEqual(requests[0], requests[1]) {
+		t.Fatalf("variables changed across query-id refresh: %#v", requests)
+	}
+}
+
+func TestFetchBookmarksRejectsMissingSessionBeforeAnyRequest(t *testing.T) {
+	requests := 0
+	client := NewWebClient(&config.Config{BookmarksQID: "bookmarks-qid"})
+	client.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		return response(http.StatusOK, bookmarksFixture), nil
+	})}
+
+	if _, err := client.FetchBookmarks(context.Background(), "", 30); err == nil {
+		t.Fatal("FetchBookmarks succeeded without a session")
+	}
+	if requests != 0 {
+		t.Fatalf("requests = %d, want 0", requests)
+	}
+}
+
+func configuredBookmarksTestClient(t *testing.T, handler func(*http.Request) (*http.Response, error)) *WebClient {
+	t.Helper()
+	client := NewWebClient(&config.Config{
+		AuthToken:    "auth",
+		CT0:          "csrf",
+		BookmarksQID: "bookmarks-qid",
+	})
+	client.httpClient = &http.Client{Transport: roundTripFunc(handler)}
+	return client
+}
+
+func decodeBookmarkVariables(t *testing.T, req *http.Request) map[string]any {
+	t.Helper()
+	raw := req.URL.Query().Get("variables")
+	if raw == "" {
+		t.Fatal("request has no variables parameter")
+	}
+	var variables map[string]any
+	if err := json.Unmarshal([]byte(raw), &variables); err != nil {
+		t.Fatalf("decode variables %q: %v", raw, err)
+	}
+	return variables
+}

--- a/pkg/api/discover.go
+++ b/pkg/api/discover.go
@@ -109,6 +109,9 @@ func operationHint(operation string) string {
 	if strings.Contains(operation, "Home") {
 		return "HomeTimeline"
 	}
+	if operation == "SearchTimeline" {
+		return "SearchTimeline"
+	}
 	if strings.Contains(operation, "Tweet") {
 		return "Compose"
 	}

--- a/pkg/api/discover_test.go
+++ b/pkg/api/discover_test.go
@@ -45,6 +45,26 @@ func TestFindOperationQID(t *testing.T) {
 	}
 }
 
+func TestOperationHintSelectsTheBundleForEachOperationFamily(t *testing.T) {
+	tests := []struct {
+		operation string
+		want      string
+	}{
+		{operation: "TweetDetail", want: "TweetDetail"},
+		{operation: "HomeTimeline", want: "HomeTimeline"},
+		{operation: "CreateTweet", want: "Compose"},
+		{operation: "SearchTimeline", want: "SearchTimeline"},
+		{operation: "Bookmarks", want: "Bookmarks"},
+	}
+	for _, test := range tests {
+		t.Run(test.operation, func(t *testing.T) {
+			if got := operationHint(test.operation); got != test.want {
+				t.Fatalf("operationHint(%q) = %q, want %q", test.operation, got, test.want)
+			}
+		})
+	}
+}
+
 func TestWebpackChunkURLs(t *testing.T) {
 	runtime := `69195:"bundle.HomeTimeline",73796:"shared~bundle.LoggedInMain~bundle.HomeTimeline",69195:"0f610dc",73796:"e992705"`
 	urls := webpackChunkURLs(runtime, "HomeTimeline")

--- a/pkg/api/search.go
+++ b/pkg/api/search.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"strings"
+)
+
+const searchOperation = "SearchTimeline"
+
+// FetchSearchTimeline returns a page of search results for query.
+func (c *WebClient) FetchSearchTimeline(ctx context.Context, query, cursor string, count int) (*TimelinePage, error) {
+	if strings.TrimSpace(query) == "" {
+		return nil, errors.New("search query is empty")
+	}
+	// Unlike the home, following, and bookmark timelines, SearchTimeline answers
+	// 404 with an empty body when the transaction header is missing, so the
+	// header is not optional here despite this being a read.
+	return c.fetchTimelineOp(ctx, searchOperation, "", "XEET_SEARCHTIMELINE_QID", count, true,
+		func(count int) map[string]any {
+			variables := map[string]any{
+				"rawQuery":    query,
+				"count":       count,
+				"querySource": "typed_query",
+				"product":     "Top",
+			}
+			if cursor != "" {
+				variables["cursor"] = cursor
+			}
+			return variables
+		})
+}

--- a/pkg/api/search_live_test.go
+++ b/pkg/api/search_live_test.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/melqtx/xeet/pkg/config"
+)
+
+func TestSearchTimelineLive(t *testing.T) {
+	if os.Getenv("XEET_LIVE_SEARCH") != "1" {
+		t.Skip("set XEET_LIVE_SEARCH=1 to run")
+	}
+	mgr, err := config.NewConfigManager()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := mgr.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+	defer cancel()
+	client := NewWebClient(cfg)
+	first, err := client.FetchSearchTimeline(ctx, "golang", "", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("first page: %d posts; cursor=%t", len(first.Posts), first.Cursor != "")
+	if len(first.Posts) == 0 {
+		t.Fatal("search returned no posts; a popular query returning nothing means the variables or the entry walker are wrong")
+	}
+	if first.Cursor == "" {
+		t.Fatal("no bottom cursor; pagination would dead-end after the first page")
+	}
+
+	second, err := client.FetchSearchTimeline(ctx, "golang", first.Cursor, 10)
+	if err != nil {
+		t.Fatalf("second page with cursor %q: %v", first.Cursor, err)
+	}
+	t.Logf("second page: %d posts", len(second.Posts))
+	if len(second.Posts) > 0 && second.Posts[0].ID == first.Posts[0].ID {
+		t.Fatal("cursor did not advance; the second page repeats the first")
+	}
+
+	// operationHint used to route anything containing "Tweet" to the composer
+	// bundle, which silently starved SearchTimeline of a query id.
+	if cfg.SearchTimelineQID == "" {
+		if !client.ApplyRefreshedQueryIDs(cfg) {
+			t.Fatal("reached the endpoint but staged no query id for persistence")
+		}
+		if cfg.SearchTimelineQID == "" {
+			t.Fatal("ApplyRefreshedQueryIDs reported work but left SearchTimelineQID empty")
+		}
+		t.Logf("discovered search query id staged for persistence (len=%d)", len(cfg.SearchTimelineQID))
+	}
+}

--- a/pkg/api/search_test.go
+++ b/pkg/api/search_test.go
@@ -1,0 +1,233 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/melqtx/xeet/pkg/config"
+)
+
+const searchFixture = `{
+  "data": {
+    "search_by_raw_query": {
+      "search_timeline": {
+        "timeline": {
+          "instructions": [{
+            "type": "TimelineAddEntries",
+            "entries": [
+              {
+                "entryId": "tweet-direct",
+                "content": {
+                  "entryType": "TimelineTimelineItem",
+                  "itemContent": {
+                    "tweet_results": {
+                      "result": {
+                        "rest_id": "direct",
+                        "legacy": {"full_text": "direct result"}
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "entryId": "search-conversation",
+                "content": {
+                  "entryType": "TimelineTimelineModule",
+                  "items": [{
+                    "entryId": "search-conversation-module",
+                    "item": {
+                      "itemContent": {
+                        "tweet_results": {
+                          "result": {
+                            "rest_id": "module",
+                            "legacy": {"full_text": "module result"}
+                          }
+                        }
+                      }
+                    }
+                  }]
+                }
+              },
+              {
+                "entryId": "cursor-bottom",
+                "content": {
+                  "entryType": "TimelineTimelineCursor",
+                  "cursorType": "Bottom",
+                  "value": "CURSOR_S1"
+                }
+              }
+            ]
+          }]
+        }
+      }
+    }
+  }
+}`
+
+func TestFetchSearchTimelineParsesDirectAndModuleResultsInEntryOrder(t *testing.T) {
+	client := configuredSearchTestClient(t, func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/i/api/graphql/search-qid/SearchTimeline" {
+			t.Fatalf("path = %q, want SearchTimeline GraphQL path", req.URL.Path)
+		}
+		variables := decodeSearchVariables(t, req)
+		for name, want := range map[string]any{
+			"rawQuery":    "go tui",
+			"count":       float64(25),
+			"product":     "Top",
+			"querySource": "typed_query",
+		} {
+			if got := variables[name]; got != want {
+				t.Fatalf("variables.%s = %#v, want %#v", name, got, want)
+			}
+		}
+		if _, ok := variables["cursor"]; ok {
+			t.Fatalf("first-page variables unexpectedly contain cursor: %#v", variables)
+		}
+		return response(http.StatusOK, searchFixture), nil
+	})
+
+	page, err := client.FetchSearchTimeline(context.Background(), "go tui", "", 25)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if page.Cursor != "CURSOR_S1" {
+		t.Fatalf("cursor = %q, want CURSOR_S1", page.Cursor)
+	}
+	if len(page.Posts) != 2 {
+		t.Fatalf("posts = %+v", page.Posts)
+	}
+	for i, want := range []struct {
+		id   string
+		text string
+	}{
+		{id: "direct", text: "direct result"},
+		{id: "module", text: "module result"},
+	} {
+		if page.Posts[i].ID != want.id || page.Posts[i].Text != want.text {
+			t.Fatalf("post %d = %+v, want id=%q text=%q", i, page.Posts[i], want.id, want.text)
+		}
+	}
+}
+
+func TestFetchSearchTimelinePassesCursorThroughToGraphQLVariables(t *testing.T) {
+	client := configuredSearchTestClient(t, func(req *http.Request) (*http.Response, error) {
+		variables := decodeSearchVariables(t, req)
+		if variables["cursor"] != "next-page" {
+			t.Fatalf("variables.cursor = %#v, want next-page", variables["cursor"])
+		}
+		return response(http.StatusOK, searchFixture), nil
+	})
+
+	if _, err := client.FetchSearchTimeline(context.Background(), "go", "next-page", 30); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFetchSearchTimelineRejectsEmptyQueryBeforeAnyRequest(t *testing.T) {
+	requests := 0
+	client := configuredSearchTestClient(t, func(req *http.Request) (*http.Response, error) {
+		requests++
+		return response(http.StatusOK, searchFixture), nil
+	})
+
+	_, err := client.FetchSearchTimeline(context.Background(), " \t\n", "", 30)
+	if err == nil || err.Error() != "search query is empty" {
+		t.Fatalf("error = %v, want search query is empty", err)
+	}
+	if requests != 0 {
+		t.Fatalf("requests = %d, want 0", requests)
+	}
+}
+
+func TestFetchSearchTimelineDiscoversAndExposesMissingQueryIDForPersistence(t *testing.T) {
+	requests := 0
+	client := NewWebClient(&config.Config{AuthToken: "auth", CT0: "csrf"})
+	client.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if !strings.Contains(req.URL.Path, "/fresh-search/SearchTimeline") {
+			t.Fatalf("path = %q", req.URL.Path)
+		}
+		return response(http.StatusOK, searchFixture), nil
+	})}
+	client.discover = func(_ context.Context, auth, ct0, operation string) (string, error) {
+		if auth != "auth" || ct0 != "csrf" || operation != searchOperation {
+			t.Fatalf("discovery args = auth:%q ct0:%q operation:%q", auth, ct0, operation)
+		}
+		return "fresh-search", nil
+	}
+	client.transactionID = func(context.Context, string, string) (string, error) {
+		return "stub-transaction-id", nil
+	}
+
+	if _, err := client.FetchSearchTimeline(context.Background(), "go", "", 30); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{}
+	if requests != 1 || !client.ApplyRefreshedQueryIDs(cfg) || cfg.SearchTimelineQID != "fresh-search" {
+		t.Fatalf("requests=%d config=%+v", requests, cfg)
+	}
+}
+
+func configuredSearchTestClient(t *testing.T, handler func(*http.Request) (*http.Response, error)) *WebClient {
+	t.Helper()
+	client := NewWebClient(&config.Config{
+		AuthToken:         "auth",
+		CT0:               "csrf",
+		SearchTimelineQID: "search-qid",
+	})
+	client.httpClient = &http.Client{Transport: roundTripFunc(handler)}
+	// The real generator derives its key by fetching x.com, which the stubbed
+	// transport would answer with search fixtures.
+	client.transactionID = func(context.Context, string, string) (string, error) {
+		return "stub-transaction-id", nil
+	}
+	return client
+}
+
+func decodeSearchVariables(t *testing.T, req *http.Request) map[string]any {
+	t.Helper()
+	raw := req.URL.Query().Get("variables")
+	if raw == "" {
+		t.Fatal("request has no variables parameter")
+	}
+	var variables map[string]any
+	if err := json.Unmarshal([]byte(raw), &variables); err != nil {
+		t.Fatalf("decode variables %q: %v", raw, err)
+	}
+	return variables
+}
+
+func TestFetchSearchTimelineSendsTransactionHeaderThatBookmarksOmits(t *testing.T) {
+	var searchHeader string
+	search := configuredSearchTestClient(t, func(req *http.Request) (*http.Response, error) {
+		searchHeader = req.Header.Get("X-Client-Transaction-Id")
+		return response(http.StatusOK, searchFixture), nil
+	})
+	if _, err := search.FetchSearchTimeline(context.Background(), "go tui", "", 25); err != nil {
+		t.Fatal(err)
+	}
+	// X answers SearchTimeline with a bodyless 404 when this header is absent,
+	// which is indistinguishable from a dead endpoint at the call site.
+	if searchHeader == "" {
+		t.Fatal("search sent no X-Client-Transaction-Id; the live endpoint would 404")
+	}
+
+	var bookmarksHeader string
+	bookmarks := NewWebClient(&config.Config{AuthToken: "auth", CT0: "csrf", BookmarksQID: "bookmarks-qid"})
+	bookmarks.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		bookmarksHeader = req.Header.Get("X-Client-Transaction-Id")
+		return response(http.StatusOK, searchFixture), nil
+	})}
+	bookmarks.transactionID = func(context.Context, string, string) (string, error) {
+		return "stub-transaction-id", nil
+	}
+	if _, err := bookmarks.FetchBookmarks(context.Background(), "", 25); err != nil {
+		t.Fatal(err)
+	}
+	if bookmarksHeader != "" {
+		t.Fatalf("bookmarks sent X-Client-Transaction-Id = %q; only search needs it and minting one costs a round trip", bookmarksHeader)
+	}
+}

--- a/pkg/api/timeline.go
+++ b/pkg/api/timeline.go
@@ -112,7 +112,7 @@ func (c *WebClient) FetchFollowingTimeline(ctx context.Context, cursor string, c
 }
 
 func (c *WebClient) fetchTimeline(ctx context.Context, operation, fallback, environment, cursor string, count int) (*TimelinePage, error) {
-	return c.fetchTimelineOp(ctx, operation, fallback, environment, count, func(count int) map[string]any {
+	return c.fetchTimelineOp(ctx, operation, fallback, environment, count, false, func(count int) map[string]any {
 		return timelineVariables(cursor, count)
 	})
 }
@@ -121,6 +121,7 @@ func (c *WebClient) fetchTimelineOp(
 	ctx context.Context,
 	operation, fallback, environment string,
 	count int,
+	withTransactionID bool,
 	buildVars func(count int) map[string]any,
 ) (*TimelinePage, error) {
 	if c.authToken == "" || c.ct0 == "" {
@@ -138,7 +139,7 @@ func (c *WebClient) fetchTimelineOp(
 		qid = fresh
 	}
 
-	res, err := c.doTimelineOp(ctx, operation, qid, buildVars(count))
+	res, err := c.doTimelineOp(ctx, operation, qid, buildVars(count), withTransactionID)
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +148,7 @@ func (c *WebClient) fetchTimelineOp(
 		if discoverErr != nil {
 			return nil, fmt.Errorf("home timeline endpoint changed and discovery failed: %w", discoverErr)
 		}
-		res, err = c.doTimelineOp(ctx, operation, fresh, buildVars(count))
+		res, err = c.doTimelineOp(ctx, operation, fresh, buildVars(count), withTransactionID)
 		if err != nil {
 			return nil, err
 		}
@@ -195,7 +196,7 @@ func timelineVariables(cursor string, count int) map[string]any {
 
 // Timeline reads are idempotent, so transient failures are retried here; the
 // mutation paths deliberately are not.
-func (c *WebClient) doTimelineOp(ctx context.Context, operation, qid string, variables map[string]any) (*httpResult, error) {
+func (c *WebClient) doTimelineOp(ctx context.Context, operation, qid string, variables map[string]any, withTransactionID bool) (*httpResult, error) {
 	variablesJSON, _ := json.Marshal(variables)
 	featuresJSON, _ := json.Marshal(timelineFeatures)
 	fieldTogglesJSON, _ := json.Marshal(timelineFieldToggles)
@@ -211,26 +212,88 @@ func (c *WebClient) doTimelineOp(ctx context.Context, operation, qid string, var
 			return nil, err
 		}
 		c.setHeaders(req)
+		// The id is derived from the method, path, and current time, so it is
+		// minted per attempt rather than once per call: a retry that replays an
+		// earlier id is rejected exactly like a request that omits it.
+		if withTransactionID && c.transactionID != nil {
+			transactionID, err := c.transactionID(ctx, req.Method, req.URL.Path)
+			if err != nil {
+				return nil, fmt.Errorf("generate X transaction id: %w", err)
+			}
+			req.Header.Set("X-Client-Transaction-Id", transactionID)
+		}
 		return req, nil
 	}, true, 20<<20)
 }
 
 func parseTimeline(payload any) TimelinePage {
-	page := TimelinePage{}
+	posts, bottomCursor := parseEntries(payload)
+	return TimelinePage{Posts: posts, Cursor: bottomCursor}
+}
+
+// This deliberately duplicates parseConversation's walker instead of sharing
+// it: conversation.go changes frequently upstream, and coupling the two would
+// make rebases costlier without changing conversation behavior.
+func parseEntries(payload any) (posts []TimelinePost, bottomCursor string) {
 	seen := map[string]bool{}
+
+	parseItemContent := func(raw any) {
+		item, ok := raw.(map[string]any)
+		if !ok {
+			return
+		}
+		if post, ok := parseTimelineItem(item); ok && !seen[post.ID] {
+			seen[post.ID] = true
+			posts = append(posts, post)
+		}
+	}
+
+	parseCursor := func(item map[string]any) {
+		cursorType, _ := item["cursorType"].(string)
+		kind := strings.ToLower(cursorType)
+		if kind == "bottom" || strings.Contains(kind, "showmore") {
+			if value, _ := item["value"].(string); value != "" {
+				bottomCursor = value
+			}
+		}
+	}
+
+	parseEntry := func(raw any) {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			return
+		}
+		content, _ := entry["content"].(map[string]any)
+		if content == nil {
+			content = entry
+		}
+		parseCursor(content)
+		if item, ok := content["itemContent"].(map[string]any); ok {
+			parseCursor(item)
+			parseItemContent(item)
+		}
+		if items, ok := content["items"].([]any); ok {
+			for _, rawItem := range items {
+				moduleItem, _ := rawItem.(map[string]any)
+				item, _ := moduleItem["item"].(map[string]any)
+				if item == nil {
+					item = moduleItem
+				}
+				if itemContent, ok := item["itemContent"].(map[string]any); ok {
+					parseCursor(itemContent)
+					parseItemContent(itemContent)
+				}
+			}
+		}
+	}
+
 	var walk func(any)
 	walk = func(node any) {
 		switch value := node.(type) {
 		case map[string]any:
-			if cursorType, _ := value["cursorType"].(string); strings.EqualFold(cursorType, "Bottom") {
-				if cursor, _ := value["value"].(string); cursor != "" {
-					page.Cursor = cursor
-				}
-			}
-			if item, ok := value["itemContent"].(map[string]any); ok {
-				if post, ok := parseTimelineItem(item); ok && !seen[post.ID] {
-					seen[post.ID] = true
-					page.Posts = append(page.Posts, post)
+			if entries, ok := value["entries"].([]any); ok {
+				for _, entry := range entries {
+					parseEntry(entry)
 				}
 				return
 			}
@@ -244,7 +307,7 @@ func parseTimeline(payload any) TimelinePage {
 		}
 	}
 	walk(payload)
-	return page
+	return posts, bottomCursor
 }
 
 func parseTimelineItem(item map[string]any) (TimelinePost, bool) {

--- a/pkg/api/timeline.go
+++ b/pkg/api/timeline.go
@@ -112,6 +112,17 @@ func (c *WebClient) FetchFollowingTimeline(ctx context.Context, cursor string, c
 }
 
 func (c *WebClient) fetchTimeline(ctx context.Context, operation, fallback, environment, cursor string, count int) (*TimelinePage, error) {
+	return c.fetchTimelineOp(ctx, operation, fallback, environment, count, func(count int) map[string]any {
+		return timelineVariables(cursor, count)
+	})
+}
+
+func (c *WebClient) fetchTimelineOp(
+	ctx context.Context,
+	operation, fallback, environment string,
+	count int,
+	buildVars func(count int) map[string]any,
+) (*TimelinePage, error) {
 	if c.authToken == "" || c.ct0 == "" {
 		return nil, fmt.Errorf("no session; run 'xeet auth' first")
 	}
@@ -119,8 +130,15 @@ func (c *WebClient) fetchTimeline(ctx context.Context, operation, fallback, envi
 		count = 30
 	}
 	qid := c.operationQueryID(operation, fallback, environment)
+	if qid == "" {
+		fresh, discoverErr := c.discoverOperation(ctx, operation)
+		if discoverErr != nil {
+			return nil, fmt.Errorf("discover %s endpoint: %w", operation, discoverErr)
+		}
+		qid = fresh
+	}
 
-	res, err := c.doTimeline(ctx, operation, qid, cursor, count)
+	res, err := c.doTimelineOp(ctx, operation, qid, buildVars(count))
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +147,7 @@ func (c *WebClient) fetchTimeline(ctx context.Context, operation, fallback, envi
 		if discoverErr != nil {
 			return nil, fmt.Errorf("home timeline endpoint changed and discovery failed: %w", discoverErr)
 		}
-		res, err = c.doTimeline(ctx, operation, fresh, cursor, count)
+		res, err = c.doTimelineOp(ctx, operation, fresh, buildVars(count))
 		if err != nil {
 			return nil, err
 		}
@@ -159,8 +177,7 @@ func (c *WebClient) fetchTimeline(ctx context.Context, operation, fallback, envi
 	return &page, nil
 }
 
-// doTimeline is a read, so transient failures are retried.
-func (c *WebClient) doTimeline(ctx context.Context, operation, qid, cursor string, count int) (*httpResult, error) {
+func timelineVariables(cursor string, count int) map[string]any {
 	variables := map[string]any{
 		"count":                  count,
 		"includePromotedContent": true,
@@ -173,6 +190,12 @@ func (c *WebClient) doTimeline(ctx context.Context, operation, qid, cursor strin
 		variables["cursor"] = cursor
 		variables["requestContext"] = "scroll"
 	}
+	return variables
+}
+
+// Timeline reads are idempotent, so transient failures are retried here; the
+// mutation paths deliberately are not.
+func (c *WebClient) doTimelineOp(ctx context.Context, operation, qid string, variables map[string]any) (*httpResult, error) {
 	variablesJSON, _ := json.Marshal(variables)
 	featuresJSON, _ := json.Marshal(timelineFeatures)
 	fieldTogglesJSON, _ := json.Marshal(timelineFieldToggles)

--- a/pkg/api/timeline_test.go
+++ b/pkg/api/timeline_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestParseTimeline(t *testing.T) {
-	fixture := `[
+	fixture := `{"entries":[
 	  {"itemContent":{"tweet_results":{"result":{
 	    "rest_id":"1",
 	    "legacy":{"full_text":"hello timeline","reply_count":2,"retweet_count":3,"favorite_count":4,"favorited":true,"created_at":"Mon Jul 20 10:00:00 +0000 2026","extended_entities":{"media":[{"type":"photo","media_url_https":"https://pbs.twimg.com/media/abc","ext_alt_text":"a cat","original_info":{"width":1200,"height":800}}]}},
@@ -19,7 +19,7 @@ func TestParseTimeline(t *testing.T) {
 	    "core":{"user_results":{"result":{"legacy":{"name":"Bob","screen_name":"bob"}}}}
 	  }}}}},
 	  {"cursorType":"Bottom","value":"next-page"}
-	]`
+	]}`
 	var payload any
 	if err := json.Unmarshal([]byte(fixture), &payload); err != nil {
 		t.Fatal(err)
@@ -53,18 +53,18 @@ func TestParseTimelineUnescapesText(t *testing.T) {
 
 func TestParseTimelineDeduplicatesTweet(t *testing.T) {
 	item := map[string]any{"itemContent": map[string]any{"tweet_results": map[string]any{"result": map[string]any{"rest_id": "1", "legacy": map[string]any{"full_text": "same"}}}}}
-	page := parseTimeline([]any{item, item})
+	page := parseTimeline(map[string]any{"entries": []any{item, item}})
 	if len(page.Posts) != 1 {
 		t.Fatalf("got %d posts", len(page.Posts))
 	}
 }
 
 func TestParseTimelineSkipsDeletedAndPromotedPosts(t *testing.T) {
-	fixture := `{"data":{"timeline":[
+	fixture := `{"data":{"timeline":{"entries":[
 	  {"itemContent":{"tweet_results":{"result":{"__typename":"TweetTombstone","tombstone":{"text":{"text":"deleted"}}}}}},
 	  {"itemContent":{"promoted_metadata":{},"tweet_results":{"result":{"rest_id":"ad","legacy":{"full_text":"ad"}}}}},
 	  {"itemContent":{"tweet_results":{"result":{"rest_id":"ok","legacy":{"full_text":"real post"}}}}}
-	]}}`
+	]}}}`
 	var payload any
 	if err := json.Unmarshal([]byte(fixture), &payload); err != nil {
 		t.Fatal(err)
@@ -76,10 +76,10 @@ func TestParseTimelineSkipsDeletedAndPromotedPosts(t *testing.T) {
 }
 
 func TestParseTimelineVisibilityWrapper(t *testing.T) {
-	fixture := `{"itemContent":{"tweet_results":{"result":{"__typename":"TweetWithVisibilityResults","tweet":{
+	fixture := `{"entries":[{"itemContent":{"tweet_results":{"result":{"__typename":"TweetWithVisibilityResults","tweet":{
 	  "rest_id":"wrapped","legacy":{"full_text":"visible"},
 	  "core":{"user_results":{"result":{"core":{"name":"Alice","screen_name":"alice"}}}}
-	}}}}}`
+	}}}}}]}`
 	var payload any
 	if err := json.Unmarshal([]byte(fixture), &payload); err != nil {
 		t.Fatal(err)
@@ -91,13 +91,13 @@ func TestParseTimelineVisibilityWrapper(t *testing.T) {
 }
 
 func TestParseTimelineMultipleImages(t *testing.T) {
-	fixture := `{"itemContent":{"tweet_results":{"result":{
+	fixture := `{"entries":[{"itemContent":{"tweet_results":{"result":{
 	  "rest_id":"photos","legacy":{"full_text":"album","extended_entities":{"media":[
 	    {"type":"photo","media_url_https":"https://pbs.twimg.com/media/a?format=jpg&name=small"},
 	    {"type":"photo","media_url_https":"https://pbs.twimg.com/media/b?format=png&name=small","ext_alt_text":"second image"},
 	    {"type":"photo"}
 	  ]}}
-	}}}}`
+	}}}}]}`
 	var payload any
 	if err := json.Unmarshal([]byte(fixture), &payload); err != nil {
 		t.Fatal(err)
@@ -108,5 +108,35 @@ func TestParseTimelineMultipleImages(t *testing.T) {
 	}
 	if page.Posts[0].Media[1].AltText != "second image" {
 		t.Fatalf("media = %+v", page.Posts[0].Media)
+	}
+}
+
+func TestParseTimelinePreservesDirectAndModuleItemOrderAndShowMoreCursor(t *testing.T) {
+	item := func(id string) map[string]any {
+		return map[string]any{"tweet_results": map[string]any{"result": map[string]any{
+			"rest_id": id,
+			"legacy":  map[string]any{"full_text": id},
+		}}}
+	}
+	payload := map[string]any{"data": map[string]any{"timeline": map[string]any{"entries": []any{
+		map[string]any{"content": map[string]any{"itemContent": item("direct")}},
+		map[string]any{"content": map[string]any{"items": []any{
+			map[string]any{"item": map[string]any{"itemContent": item("module-first")}},
+			map[string]any{"item": map[string]any{"itemContent": item("module-second")}},
+		}}},
+		map[string]any{"content": map[string]any{"cursorType": "ShowMoreThreads", "value": "next-module"}},
+	}}}}
+
+	page := parseTimeline(payload)
+	if page.Cursor != "next-module" {
+		t.Fatalf("cursor = %q, want next-module", page.Cursor)
+	}
+	if len(page.Posts) != 3 {
+		t.Fatalf("posts = %+v", page.Posts)
+	}
+	for i, want := range []string{"direct", "module-first", "module-second"} {
+		if page.Posts[i].ID != want {
+			t.Fatalf("post %d ID = %q, want %q", i, page.Posts[i].ID, want)
+		}
 	}
 }

--- a/pkg/api/web.go
+++ b/pkg/api/web.go
@@ -176,6 +176,7 @@ func NewWebClient(cfg *config.Config) *WebClient {
 		"CreateTweet":        cfg.CreateTweetQID,
 		"HomeTimeline":       cfg.HomeTimelineQID,
 		"HomeLatestTimeline": cfg.HomeLatestTimelineQID,
+		"Bookmarks":          cfg.BookmarksQID,
 		"FavoriteTweet":      cfg.FavoriteTweetQID,
 		"UnfavoriteTweet":    cfg.UnfavoriteTweetQID,
 		"Viewer":             cfg.ViewerQID,
@@ -247,6 +248,8 @@ func (c *WebClient) ApplyRefreshedQueryIDs(cfg *config.Config) bool {
 			cfg.HomeTimelineQID = qid
 		case "HomeLatestTimeline":
 			cfg.HomeLatestTimelineQID = qid
+		case "Bookmarks":
+			cfg.BookmarksQID = qid
 		case "FavoriteTweet":
 			cfg.FavoriteTweetQID = qid
 		case "UnfavoriteTweet":

--- a/pkg/api/web.go
+++ b/pkg/api/web.go
@@ -177,6 +177,7 @@ func NewWebClient(cfg *config.Config) *WebClient {
 		"HomeTimeline":       cfg.HomeTimelineQID,
 		"HomeLatestTimeline": cfg.HomeLatestTimelineQID,
 		"Bookmarks":          cfg.BookmarksQID,
+		"SearchTimeline":     cfg.SearchTimelineQID,
 		"FavoriteTweet":      cfg.FavoriteTweetQID,
 		"UnfavoriteTweet":    cfg.UnfavoriteTweetQID,
 		"Viewer":             cfg.ViewerQID,
@@ -250,6 +251,8 @@ func (c *WebClient) ApplyRefreshedQueryIDs(cfg *config.Config) bool {
 			cfg.HomeLatestTimelineQID = qid
 		case "Bookmarks":
 			cfg.BookmarksQID = qid
+		case "SearchTimeline":
+			cfg.SearchTimelineQID = qid
 		case "FavoriteTweet":
 			cfg.FavoriteTweetQID = qid
 		case "UnfavoriteTweet":

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	HomeTimelineQID       string    `yaml:"home_timeline_qid,omitempty"`
 	HomeLatestTimelineQID string    `yaml:"home_latest_timeline_qid,omitempty"`
 	BookmarksQID          string    `yaml:"bookmarks_qid,omitempty"`
+	SearchTimelineQID     string    `yaml:"search_timeline_qid,omitempty"`
 	FavoriteTweetQID      string    `yaml:"favorite_tweet_qid,omitempty"`
 	UnfavoriteTweetQID    string    `yaml:"unfavorite_tweet_qid,omitempty"`
 	ViewerQID             string    `yaml:"viewer_qid,omitempty"`
@@ -100,6 +101,7 @@ type fileConfig struct {
 	HomeTimelineQID       string `yaml:"home_timeline_qid,omitempty"`
 	HomeLatestTimelineQID string `yaml:"home_latest_timeline_qid,omitempty"`
 	BookmarksQID          string `yaml:"bookmarks_qid,omitempty"`
+	SearchTimelineQID     string `yaml:"search_timeline_qid,omitempty"`
 	FavoriteTweetQID      string `yaml:"favorite_tweet_qid,omitempty"`
 	UnfavoriteTweetQID    string `yaml:"unfavorite_tweet_qid,omitempty"`
 	ViewerQID             string `yaml:"viewer_qid,omitempty"`
@@ -145,6 +147,7 @@ func (cm *ConfigManager) Load() (*Config, error) {
 		HomeTimelineQID:       fc.HomeTimelineQID,
 		HomeLatestTimelineQID: fc.HomeLatestTimelineQID,
 		BookmarksQID:          fc.BookmarksQID,
+		SearchTimelineQID:     fc.SearchTimelineQID,
 		FavoriteTweetQID:      fc.FavoriteTweetQID,
 		UnfavoriteTweetQID:    fc.UnfavoriteTweetQID,
 		ViewerQID:             fc.ViewerQID,
@@ -247,6 +250,7 @@ func (cm *ConfigManager) Save(config *Config) error {
 			CreateTweetQID: config.CreateTweetQID, HomeTimelineQID: config.HomeTimelineQID,
 			HomeLatestTimelineQID: config.HomeLatestTimelineQID,
 			BookmarksQID:          config.BookmarksQID,
+			SearchTimelineQID:     config.SearchTimelineQID,
 			FavoriteTweetQID:      config.FavoriteTweetQID, UnfavoriteTweetQID: config.UnfavoriteTweetQID,
 			ViewerQID: config.ViewerQID, TweetDetailQID: config.TweetDetailQID,
 			Theme: config.Theme,
@@ -286,6 +290,7 @@ func fileConfigFor(config *Config) *fileConfig {
 		HomeTimelineQID:       config.HomeTimelineQID,
 		HomeLatestTimelineQID: config.HomeLatestTimelineQID,
 		BookmarksQID:          config.BookmarksQID,
+		SearchTimelineQID:     config.SearchTimelineQID,
 		FavoriteTweetQID:      config.FavoriteTweetQID,
 		UnfavoriteTweetQID:    config.UnfavoriteTweetQID,
 		ViewerQID:             config.ViewerQID,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	CreateTweetQID        string    `yaml:"create_tweet_qid"`
 	HomeTimelineQID       string    `yaml:"home_timeline_qid,omitempty"`
 	HomeLatestTimelineQID string    `yaml:"home_latest_timeline_qid,omitempty"`
+	BookmarksQID          string    `yaml:"bookmarks_qid,omitempty"`
 	FavoriteTweetQID      string    `yaml:"favorite_tweet_qid,omitempty"`
 	UnfavoriteTweetQID    string    `yaml:"unfavorite_tweet_qid,omitempty"`
 	ViewerQID             string    `yaml:"viewer_qid,omitempty"`
@@ -98,6 +99,7 @@ type fileConfig struct {
 	CreateTweetQID        string `yaml:"create_tweet_qid,omitempty"`
 	HomeTimelineQID       string `yaml:"home_timeline_qid,omitempty"`
 	HomeLatestTimelineQID string `yaml:"home_latest_timeline_qid,omitempty"`
+	BookmarksQID          string `yaml:"bookmarks_qid,omitempty"`
 	FavoriteTweetQID      string `yaml:"favorite_tweet_qid,omitempty"`
 	UnfavoriteTweetQID    string `yaml:"unfavorite_tweet_qid,omitempty"`
 	ViewerQID             string `yaml:"viewer_qid,omitempty"`
@@ -142,6 +144,7 @@ func (cm *ConfigManager) Load() (*Config, error) {
 		CreateTweetQID:        fc.CreateTweetQID,
 		HomeTimelineQID:       fc.HomeTimelineQID,
 		HomeLatestTimelineQID: fc.HomeLatestTimelineQID,
+		BookmarksQID:          fc.BookmarksQID,
 		FavoriteTweetQID:      fc.FavoriteTweetQID,
 		UnfavoriteTweetQID:    fc.UnfavoriteTweetQID,
 		ViewerQID:             fc.ViewerQID,
@@ -243,6 +246,7 @@ func (cm *ConfigManager) Save(config *Config) error {
 		return cm.writeFile(&fileConfig{
 			CreateTweetQID: config.CreateTweetQID, HomeTimelineQID: config.HomeTimelineQID,
 			HomeLatestTimelineQID: config.HomeLatestTimelineQID,
+			BookmarksQID:          config.BookmarksQID,
 			FavoriteTweetQID:      config.FavoriteTweetQID, UnfavoriteTweetQID: config.UnfavoriteTweetQID,
 			ViewerQID: config.ViewerQID, TweetDetailQID: config.TweetDetailQID,
 			Theme: config.Theme,
@@ -281,6 +285,7 @@ func fileConfigFor(config *Config) *fileConfig {
 		CreateTweetQID:        config.CreateTweetQID,
 		HomeTimelineQID:       config.HomeTimelineQID,
 		HomeLatestTimelineQID: config.HomeLatestTimelineQID,
+		BookmarksQID:          config.BookmarksQID,
 		FavoriteTweetQID:      config.FavoriteTweetQID,
 		UnfavoriteTweetQID:    config.UnfavoriteTweetQID,
 		ViewerQID:             config.ViewerQID,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -45,7 +45,8 @@ func TestSaveLoadRoundtrip(t *testing.T) {
 
 	in := &Config{
 		AuthToken: "tok123", CT0: "csrf456", CreateTweetQID: "qid789",
-		HomeTimelineQID: "home123", BookmarksQID: "bookmarks123", FavoriteTweetQID: "like123", UnfavoriteTweetQID: "unlike123", ViewerQID: "viewer123",
+		HomeTimelineQID: "home123", BookmarksQID: "bookmarks123", SearchTimelineQID: "search123",
+		FavoriteTweetQID: "like123", UnfavoriteTweetQID: "unlike123", ViewerQID: "viewer123",
 		TweetDetailQID: "detail123",
 		SessionBrowser: "Firefox", SessionProfile: "default-release", SessionDomain: "x.com",
 		SessionExpires:  time.Date(2027, 1, 2, 3, 4, 5, 0, time.UTC),
@@ -103,6 +104,22 @@ func TestSaveWithoutSessionPersistsBookmarksQueryID(t *testing.T) {
 	}
 	if cfg.BookmarksQID != "bookmarks123" {
 		t.Fatalf("BookmarksQID = %q, want bookmarks123", cfg.BookmarksQID)
+	}
+}
+
+func TestSaveWithoutSessionPersistsSearchTimelineQueryID(t *testing.T) {
+	dir := t.TempDir()
+	cm := newConfigManagerAt(dir, newFakeStore())
+
+	if err := cm.Save(&Config{SearchTimelineQID: "search123"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := cm.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.SearchTimelineQID != "search123" {
+		t.Fatalf("SearchTimelineQID = %q, want search123", cfg.SearchTimelineQID)
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -45,7 +45,7 @@ func TestSaveLoadRoundtrip(t *testing.T) {
 
 	in := &Config{
 		AuthToken: "tok123", CT0: "csrf456", CreateTweetQID: "qid789",
-		HomeTimelineQID: "home123", FavoriteTweetQID: "like123", UnfavoriteTweetQID: "unlike123", ViewerQID: "viewer123",
+		HomeTimelineQID: "home123", BookmarksQID: "bookmarks123", FavoriteTweetQID: "like123", UnfavoriteTweetQID: "unlike123", ViewerQID: "viewer123",
 		TweetDetailQID: "detail123",
 		SessionBrowser: "Firefox", SessionProfile: "default-release", SessionDomain: "x.com",
 		SessionExpires:  time.Date(2027, 1, 2, 3, 4, 5, 0, time.UTC),
@@ -87,6 +87,22 @@ func TestTokensNeverTouchDisk(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "Firefox") || !strings.Contains(string(data), "default-release") {
 		t.Fatalf("expected non-secret session source metadata, got:\n%s", data)
+	}
+}
+
+func TestSaveWithoutSessionPersistsBookmarksQueryID(t *testing.T) {
+	dir := t.TempDir()
+	cm := newConfigManagerAt(dir, newFakeStore())
+
+	if err := cm.Save(&Config{BookmarksQID: "bookmarks123"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := cm.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.BookmarksQID != "bookmarks123" {
+		t.Fatalf("BookmarksQID = %q, want bookmarks123", cfg.BookmarksQID)
 	}
 }
 


### PR DESCRIPTION
Adds two read-only feeds: bookmarks (`b`, `--bookmarks`) and search (`/`, `xeet search`).

Nothing here schedules, bulk-posts, scrapes, or automates engagement — both are one user-initiated read per keypress, and everything stays on `x.com`. Happy to close this if it is outside what you want xeet to be; the `SearchTimeline` finding below is worth having either way.

## The thing you'll want to know regardless of this PR

**`SearchTimeline` requires a per-request `X-Client-Transaction-Id`.** Without it X answers `404` with an empty body — no error message, no `Content-Type`. The home, following, and bookmark timelines do not need the header, so this is specific to search.

That failure is nastier than it sounds: an empty 404 is indistinguishable from a rotated query id at the call site, so `needsQueryIDRefresh` rediscovers, retries, gets another empty 404, and reports "endpoint changed and discovery failed". You would look at query-id discovery forever. What gave it away was `x-rate-limit-remaining` decrementing on the 404s — the endpoint was alive and deliberately rejecting us.

Verified by isolating it against a real session:

```
baseline                     -> 404, 0 bytes
referer = /search            -> 404, 0 bytes
x-client-transaction-id      -> 200, 37210 bytes
```

Reusing an id fails, so it is minted per attempt (including retries) rather than once per call. Only search opts in — the other feeds skip it because generating one costs a round trip they don't need.

`operationHint` also routed `SearchTimeline` to the composer bundle, since it matches `strings.Contains(operation, "Tweet")`. Fixed with an explicit case and a table test.

## The one behavioural change to existing feeds

`parseTimeline` walked the payload blindly for any `itemContent`. Search nests tweets inside conversation modules under `content.items[]`, which that walk never descends into, so it would have silently dropped a chunk of every result page. It now works from the instruction `entries` arrays and handles module items.

Because that changes how home/following/bookmarks parse too, I checked it against the live home timeline rather than trusting the tests: **35 posts before, 35 posts after**, twice each. The existing fixtures were bare `itemContent` objects that don't match a real response, so they now sit inside an `entries` array — assertions unchanged.

`parseConversation` keeps its own copy of the walker on purpose. It changes often here, and sharing would make your rebases costlier for no behaviour gain.

## Design

Feed identity was a `following bool`, which doesn't extend past two feeds, so the first commit turns it into a `FeedKind` enum. That commit is behaviour-preserving and stands alone if you want only that.

Search results are a **feed kind, not a screen** — only the prompt is a mode. That's what lets search reuse pagination, refresh, the stale-page guard, previews, likes, replies, and thread drill-down with no new message types and no changes to the viewport or selection code.

`f` still toggles for-you/following only. A four-way cycle on one key would make reaching a specific feed take up to three presses.

## Query ids

Both operations use the empty-fallback discover-on-first-use path `TweetDetail` already uses — no hardcoded ids. Discovered ids thread through every config load/save site so they persist instead of being rediscovered each launch. (Missing one of those sites is invisible at runtime: the feed works, it just spends a request every time. There's a test for it.)

## Verification

- `go build`, `go vet`, `go test -race`, and staticcheck v0.7.0 all clean. Two pre-existing failures in `internal/timeline` (`TestPreviewsPrefetchAroundSelection`, `TestUnselectedPostNearSelectionRendersCachedImage`) reproduce on unmodified main in my terminal and are untouched.
- Offline tests: request shape, variables, cursor pass-through, count clamping, query-id discovery and persistence, module descent and entry order, empty-query rejection with zero requests, and that search sends the transaction header while bookmarks doesn't.
- Live tests gated behind `XEET_LIVE_BOOKMARKS` / `XEET_LIVE_SEARCH`, matching the existing live tests. Both pass against a real account, including second-page cursor advance.
- Driven by hand in a real terminal: `/` from the feed and from inside a thread, esc, empty submit, `R` on a search feed, thread drill-down out of results.
