### PR TITLE
tests: stop the timeline suite from inheriting the developer's terminal

### DIFF
--- a/internal/timeline/main_test.go
+++ b/internal/timeline/main_test.go
@@ -1,0 +1,30 @@
+package timeline
+
+import (
+	"os"
+	"testing"
+)
+
+// The image mode is resolved from the environment, so without this the suite
+// asserts against whichever terminal the developer happens to be running in:
+// the same tests pass in Terminal.app and fail in Ghostty, kitty, WezTerm, and
+// iTerm2. Individual tests already scrubbed parts of this — see the SSH
+// variables in TestResolveImageModeInsideTmux — but a per-test list is only
+// ever as complete as the detection was on the day it was written.
+//
+// TERM is pinned rather than unset because lipgloss derives its color profile
+// from it, and an empty TERM would change rendered output everywhere.
+func TestMain(m *testing.M) {
+	os.Setenv("TERM", "xterm-256color")
+	for _, key := range []string{
+		"ZELLIJ", "TMUX",
+		"TERM_PROGRAM", "LC_TERMINAL",
+		"WEZTERM_PANE", "WEZTERM_EXECUTABLE",
+		"ITERM_SESSION_ID", "KITTY_WINDOW_ID",
+		"__CFBundleIdentifier",
+		"SSH_CLIENT", "SSH_CONNECTION", "SSH_TTY",
+	} {
+		os.Unsetenv(key)
+	}
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
`go test ./internal/timeline/` passes or fails depending on which terminal the developer is running it in:

| terminal | result on `main` |
| --- | --- |
| Ghostty, kitty | 2 failures |
| WezTerm, iTerm2 | 3 failures |
| Terminal.app, plain xterm, tmux | all pass |

```
--- FAIL: TestPreviewsPrefetchAroundSelection
    preview_test.go:380: prefetched 10 previews
--- FAIL: TestUnselectedPostNearSelectionRendersCachedImage
    view_test.go:93: image outside the inline radius rendered inline
--- FAIL: TestEmbeddedGhosttyHostDowngrades          (WezTerm / iTerm2 only)
```

**Nothing is wrong with the code they cover.** `New()` resolves the image mode from the environment, and native previews genuinely do widen the prefetch window and genuinely do keep cached images inline past `inlineImageRadius` — exactly as the comments beside those two branches say they should. The tests simply never asked for the mode whose behaviour they assert.

The third failure is the most telling one. `TestEmbeddedGhosttyHostDowngrades` already clears `ZELLIJ`, `TMUX`, `TERM_PROGRAM`, `TERM`, and `__CFBundleIdentifier` — but not `WEZTERM_PANE`, and the WezTerm branch in `resolveImageMode` is checked first, so on a WezTerm machine it never reaches the Ghostty logic it is testing. The intent was already there; a hand-maintained list is just only ever as complete as detection was on the day it was written. `TestResolveImageModeInsideTmux` says the same thing in its own comment:

> Cleared so the assertions below fail for the reason they claim even when the suite itself runs over ssh.

So this clears the variables once for the package instead.

### What this changes

One new file, `internal/timeline/main_test.go`. **No production code is touched.**

`TERM` is pinned rather than unset because lipgloss derives its color profile from it, and an empty `TERM` would change rendered output in tests that have nothing to do with images.

### Verification

Full package, six simulated environments, before and after:

| env | before | after |
| --- | --- | --- |
| Ghostty | 2 FAIL | ok |
| kitty | 2 FAIL | ok |
| WezTerm | 3 FAIL | ok |
| iTerm2 | 3 FAIL | ok |
| plain xterm | ok | ok |
| tmux | ok | ok |

The tests still catch real regressions rather than merely being silenced — with the fix applied:

| deliberate break | caught by |
| --- | --- |
| `showImage := abs(i-m.selected) <= inlineImageRadius` → `showImage := true` | `image outside the inline radius rendered inline` |
| `from := max(0, m.selected-prefetchBehind)` → `from := 0` | `prefetched 10 previews` |

(Worth noting separately: `TestPreviewsPrefetchAroundSelection` asserts `len(m.previews) != prefetchBehind+prefetchAhead+1`, so changing either constant moves both sides of the comparison and the test still passes. That is a pre-existing gap in what the test can detect and I have left it alone here.)
