### PR TITLE
polish search

### DIFF
--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -213,7 +213,7 @@ func NewWithImageMode(requested string) Model {
 	editor.SetWidth(60)
 	editor.SetHeight(6)
 	search := textinput.New()
-	search.Placeholder = "search"
+	search.Placeholder = `from:alice "terminal ui"`
 	search.CharLimit = 512
 	mode, note := resolveImageMode(requested)
 	return Model{
@@ -827,7 +827,8 @@ func (m *Model) resize() {
 	m.viewport.Height = viewportHeight
 	m.replyEditor.SetWidth(max(20, w-6))
 	m.replyEditor.SetHeight(min(7, max(3, m.height-16)))
-	m.searchInput.Width = max(20, w-6)
+	m.searchInput.Width = max(10, w-16)
+	m.searchInput.SetCursor(m.searchInput.Position())
 	m.syncViewport()
 	m.ensureSelectedVisible()
 }

--- a/internal/timeline/pty_test.go
+++ b/internal/timeline/pty_test.go
@@ -90,6 +90,9 @@ func TestTimelinePTYNavigationResizeAndHelp(t *testing.T) {
 
 	time.Sleep(120 * time.Millisecond)
 	writeKey("j")
+	writeKey("/")
+	writeKey("terminal cats")
+	writeKey("\x1b")
 	if err := pty.Setsize(terminal, &pty.Winsize{Rows: 15, Cols: 42}); err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +115,7 @@ func TestTimelinePTYNavigationResizeAndHelp(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 	output := captured.String()
-	for _, want := range []string{"xeet", "Alice", "timeline keys"} {
+	for _, want := range []string{"xeet", "Alice", "search posts", "timeline keys"} {
 		if !strings.Contains(output, want) {
 			t.Errorf("PTY output missing %q; output:\n%s", want, output)
 		}

--- a/internal/timeline/search.go
+++ b/internal/timeline/search.go
@@ -15,8 +15,14 @@ func (m *Model) beginSearch() tea.Cmd {
 }
 
 func (m Model) cancelSearch() (tea.Model, tea.Cmd) {
-	m.mode = m.searchReturn
 	m.searchInput.Blur()
+	// `xeet search` starts directly in an empty prompt. There is no previous
+	// feed to reveal in that case, so escape should leave instead of exposing
+	// an empty search-results screen.
+	if m.searchReturn == modeFeed && m.feed == FeedSearch && m.searchQuery == "" && len(m.posts) == 0 {
+		return m, tea.Quit
+	}
+	m.mode = m.searchReturn
 	m.syncViewport()
 	m.ensureSelectedVisible()
 	return m, m.imageRepaint(m.requestPreviews())

--- a/internal/timeline/search_test.go
+++ b/internal/timeline/search_test.go
@@ -1,6 +1,8 @@
 package timeline
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -148,16 +150,142 @@ func TestSearchViewAndHeaderExposeQueryWithinWidth(t *testing.T) {
 	m.beginSearch()
 
 	view := m.View()
-	for _, want := range []string{"search", "enter: search", "esc: cancel"} {
+	for _, want := range []string{"search posts", "type a query", "enter search", "esc results"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("search prompt missing %q:\n%s", want, view)
 		}
+	}
+	if width := maxLineWidth(view); width > m.width {
+		t.Fatalf("search prompt width=%d exceeds terminal width=%d:\n%s", width, m.width, view)
+	}
+	if lines := strings.Count(view, "\n") + 1; lines > m.height {
+		t.Fatalf("search prompt has %d lines in a %d-row terminal:\n%s", lines, m.height, view)
 	}
 
 	m.mode = modeFeed
 	header := m.header(m.contentWidth())
 	if width := maxLineWidth(header); width > m.contentWidth() {
 		t.Fatalf("search header width=%d exceeds content width=%d:\n%s", width, m.contentWidth(), header)
+	}
+}
+
+func TestSearchPromptExplainsWhereEscapeReturns(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		feed       FeedKind
+		returnMode mode
+		query      string
+		want       string
+	}{
+		{name: "for you", feed: FeedForYou, want: "esc back to for you"},
+		{name: "following", feed: FeedFollowing, want: "esc back to following"},
+		{name: "bookmarks", feed: FeedBookmarks, want: "esc back to bookmarks"},
+		{name: "results", feed: FeedSearch, query: "cats", want: "esc back to results"},
+		{name: "thread", feed: FeedSearch, returnMode: modeThread, query: "cats", want: "esc back to replies"},
+		{name: "fresh command", feed: FeedSearch, want: "esc quit"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			m := NewWithImageMode("off")
+			m.width = 80
+			m.height = 24
+			m.loading = false
+			m.feed = test.feed
+			m.searchQuery = test.query
+			m.mode = modeSearch
+			m.searchReturn = test.returnMode
+			if view := m.View(); !strings.Contains(view, test.want) {
+				t.Fatalf("search prompt missing %q:\n%s", test.want, view)
+			}
+		})
+	}
+}
+
+func TestFreshSearchCommandEscapeQuits(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.loading = false
+	m.feed = FeedSearch
+	m.mode = modeSearch
+	m.searchReturn = modeFeed
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = next.(Model)
+	if cmd == nil || m.searchInput.Focused() || m.mode != modeSearch {
+		t.Fatalf("fresh search escape did not quit cleanly: cmd=%v focused=%v mode=%v", cmd, m.searchInput.Focused(), m.mode)
+	}
+	if _, ok := cmd().(tea.QuitMsg); !ok {
+		t.Fatal("fresh search escape returned a non-quit command")
+	}
+}
+
+func TestSearchResultsHavePurposeBuiltLoadingEmptyAndErrorStates(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.width = 80
+	m.height = 24
+	m.resize()
+	m.feed = FeedSearch
+	m.searchQuery = "from:alice terminal ui"
+
+	if view := m.View(); !strings.Contains(view, "searching “from:alice terminal ui”…") ||
+		!strings.Contains(view, "/ edit search") {
+		t.Fatalf("search loading state is unclear:\n%s", view)
+	}
+
+	m.loading = false
+	if view := m.View(); !strings.Contains(view, "no posts found") ||
+		!strings.Contains(view, "try fewer words") ||
+		!strings.Contains(view, "f for you") {
+		t.Fatalf("search empty state is unclear:\n%s", view)
+	}
+
+	m.err = errors.New("offline")
+	if view := m.View(); !strings.Contains(view, "search couldn't reach X") ||
+		!strings.Contains(view, "R retry") ||
+		!strings.Contains(view, "/ edit search") {
+		t.Fatalf("search error state is unclear:\n%s", view)
+	}
+}
+
+func TestSearchResultsFooterPrioritizesEditingTheQuery(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.width = 80
+	m.loading = false
+	m.feed = FeedSearch
+	m.searchQuery = "cats"
+	m.posts = []api.TimelinePost{{ID: "1", Text: "cat"}}
+
+	footer := m.footer()
+	for _, want := range []string{"/ edit search", "R refresh", "enter replies"} {
+		if !strings.Contains(footer, want) {
+			t.Fatalf("search footer missing %q: %s", want, footer)
+		}
+	}
+}
+
+func TestSearchResultStatesStayInsideTerminal(t *testing.T) {
+	for _, size := range []struct{ width, height int }{{42, 15}, {80, 24}} {
+		for _, state := range []string{"loading", "empty", "error"} {
+			t.Run(fmt.Sprintf("%dx%d/%s", size.width, size.height, state), func(t *testing.T) {
+				m := NewWithImageMode("off")
+				m.feed = FeedSearch
+				m.searchQuery = strings.Repeat("猫 terminal ", 20)
+				m = update(t, m, tea.WindowSizeMsg{Width: size.width, Height: size.height})
+				switch state {
+				case "empty":
+					m.loading = false
+				case "error":
+					m.loading = false
+					m.err = errors.New("offline")
+				}
+
+				view := m.View()
+				if width := maxLineWidth(view); width > size.width {
+					t.Fatalf("view width=%d exceeds terminal width=%d:\n%s", width, size.width, view)
+				}
+				if lines := strings.Count(view, "\n") + 1; lines != size.height {
+					t.Fatalf("view has %d lines in a %d-row terminal:\n%s", lines, size.height, view)
+				}
+			})
+		}
 	}
 }
 

--- a/internal/timeline/view.go
+++ b/internal/timeline/view.go
@@ -37,15 +37,36 @@ func (m Model) View() string {
 
 	footer := m.footer()
 	if m.loading && len(m.posts) == 0 {
+		message := m.spinner.View() + " gathering xeets…"
+		loadingFooter := footer
+		if m.feed == FeedSearch {
+			query := ansi.Truncate(m.searchQuery, max(8, m.viewport.Width-20), "…")
+			message = m.spinner.View() + " searching “" + query + "”…"
+			loadingFooter = "/ edit search  ·  q quit"
+		}
 		center := lipgloss.Place(m.viewport.Width, m.viewport.Height, lipgloss.Center, lipgloss.Center,
-			lipgloss.NewStyle().Foreground(lavender).Render(m.spinner.View()+" gathering xeets…"))
-		return m.shell(center, footer)
+			lipgloss.NewStyle().Foreground(lavender).Render(message))
+		return m.shell(center, loadingFooter)
 	}
 	if m.err != nil && len(m.posts) == 0 {
+		title := "the cat lost the timeline"
+		errorFooter := m.errorFooter(true)
+		if m.feed == FeedSearch {
+			title = "search couldn't reach X"
+			errorFooter = m.searchErrorFooter(true)
+		}
 		center := lipgloss.Place(m.viewport.Width, m.viewport.Height, lipgloss.Center, lipgloss.Center,
 			lipgloss.NewStyle().Foreground(red).Width(max(20, m.viewport.Width-8)).Align(lipgloss.Center).
-				Render("the cat lost the timeline\n\n"+m.err.Error()))
-		return m.shell(center, m.errorFooter(true))
+				Render(title+"\n\n"+m.err.Error()))
+		return m.shell(center, errorFooter)
+	}
+	if m.feed == FeedSearch && len(m.posts) == 0 {
+		query := ansi.Truncate(m.searchQuery, max(8, m.viewport.Width-24), "…")
+		message := lipgloss.NewStyle().Foreground(bright).Bold(true).Render("no posts found") + "\n\n" +
+			lipgloss.NewStyle().Foreground(muted).Width(max(20, m.viewport.Width-8)).Align(lipgloss.Center).
+				Render("nothing matched “"+query+"”\ntry fewer words or remove a search operator")
+		center := lipgloss.Place(m.viewport.Width, m.viewport.Height, lipgloss.Center, lipgloss.Center, message)
+		return m.shell(center, m.searchEmptyFooter())
 	}
 	return m.shell(m.viewport.View(), footer)
 }
@@ -81,7 +102,7 @@ func (m Model) header(width int) string {
 	case FeedBookmarks:
 		status = "bookmarks"
 	case FeedSearch:
-		status = truncateRunes("search: "+m.searchQuery, max(9, width-12))
+		status = ansi.Truncate("search · “"+m.searchQuery+"”", max(9, width-12), "…")
 	}
 	if m.mode == modeThread {
 		status = "replies"
@@ -112,11 +133,26 @@ func (m Model) footer() string {
 		return m.toast
 	}
 	if m.err != nil {
+		if m.feed == FeedSearch {
+			return m.searchErrorFooter(false)
+		}
 		return m.errorFooter(false)
 	}
 	position := 0
 	if len(m.posts) > 0 {
 		position = m.selected + 1
+	}
+	if m.feed == FeedSearch {
+		var footer string
+		if m.expanded {
+			footer = fmt.Sprintf("%d/%d · / edit · e collapse · o browser · ? help", position, len(m.posts))
+		} else {
+			footer = fmt.Sprintf("%d/%d · / edit search · R refresh · enter replies · ? help", position, len(m.posts))
+		}
+		if ansi.StringWidth(footer) > m.contentWidth() {
+			return fmt.Sprintf("%d/%d · / edit · ? help", position, len(m.posts))
+		}
+		return footer
 	}
 	if m.contentWidth() < 50 || len(m.posts) == 0 {
 		return fmt.Sprintf("%d/%d  ·  ? help", position, len(m.posts))
@@ -136,6 +172,29 @@ func (m Model) errorFooter(includeQuit bool) string {
 		parts = append(parts, "q quit")
 	}
 	return strings.Join(parts, "  ·  ")
+}
+
+func (m Model) searchErrorFooter(includeQuit bool) string {
+	edit := "/ edit search"
+	if m.contentWidth() < 44 {
+		edit = "/ edit"
+	}
+	parts := []string{"R retry", edit}
+	if errors.Is(m.err, api.ErrSessionExpired) {
+		parts = append([]string{"a reconnect"}, parts...)
+	}
+	if includeQuit {
+		parts = append(parts, "q quit")
+	}
+	return strings.Join(parts, "  ·  ")
+}
+
+func (m Model) searchEmptyFooter() string {
+	footer := "/ edit search  ·  f for you  ·  q quit"
+	if ansi.StringWidth(footer) > m.contentWidth() {
+		return "/ edit  ·  f for you  ·  q quit"
+	}
+	return footer
 }
 
 func (m Model) viewThread() string {
@@ -572,12 +631,70 @@ func (m Model) viewReply() string {
 
 func (m Model) viewSearch() string {
 	w := m.contentWidth()
-	title := lipgloss.NewStyle().Foreground(pink).Bold(true).Render("search")
+	title := lipgloss.NewStyle().Foreground(pink).Bold(true).Render("search posts")
+	description := "find words, accounts, or exact phrases"
+	if m.width < 48 {
+		description = "type a query"
+	}
+	// Keep the text input itself narrower than its styled border so long
+	// queries scroll horizontally instead of making the panel grow vertically.
+	m.searchInput.Width = max(10, w-16)
+	m.searchInput.SetCursor(m.searchInput.Position())
 	input := lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(blue).
-		Padding(0, 1).Width(w - 4).Render(m.searchInput.View())
-	hint := lipgloss.NewStyle().Foreground(muted).Render("enter: search · esc: cancel")
-	content := title + "\n\n" + input + "\n\n" + hint
-	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, content)
+		Padding(0, 1).Width(max(16, w-12)).Render(m.searchInput.View())
+
+	back := m.searchBackLabel()
+	hint := "enter search  ·  esc " + back
+	if m.width < 48 {
+		hint = "enter search  ·  esc " + m.searchBackShortLabel()
+	} else if m.width >= 52 {
+		hint += "  ·  ctrl+u clear"
+	}
+	content := title + "\n" +
+		lipgloss.NewStyle().Foreground(muted).Render(description) + "\n\n" +
+		input + "\n\n" +
+		lipgloss.NewStyle().Foreground(muted).Render(hint)
+	box := lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lavender).
+		Padding(1, 2).Width(max(20, w-6)).Render(content)
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, box)
+}
+
+func (m Model) searchBackLabel() string {
+	if m.searchReturn == modeThread {
+		return "back to replies"
+	}
+	switch m.feed {
+	case FeedFollowing:
+		return "back to following"
+	case FeedBookmarks:
+		return "back to bookmarks"
+	case FeedSearch:
+		if m.searchQuery == "" && len(m.posts) == 0 {
+			return "quit"
+		}
+		return "back to results"
+	default:
+		return "back to for you"
+	}
+}
+
+func (m Model) searchBackShortLabel() string {
+	if m.searchReturn == modeThread {
+		return "replies"
+	}
+	switch m.feed {
+	case FeedFollowing:
+		return "following"
+	case FeedBookmarks:
+		return "bookmarks"
+	case FeedSearch:
+		if m.searchQuery == "" && len(m.posts) == 0 {
+			return "quit"
+		}
+		return "results"
+	default:
+		return "for you"
+	}
 }
 
 func (m Model) viewZoom() string {


### PR DESCRIPTION
## Summary

- add a structured, responsive search prompt with context-aware controls
- add search-specific loading, empty, error, header, and footer states
- keep long and Unicode queries within narrow terminal layouts
- exit a fresh `xeet search` prompt cleanly and extend PTY coverage

## Testing

- `go test -race ./...`
- `go vet ./...`
- `go run honnef.co/go/tools/cmd/staticcheck@v0.7.0 ./...`
- focused search and PTY tests repeated 20 times
- manual terminal checks at wide and narrow sizes
