### PR TITLE
lists, multi-column, and multi-account

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+# xeet fork — Claude Code 向けコンテキスト
+
+このリポは melqtx/xeet の fork（origin: github.com/rrrrnmtsu/xeet）。
+改修は必ずこのリポ（/Users/remma/dev/xeet）で行う。他リポのセッションから
+xeet を触らない（コンテキストがここにあるため）。
+
+## ブランチ・出荷状況
+
+作業ブランチ: `feat/lists-multi-column-multi-account`（main への PR 先は main）
+
+upstream には無い fork 独自機能（全部このブランチにコミット済み）:
+
+| 機能 | コミット | 入口 |
+|---|---|---|
+| 通知カラム | 1b36073 | NotificationsTimeline、`--columns notifications,...` |
+| リポスト/解除 | d1cb8c6 | TUI `t` キー（トグル・楽観更新） |
+| 引用ポスト | d7b364e | TUI `Q` キー、`xeet post --quote <id>` |
+| プロフィールTL | 2157677 | TUI `u` キー（フォーカスカラムのフィード切替） |
+| ブックマーク登録/解除 | 3880d89 | TUI `B` キー |
+| URLからポスト取得 | a9596b1 | `xeet fetch <url-or-id>`（JSON 既定、`--text`/`--replies`/`--account`） |
+
+## エージェントからポストを読む
+
+セッションで X のポスト URL を共有されたら:
+
+```bash
+xeet fetch <url> | jq .text        # 本文
+xeet fetch <url> | jq .article     # X長文記事（あれば title/text）
+xeet fetch <url> --replies 5       # 返信込み
+```
+
+見つからない・権限がない場合は終了コード 1。WebFetch は X の JS
+レンダリングで詰むので使わない。
+
+## 鉄則（壊すと静かに死ぬ所）
+
+1. **QID 捏造禁止**。空フォールバック + eager `discoverOperation` +
+   env override（`XEET_<OP>_QID`）+ config 永続化の既存経路だけ使う
+2. **config QID 配管は1オペレーション7点**: Config struct と fileConfig
+   struct の**両方**（片方だけだと Save() が静かに落とす）+
+   fileConfigFor + configFromFile + SaveQueryIDs + web.go の
+   operationQIDs 初期化 + ApplyRefreshedQueryIDs case
+3. **Transaction ID が要るオペレーション**: SearchTimeline、
+   CreateRetweet/DeleteRetweet、CreateBookmark/DeleteBookmark
+   （ヘッダ無しだと bodyless 404。likes・UserByScreenName・UserTweets は不要）
+4. **冪等性でリトライを決める**: likes/CreateBookmark = 冪等 →
+   transient リトライあり。CreateRetweet/DeleteBookmark = 非冪等 →
+   単発（リプレイすると GraphQL エラー。TUI は楽観状態をロールバック）
+5. **GraphQL 400/422 が来たら**: エラーボディが指名した変数だけ足す。
+   推測で変数を増やさない。新規依存も禁止
+6. **fieldToggles は共有マップを直接いじらない**。読み取り拡張が要る
+   エンドポイントはコピーに opt-in させる（例: tweetDetailFieldToggles の
+   withArticlePlainText。pkg/api/conversation.go の Why not コメント参照）
+7. **共有パーサに載せる**: ポストの legacy パースは parseTimelineItem
+   （pkg/api/timeline.go）に集約。エンドポイント個別にパースを書かない
+
+## コード/テスト/コミット/コメントの軸
+
+- コード本体 = How、テスト = What、コミットログ = Why、
+  コードコメント = Why not（見送った代替案）のみ
+
+## live テスト（全て env ゲート）
+
+`XEET_LIVE_TIMELINE` / `XEET_LIVE_CONVERSATION` / `XEET_LIVE_SEARCH` /
+`XEET_LIVE_BOOKMARKS` / `XEET_LIVE_BOOKMARK`（+`_TWEET_ID`）/
+`XEET_LIVE_RETWEET` / `XEET_LIVE_QUOTE` / `XEET_LIVE_PROFILE` /
+`XEET_LIVE_LISTS` / `XEET_LIVE_NOTIFICATIONS` / `XEET_LIVE_ARTICLE`（+`_TWEET_ID`）/
+`XEET_LIVE_VERIFY` / `XEET_LIVE_DISCOVER`
+
+新しい GraphQL オペレーションを足したら unit + live 両方を書くこと。
+live でしか分からん挙動（transaction header 要否、非冪等性など）が必ずある。
+
+## 検証コマンド
+
+```bash
+go build ./... && go vet ./... && go test -race ./... -count=1
+```
+
+TUI のヘルプ表示は 15 行端末で center-crop される。short 版は feed 8 行・
+thread 6 行予算、各行 28 文字以内（view.go）。
+
+## 未着手の残件
+
+- 引用ライブテストの残骸ポスト **2082616681940341043** を X 上で手動削除
+  （delete API はスコープ外。ユーザー作業）
+
+## 参考
+
+- `SPEC-lists-columns-accounts.md` — マルチカラム/マルチアカウントの設計仕様
+- `PROGRESS.md` — 作業ログ

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ xeet --list 1234567890                # start on a list by id
 xeet search "go tui"                  # search posts and browse results
 xeet --columns 2                      # show two side-by-side feeds
 xeet --columns foryou,bookmarks       # choose each column's feed
+xeet --columns notifications,foryou   # watch likes and replies roll in
 xeet columns save "foryou,following"  # save the default layout
 xeet --barebones                      # text-only feed
 xeet --compose                        # skip the feed, open the composer
@@ -208,7 +209,7 @@ new, and stacks fresh posts on top with a toast when they arrive.
 
 `--columns 2` through `--columns 4` repeats the selected feed in equal-width
 columns. a comma-separated layout can mix `foryou`, `following`, `bookmarks`,
-`list:<id>`, and `search:<query>`. `xeet columns save "..."` writes that
+`notifications`, `list:<id>`, and `search:<query>`. `xeet columns save "..."` writes that
 layout to `~/.xeet.yaml`; trying a layout never saves it implicitly.
 `tab` / `shift+tab` (or `]` / `[`) moves focus; navigation and post actions
 apply to the focused column. if the terminal is too narrow, xeet shows only

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ echo "piped in" | xeet post           # reads stdin
 xeet post "photos" -i one.png -i two.jpg
 xeet post --image meme.png             # image-only, no text
 xeet post "a reply" --reply 1234567890
+xeet post "a quote" --quote 1234567890
 ```
 
 if your session feels off:
@@ -174,6 +175,7 @@ come back next time.
 | `A` | read image descriptions (works with previews off) |
 | `l` | like / unlike |
 | `t` | repost / unrepost |
+| `Q` | quote the selected post |
 | `r` | reply in place |
 | `o` | open in browser |
 | `y` | copy link |

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ come back next time.
 | `A` | read image descriptions (works with previews off) |
 | `l` | like / unlike |
 | `t` | repost / unrepost |
+| `B` | bookmark / unbookmark |
 | `Q` | quote the selected post |
 | `u` | open the author's profile timeline |
 | `r` | reply in place |

--- a/README.md
+++ b/README.md
@@ -186,6 +186,24 @@ conversation, `j`/`k` moves through replies, `r` replies to the selected
 item, `R` reloads, and `esc` drops you back exactly where you were in the
 timeline.
 
+**auto-refresh**
+
+the timeline is manual-only by default: nothing refetches until you press
+`R`. to keep the focused column current on its own, set an interval once in
+`~/.xeet.yaml` or pass one for a single run:
+
+```bash
+xeet --refresh 60s   # poll the focused column every minute
+```
+
+```yaml
+refresh_interval: 5m
+```
+
+polling follows focus, so `tab` moves it to another column. it pauses while
+you read a thread or the column holds an error, stays quiet when nothing is
+new, and stacks fresh posts on top with a toast when they arrive.
+
 ### multi-column
 
 `--columns 2` through `--columns 4` repeats the selected feed in equal-width

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ come back next time.
 | `i` | zoom the post's image to the whole terminal |
 | `A` | read image descriptions (works with previews off) |
 | `l` | like / unlike |
+| `t` | repost / unrepost |
 | `r` | reply in place |
 | `o` | open in browser |
 | `y` | copy link |

--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ if your session feels off:
 xeet whoami            # which account is connected
 xeet doctor            # session metadata + one authenticated read
 xeet doctor --offline  # local metadata only, no network
-xeet logout            # delete xeet's copy of the session
+xeet logout            # delete xeet's active session
+xeet logout --all      # delete every xeet session and the config file
 ```
 
 diagnostics print a short fingerprint and the browser/profile, never the
@@ -259,8 +260,13 @@ xeet reuses the x.com session already in your browser and speaks the same
 unsupported internal graphql endpoints the website does. the imported
 `auth_token` and `ct0` cookies grant account-level access, so treat them
 like a password. they live in the macos keychain or linux secret service, never
-in the yaml config file. `xeet logout` deletes xeet's copy (your browser
-stays logged in).
+in the yaml config file. account metadata and global settings use config schema
+v2 in `~/.xeet.yaml`; sessions from older installs migrate offline on first
+load. don't run an older xeet binary after migration: it cannot understand the
+`accounts:` block and may erase it when saving. new binaries refuse writes to
+config versions newer than they understand. `xeet logout` deletes the active
+session and `xeet logout --all` deletes every saved session (your browser stays
+logged in).
 
 <details>
 <summary>details: query ids and retries</summary>

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ come back next time.
 | `l` | like / unlike |
 | `t` | repost / unrepost |
 | `Q` | quote the selected post |
+| `u` | open the author's profile timeline |
 | `r` | reply in place |
 | `o` | open in browser |
 | `y` | copy link |

--- a/README.md
+++ b/README.md
@@ -121,6 +121,18 @@ xeet post "a reply" --reply 1234567890
 xeet post "a quote" --quote 1234567890
 ```
 
+reading a single post without the tui — handy for scripts and AI agents:
+
+```bash
+xeet fetch https://x.com/alice/status/1234567890   # JSON on stdout
+xeet fetch 1234567890 | jq .text                   # just the body
+xeet fetch <url> --text                            # human-readable instead
+xeet fetch <url> --replies 5                       # include replies
+```
+
+long posts come through in full, and X long-form articles land under
+`article.title` / `article.text`.
+
 if your session feels off:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ xeet lists                            # pick a list and browse it
 xeet --list 1234567890                # start on a list by id
 xeet search "go tui"                  # search posts and browse results
 xeet --columns 2                      # show two side-by-side feeds
+xeet --columns foryou,bookmarks       # choose each column's feed
+xeet columns save "foryou,following"  # save the default layout
 xeet --barebones                      # text-only feed
 xeet --compose                        # skip the feed, open the composer
 xeet post "hello from my shell"       # one-shot post
@@ -185,10 +187,13 @@ timeline.
 
 ### multi-column
 
-`--columns 2` through `--columns 4` splits the timeline into equal-width
-feeds. `tab` / `shift+tab` (or `]` / `[`) moves focus; navigation and post
-actions apply to the focused column. if the terminal is too narrow, xeet
-shows only the columns that fit and tells you how many are hidden.
+`--columns 2` through `--columns 4` repeats the selected feed in equal-width
+columns. a comma-separated layout can mix `foryou`, `following`, `bookmarks`,
+`list:<id>`, and `search:<query>`. `xeet columns save "..."` writes that
+layout to `~/.xeet.yaml`; trying a layout never saves it implicitly.
+`tab` / `shift+tab` (or `]` / `[`) moves focus; navigation and post actions
+apply to the focused column. if the terminal is too narrow, xeet shows only
+the columns that fit and tells you how many are hidden.
 
 ansi previews and kitty/ghostty Unicode-placeholder images compose across
 columns. iterm2 and wezterm inline images rely on relative cursor movement,

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ xeet --bookmarks                      # start on your bookmarks
 xeet lists                            # pick a list and browse it
 xeet --list 1234567890                # start on a list by id
 xeet search "go tui"                  # search posts and browse results
+xeet --columns 2                      # show two side-by-side feeds
 xeet --barebones                      # text-only feed
 xeet --compose                        # skip the feed, open the composer
 xeet post "hello from my shell"       # one-shot post
@@ -181,6 +182,19 @@ there too. inside a
 conversation, `j`/`k` moves through replies, `r` replies to the selected
 item, `R` reloads, and `esc` drops you back exactly where you were in the
 timeline.
+
+### multi-column
+
+`--columns 2` through `--columns 4` splits the timeline into equal-width
+feeds. `tab` / `shift+tab` (or `]` / `[`) moves focus; navigation and post
+actions apply to the focused column. if the terminal is too narrow, xeet
+shows only the columns that fit and tells you how many are hidden.
+
+ansi previews and kitty/ghostty Unicode-placeholder images compose across
+columns. iterm2 and wezterm inline images rely on relative cursor movement,
+which cannot be composed safely side by side, so multi-column runs fall back
+to ansi even with `--images native`. the `?` help overlay shows the fallback
+note.
 
 **themes**
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ then just:
 xeet                                  # browse your timeline, images and all
 xeet --following                      # start on the following feed
 xeet --bookmarks                      # start on your bookmarks
+xeet lists                            # pick a list and browse it
+xeet --list 1234567890                # start on a list by id
 xeet search "go tui"                  # search posts and browse results
 xeet --barebones                      # text-only feed
 xeet --compose                        # skip the feed, open the composer
@@ -159,6 +161,7 @@ come back next time.
 | `j` / `k` / arrows | move (`ctrl+d`/`ctrl+u` jumps five) |
 | `f` | switch between the for you and following feeds |
 | `b` | switch between bookmarks and the for you feed |
+| `L` | pick a list to browse |
 | `/` | search posts |
 | `enter` | open the post's replies |
 | `e` / `space` | read a truncated post in full |
@@ -172,8 +175,9 @@ come back next time.
 | `R` | refresh in place, new posts stack on top, you keep your spot |
 | `?` | key guide + which image renderer is active and why |
 
-more posts load automatically near the bottom; search results are just
-another feed, so like, reply, and thread all work there too. inside a
+more posts load automatically near the bottom; search results and list
+timelines behave like any other feed, so like, reply, and thread all work
+there too. inside a
 conversation, `j`/`k` moves through replies, `r` replies to the selected
 item, `R` reloads, and `esc` drops you back exactly where you were in the
 timeline.

--- a/SPEC-lists-columns-accounts.md
+++ b/SPEC-lists-columns-accounts.md
@@ -1,0 +1,521 @@
+# SPEC: X Lists + Multi-column + Multi-account for xeet
+
+Status: implementation-ready. Target executor: Codex (no further clarification available — every decision is made below; where reality may diverge, §13 tells you exactly what to do instead of guessing).
+
+Builds directly on the shipped Bookmarks/Search work (see `SPEC-bookmarks-search.md` and the seven commits on `feat/lists-columns-accounts`). Do NOT redo anything that spec covers: `FeedKind`, `setFeed`, `fetchTimelineOp`, `parseEntries`, `modeSearch`, `cmd/search.go`, `--bookmarks`, `b`/`/` keys are all live and verified against a real account.
+
+---
+
+## 🇯🇵 なんJまとめ（読む人向け）
+
+ワイらの xeet フォークにデカい機能を3つ足すで:
+
+1. **X Lists** — 自分のリストを feed として閲覧。`xeet lists` でピッカー、TUI 内 `L` キー、`--list <id>` フラグの3経路
+2. **マルチカラム** — TweetDeck 風に N 本の feed を横並び。各カラム独立スクロール、スレッド/リプライ/検索/ズームは全画面オーバーレイのまま（再親化を回避してリファクタ半減）
+3. **マルチアカウント** — 複数の X セッションを保存・切替。config を `version: 2` スキーマに移行、アカウントキーは **X user id**（cookie の hash やと rotate で別人扱いになるから NG）、keyring は user id suffix 化。カラムごとに別アカウントも可（最終 Phase）
+
+フェーズ構成（1 phase = 1 commit が基本、順序は **Lists → columns → accounts** 固定）:
+
+- **L1**: Lists API（`pkg/api/lists.go`: feed 取得 + リスト列挙）
+- **L2**: `FeedList` + TUI ピッカー（`L` キー）
+- **L3**: `cmd/lists.go` + `--list` フラグ + テスト
+- **C1**: `column` struct 抽出（挙動不変の機械的リファクタ、msg に column id 付与）
+- **C2**: N カラムレイアウト + focus 移動 + 幅不足時の自動縮退
+- **C3**: 画像・preview のカラム対応（iTerm2/WezTerm は ANSI 強制）
+- **C4**: `--columns` フラグ + config 永続化 + PTY テスト
+- **A1**: config schema v2 + 移行 + `SaveQueryIDs` 競合修正 + `Erase` 分割
+- **A2**: ブラウザ複数プロファイル収集（collapse 削除）+ auth picker にアカウント選択 phase
+- **A3**: `xeet accounts` list/switch + whoami/doctor 対応
+- **A4**: カラム別アカウント（stretch、A3 まで green なら着手）
+
+規模感: **11 commits、実装 +2500〜3500行 / テスト +1500〜2500行**。Lists の GraphQL 変数だけ実セッション裏取りが必要（§13）。QID は絶対に捏造禁止、discover に任せるんや。C1 が最大の一発（26 フィールド移動）やが挙動不変やからテストが守ってくれる。A1 の移行だけはミスるとユーザーのセッション飛ぶから §8.2 の手順を一字一句守ること。
+
+---
+
+## 0. Ground rules (apply to every phase)
+
+- Go **1.26.5 pinned** — do not touch the `go` directive. **No new dependencies.** Everything needed (bubbletea v1, bubbles v1, lipgloss v1, cobra, go-keyring, yaml.v3) is already a direct dep. If you add ANY dep anyway, you must update `vendorHash` in `default.nix` or the nix CI job fails. You almost certainly do not need one.
+- Every phase must pass locally: `go build ./...`, `go vet ./...`, `go test -race ./...`. The operator runs staticcheck and commits — you have **no network**, `.git` is **read-only**, and you must **not create status/progress files in the repo**. Modify only the files each phase names (plus their tests).
+- New endpoints stay on `x.com` only (SECURITY.md host allowlist).
+- **Never fabricate a GraphQL query id.** All new operations use the TweetDetail pattern: empty fallback + `discoverOperation` on first use. `FetchBookmarks` (`pkg/api/bookmarks.go`) is the current template.
+- Read-only requests need NO `X-Client-Transaction-Id` **except where §13 says a bodyless 404 proves otherwise** — that is what the `withTransactionID bool` parameter of `fetchTimelineOp` is for. Start Lists with `false`.
+- Test conventions: offline mocked tests are the default and the bar (`pkg/api` has 20 test files to crib from). Live tests go in `*_live_test.go`, gated by a per-file env var (pattern: `XEET_LIVE_BOOKMARKS`, `XEET_LIVE_SEARCH`), and must compile on all four CI platforms. PTY tests re-exec via helper env vars and are build-tagged `darwin || linux`. Test names state what is guaranteed.
+- Code comments: only "why not" (trade-offs, rejected alternatives). Commit messages: why, not what.
+
+---
+
+## 1. Phase L1 — Lists API (`pkg/api/lists.go`)
+
+**Goal**: fetch one page of a list's timeline, and enumerate the user's own lists. No TUI change.
+
+### 1.1 New file `pkg/api/lists.go`
+
+```go
+// FetchListTimeline retrieves one page of the given X List's feed.
+func (c *WebClient) FetchListTimeline(ctx context.Context, listID, cursor string, count int) (*TimelinePage, error) {
+	return c.fetchTimelineOp(ctx, "ListLatestTweetsTimeline", "", "XEET_LISTLATESTTWEETSTIMELINE_QID", count, false,
+		func(count int) map[string]any {
+			vars := map[string]any{
+				"listId": listID,
+				"count":  count,
+			}
+			if cursor != "" {
+				vars["cursor"] = cursor
+			}
+			return vars
+		})
+}
+```
+
+Response parsing goes through the existing shared `parseEntries` walker (list timelines are instruction/entry shaped like Home). If the payload root path differs from what `parseTimeline` expects, add a thin `parseListTimeline` that locates the instructions array and delegates to `parseEntries` — do NOT fork the entry walker itself (that is the `parseConversation` exception, and it stays an exception).
+
+### 1.2 List enumeration
+
+```go
+// ListInfo is one list the authenticated user owns or follows.
+type ListInfo struct {
+	ID          string
+	Name        string
+	MemberCount int
+	IsPrivate   bool
+}
+
+// FetchOwnedLists enumerates the user's lists for the picker.
+func (c *WebClient) FetchOwnedLists(ctx context.Context) ([]ListInfo, error)
+```
+
+Operation: `ListsManagementPageTimeline`, empty fallback, env override `XEET_LISTSMANAGEMENTPAGETIMELINE_QID`, `withTransactionID: false` to start. Variables: start with `{"count": 100}`. The response is a timeline-shaped payload whose entries contain `twitter_list` / list item content rather than tweets — this needs its own small parser (`parseListsPage`) that walks the same `instructions[].entries[]` shape but extracts list id/name from item content. §13 covers the unknowns. `fetchTimelineOp` hard-returns `*TimelinePage`, so add a small `fetchListsOp` in `lists.go` — but it must reuse the WHOLE existing pipeline, not just the request half: `operationQueryID` → `discoverOperation` on empty qid → `doTimelineOp` → `needsQueryIDRefresh`-triggered re-discover + retry → `statusToError` → `isTransientStatus` (`ServiceUnavailableError`) → non-200 error with `truncate(body)` → JSON decode → `graphQLError` → parse. That ladder is where rate-limit and auth errors get classified; reimplementing any rung of it is a bug. The ONLY divergence from `fetchTimelineOp`'s body is the final parse call (`parseListsPage` instead of `parseTimeline`).
+
+### 1.3 Tests (Phase L1)
+
+- `pkg/api/lists_test.go` (mocked, default): fixture JSON for a list timeline page and a lists-management page (structure per §13 R4's expected shape; update fixture if live probing corrects it). Tests:
+  - `TestFetchListTimelineParsesPostsAndCursor`
+  - `TestFetchListTimelineSendsListIDVariable` (assert request body contains `"listId"`)
+  - `TestFetchOwnedListsParsesIDNameAndPrivacy`
+  - `TestFetchListTimelineDiscoversQueryIDWhenUnset` (mirror the bookmarks discovery test)
+- `pkg/api/lists_live_test.go`: gated by `XEET_LIVE_LISTS`. One test fetching `FetchOwnedLists` then the first list's first page; skip with a clear message when the account owns no lists.
+
+**Verify phase alone**: `go test -race ./pkg/api/`; live check by the operator with `XEET_LIVE_LISTS=1`.
+
+---
+
+## 2. Phase L2 — `FeedList` kind + in-TUI picker
+
+**Goal**: `L` in the timeline opens a list picker; choosing a list switches the feed via the existing `setFeed` machinery.
+
+### 2.1 Feed kind
+
+- Add `FeedList` to the `FeedKind` enum in `internal/timeline/model.go`.
+- Add fields next to `searchQuery` (they are the same pattern — feed-kind parameters): `listID string`, `listName string` (name is display-only, for the header).
+- `fetchPageSeq` gains a `listID string` parameter (alongside the existing `query string`), and its switch gains:
+
+```go
+case FeedList:
+	id := listID
+	fetch = func(ctx context.Context, cursor string, count int) (*api.TimelinePage, error) {
+		return client.FetchListTimeline(ctx, id, cursor, count)
+	}
+```
+
+Both `setFeed` and `maybeLoadMore` call sites pass `m.listID`. (In Phase C1 these params fold into the column struct; keep them positional for now — C1 is the refactor commit, not this one.)
+
+### 2.2 Picker
+
+New file `internal/timeline/lists.go`. New `mode` value `modeListPicker` following the `modeSearch` precedent in `search.go`:
+
+- `beginListPicker() tea.Cmd` — sets mode, kicks a `fetchListsCmd(ctx) tea.Cmd` returning `listsMsg{lists []api.ListInfo, err error}`.
+- Picker state on Model (global cluster, NOT per-feed — it is an overlay): `listPicker []api.ListInfo`, `listPickerSel int`, `listPickerErr error`, `listPickerLoading bool`, `listReturn mode` (mirror `searchReturn`).
+- Keys inside picker: `j/k`/arrows move, `enter` selects (`m.listID`, `m.listName` set, then `return m, m.setFeed(FeedList)`), `esc` cancels back to `listReturn`.
+- Rendering: full-screen overlay in `view.go` alongside the search prompt branch; reuse `contentWidth()` and the search prompt's frame styling. No new styling system.
+- **Decision — fetch each launch, no config cache**: the picker fetches lists live every time it opens. One cheap request; caching list metadata would add config schema churn right before the multi-account migration (A1) for no real win.
+
+### 2.3 Keys and help
+
+- `L` (capital; lowercase `l` is taken by like) in the timeline feed opens the picker. Add to `cmd/help.go`'s `commandGroups` and the in-TUI help overlay.
+- Header for `FeedList` shows `List: <name>` (crib the Search header treatment; keep it inside `TestSearchViewAndHeaderExposeQueryWithinWidth`'s width discipline).
+
+### 2.4 Tests (Phase L2)
+
+`internal/timeline/lists_test.go`:
+- `TestListPickerOpensOnCapitalLAndClosesOnEsc`
+- `TestListPickerSelectionSwitchesFeedAndResetsState` (assert posts nil, cursor cleared, feedSeq bumped — same guarantees `setFeed` gives elsewhere)
+- `TestListFeedHeaderShowsListNameWithinWidth`
+- `TestStalePageFromPreviousFeedIsDroppedAfterListSwitch` (seq guard still holds)
+
+**Verify phase alone**: `go test -race ./internal/timeline/`; manual: open picker offline → error path renders, not a hang.
+
+---
+
+## 3. Phase L3 — `cmd/lists.go` + `--list` flag
+
+- New `cmd/lists.go`: `xeet lists` — launches the timeline TUI directly into the picker (`timeline.Run` gains a way to start in `modeListPicker`; add an optional start-mode to the existing `Run(ctx, images, feed, query)` signature — extend it to `Run(ctx, images string, feed FeedKind, query, listID string)` and treat `feed == FeedList && listID == ""` as "open picker first"). Flags: `--images`, `--theme` (copy `cmd/search.go`).
+- `--list <id>` flag on `timelineCmd` (and `rootCmd` if `--bookmarks` is mirrored there — it is; mirror it): starts directly on that list. Takes the numeric list id. **Decision — id only, no name resolution in the flag**: resolving names costs a network round-trip before the TUI even starts and introduces ambiguity; the picker is the name-based path.
+- Mark `--list` mutually exclusive with `--following`/`--bookmarks` (`MarkFlagsMutuallyExclusive`).
+- Help: add `lists` to `commandGroups`.
+- **Decision (spec decision #1) — all three entry points ship (subcommand, flag, in-TUI key)** because each serves a distinct habit (scripted launch / muscle memory / discovery) and they all funnel into the same `setFeed(FeedList)`, so the marginal cost of each is a handful of lines.
+
+### Tests (Phase L3)
+
+- `cmd/lists_test.go`: `TestListsCommandRegisteredWithFlags`, `TestTimelineListFlagIsExclusiveWithOtherFeeds` (crib existing cmd tests for flag registration assertions).
+- Extend `cmd/help_test.go` expectations.
+
+**Verify phase alone**: `go build ./... && go test -race ./cmd/`; operator smoke: `xeet lists`, `xeet timeline --list <id>`.
+
+---
+
+## 4. Phase C1 — extract the `column` struct (behavior-preserving)
+
+**Goal**: all per-feed state moves into one struct; the Model holds `columns []column` with exactly one element; every test still passes unchanged in meaning. This is the big mechanical commit — no layout change, no second column yet.
+
+### 4.1 The struct — decision #3
+
+New file `internal/timeline/column.go`:
+
+```go
+// column is one independently scrolling feed pane. With one column the TUI
+// behaves exactly as before; the struct exists so state cannot leak between
+// panes once there are several.
+type column struct {
+	id          int    // stable identity for message routing; never reused
+	feed        FeedKind
+	searchQuery string
+	listID      string
+	listName    string
+	feedSeq     int
+	posts       []api.TimelinePost
+	cursor      string
+	selected    int
+	starts      []int
+	ends        []int
+	loading     bool
+	loadingMore bool
+	refreshing  bool
+	expanded    bool
+	err         error
+	viewport    viewport.Model
+	wezFrameKey string
+
+	// thread cluster — the thread overlay is full-screen (decision #2) but its
+	// STATE belongs to the column that opened it, so returning from the overlay
+	// restores that column exactly.
+	feedSelected  int
+	threadRootID  string
+	threadPosts   []api.ConversationPost
+	threadCursor  string
+	threadLoading bool
+	threadMore    bool
+	threadErr     error
+	threadSeq     int
+}
+```
+
+Model keeps (global): `ctx`, `width`, `height`, `imageMode`, `imageNote`, `mode`, `help`, `altText`, `altTextScroll`, `zoom`, `action`, `clipboardOK`, `toast`, `toastSeq`, `err`? — no: `err` is per-feed, it moved. `liking`, `previews`, `spinner`, the reply cluster (`replyReturn`, `replyEditor`, `replyPost`, `replyPosting`, `replyErr`, `replyNotice`), the search-prompt cluster (`searchInput`, `searchReturn`), the list-picker cluster from L2, plus new: `columns []column`, `focus int`, `nextColID int`.
+
+**Decision #2 — `mode` stays GLOBAL on the Model; thread/reply/search/zoom/alt-text render as full-screen overlays.** Re-parenting `mode` into columns would force per-column key routing, per-column reply editors, and per-column overlay rendering — roughly doubling this refactor for a UX (side-by-side threads) nobody asked for. The thread *state* lives in the column (see struct) so `esc` returns each column to where it was; only the *presentation* is single-screen.
+
+### 4.2 Accessors
+
+- `func (m *Model) cur() *column { return &m.columns[m.focus] }` — the single funnel. Mechanically rewrite every `m.posts` → `m.cur().posts` etc. `currentPost()` reads from `m.cur()`; this retargets `openSelected`, `showAltText`, `zoomSelected`, `toggleSelectedLike`, `copySelectedLink`, enter→thread, `viewZoom`, `altTextRows`, `zoomLoading`, `evictDistantPreviews` in one stroke.
+- `setFeed`, `switchFeed`, `maybeLoadMore`, `applyFeedPage`, `syncViewport`, `ensureSelectedVisible`, `moveSelection`, `activePosts`, thread functions: all become operations on `*column` (method on Model that takes `c *column`, or method on `*column` taking what it needs — prefer methods on Model operating on `m.cur()` where they touch global state like spinner/previews, plain `*column` methods where they do not).
+- `applyLike` fans out over **all** columns' `posts` and `threadPosts` (For You and Following overlap heavily; cross-column duplicates are guaranteed).
+
+### 4.3 Message routing — decision #4
+
+`pageMsg`, `threadMsg`, `previewMsg`, and `likeMsg`-adjacent flows gain column identity:
+
+```go
+type pageMsg struct {
+	page  *api.TimelinePage
+	err   error
+	more  bool
+	seq   int
+	colID int
+}
+```
+
+- **`feedSeq` stays PER-COLUMN** (it moved into the struct) **and messages carry `colID`.** Rationale: seq answers "is this page from before my last feed switch", which is a per-column question; colID answers "which column asked", which seq cannot — a global tagged counter would conflate the two and reintroduce the silent-drop bug the brief documents.
+- Routing helper: `func (m *Model) columnByID(id int) *column` returning nil when the column is gone (removed columns drop their in-flight pages silently — that is correct, mirror the existing stale-seq drop).
+- `fetchPageSeq` signature becomes `fetchPageSeq(parent context.Context, feed FeedKind, query, listID, cursor string, more bool, seq, colID int)`; all five `return pageMsg{...}` sites carry `colID`. Same treatment for `threadMsg` construction in `thread.go` and `previewMsg` in `preview.go`. Update the four routing sites each in `model.go` Update / `thread.go` / `reply.go` / `search.go` to route via `columnByID` instead of assuming the singleton.
+- `applyFeedPage(msg)` first resolves the column: nil → drop; then the existing `msg.seq != c.feedSeq` guard.
+
+### 4.4 View (still one column)
+
+`View`/`shell`/`syncViewport`/`contentWidth` untouched in behavior this phase — they read from `m.cur()`. `imageFrameKey` hashes `m.cur()` state as before.
+
+### 4.5 Tests (Phase C1)
+
+All existing `internal/timeline` tests must pass with mechanical-only edits (constructor changes, field paths). Add:
+- `TestPageForRemovedColumnIsDropped` (construct pageMsg with unknown colID → no panic, no state change)
+- `TestPageRoutedToNonFocusedColumnDoesNotTouchFocusedColumn` (two columns wired manually in the test even though the UI can't create them yet — this is THE regression test for the feedSeq collision bug; write it now, it is cheap insurance for C2)
+
+**Verify phase alone**: full `go test -race ./...` green; `xeet` behaves identically by hand.
+
+---
+
+## 5. Phase C2 — N-column layout, focus, narrow fallback
+
+### 5.1 Width — decision #5
+
+`contentWidth()` becomes two functions in `view.go`:
+
+```go
+// columnContentWidth is the width of one column's text frame.
+func columnContentWidth(totalWidth, ncols int) int
+// (m Model) contentWidth() int  — kept, now returns columnContentWidth(m.width, len(m.columns))
+```
+
+Keeping the zero-arg method (now delegating) preserves the ~15 call sites; only sites that render a specific non-focused column call the parameterized form. Per-column width = `(totalWidth - gutters) / ncols`, gutter = 2 cells, clamped to `[30, 76]` as today. Overlays (thread/reply/search/zoom/alt-text/help) are full-screen and use `columnContentWidth(m.width, 1)`.
+
+**Too-narrow behavior (defined, tested)**: effective column count `effectiveCols = min(configuredCols, max(1, usable/32))` where usable accounts for gutters and the two right-edge safety cells `shell` already keeps clear. When `effectiveCols < len(m.columns)`, render only columns `[first..first+effectiveCols)` chosen so the focused column is always visible (slide the window), and show a footer note `"+N more (widen terminal)"`. Never render a column below 30 cells; never overflow; the PTY resize-to-42 test must see exactly one column.
+
+### 5.2 Composition
+
+- `renderFeedContent` renders ONE column's content string at its width (parameterized). `View` composes: render each visible column into its own `viewport`-backed block, then `lipgloss.JoinHorizontal(lipgloss.Top, blocks...)`, then the existing `shell(center, footer)`.
+- Each column keeps its own `viewport.Model` (already moved in C1); `resize()` sets every visible column's viewport to the per-column width and shared height.
+- Focused column is indicated by the existing selected-post highlight plus a header accent on the focused column's header; non-focused columns still show their selection dimmed (theme's muted style). No new theme entries — reuse existing styles.
+- Keys: `tab` / `shift+tab` cycle focus (also `[`/`]` as vim-adjacent synonyms). ALL existing keys (j/k, f, b, /, L, l, o, r, enter, …) act on the focused column via `m.cur()` — zero per-key changes thanks to C1.
+- `footer()` describes the focused column; the `< 50` degraded branch keys off the focused column's width.
+
+### 5.3 Tests (Phase C2)
+
+- `TestTwoColumnsRenderSideBySideWithoutOverflowAt100Cols`
+- `TestNarrowTerminalCollapsesToOneColumnAndNotesHiddenColumns` (width 42)
+- `TestFocusCycleMovesActionTargetBetweenColumns` (like in col 2 does not touch col 1's posts — except the deliberate `applyLike` fan-out for the SAME post id, which gets its own test: `TestLikeFansOutToDuplicatePostAcrossColumns`)
+- `TestFocusedColumnStaysVisibleWhenWindowSlides`
+- Update the frame-invariant tests the brief lists (`TestViewIsFixedHeightAndDoesNotDuplicateRows` etc.): keep their single-column assertions by running them with one column, and add a two-column variant of the fixed-height/no-duplicate assertion (`strings.Count(view, "Alice") == 1` becomes: Alice appears once *per column that contains her*).
+
+**Verify phase alone**: `go test -race ./...`; operator smoke in Ghostty at ≥100 cols with 2–3 columns.
+
+---
+
+## 6. Phase C3 — images and previews across columns
+
+### 6.1 Image mode policy — decision #7
+
+| protocol | columns == 1 | columns > 1 |
+|---|---|---|
+| ANSI half-block | as today | as today (width-parameterized, composes) |
+| Kitty native (Unicode placeholders) | as today | supported — placeholder cells are ordinary text; verify width maths (§6.3) |
+| iTerm2/WezTerm (`ESC ]1337;File=`) | as today | **forced to ANSI** with `imageNote = "multi-column: iTerm2/WezTerm images fall back to ANSI"` |
+
+The WezTerm path moves the cursor with relative `ESC[nD`/`ESC[nA` around reserved cells; `JoinHorizontal` interleaves the neighbour column's text between reservation and motion, and CSI sequences measure zero-width so lipgloss padding is wrong on exactly the image rows. There is no fix inside bubbletea's `View() string` contract (it would need absolute addressing and pane origins). Enforcement point: where `imageMode` is resolved at startup and wherever columns can grow past 1 at runtime — `if m.imageMode == imageWezTerm && len(m.columns) > 1 { downgrade to ANSI + note }`. Explicit `--images native` on that path with `--columns` ≥ 2 downgrades with the visible note rather than erroring (an error would make `--columns 2` unusable in a whole terminal family; a note is honest and recoverable). Document in README under a "Multi-column" heading and in `--images` flag help.
+
+`imageFrameKey()` (which triggers `tea.ClearScreen` for iTerm2 and hashes all of `starts`): with the forced-ANSI rule it only ever runs with one column, so leave its logic alone; assert that with a test (`TestWezTermPathNeverRunsMultiColumn`).
+
+### 6.2 Preview cache — decision #6
+
+**Shared cache, keyed by post id, unchanged key** — legal because all columns share ONE width (equal split, §5.1), so the "refetch when cached preview is wider than the frame" invariant still cannot ping-pong: widths in play are {column width, full-screen overlay widths}, and refetch only ever *shrinks* toward the narrowest, which is the (uniform) column width.
+
+**EXPLICIT INVARIANT (load-bearing, must be written into the code): all feed columns are equal width; the shared post-id-keyed preview cache is only correct because of this.** If anyone later introduces unequal column widths (resizable panes, a wide "main" column), the width-based refetch loop returns: a preview cached at the wide column's width is "too wide" for the narrow one, gets refetched narrower, then looks degraded in the wide column, forever. Requirement: put this as a "why not per-column cache" comment directly on the `previews` map declaration AND on `columnContentWidth` ("all columns equal width — the preview cache depends on this; see previews map"), so a future width change trips over it at the two places it would be made. Changes needed:
+
+- `evictDistantPreviews`: keep-set becomes the **union over all visible columns** of their `activePosts()` window plus each column's `selected` — not just the focused column. This is the fix for the evict-then-refetch churn the brief flags.
+- `maxCachedPreviews`: `48 * len(m.columns)` capped at 144. Scaling matters because N columns hold N viewports of posts on screen at once.
+- Kitty image ids stay `fnv32(postID) & 0xFFFFFF` — same post in two columns intentionally shares the image id and the transmitted image (no collision, and dedup is a feature).
+- `requestPreviews` iterates visible columns, requesting at the shared column width; `previewMsg` carries `colID` only for routing the repaint, the stored state stays global.
+
+### 6.3 Kitty width caution
+
+U+10EEEE is Plane-16 PUA (go-runewidth reports width 1) and the row/column diacritics are combining marks (width 0). `columnContentWidth`-based padding around `nativePreviewBlock` output must measure with the same function lipgloss uses today — add `TestNativePlaceholderRowsMeasureAtDeclaredWidth` locking the measured width of a placeholder row to the declared image cell width, so a future runewidth bump fails loudly instead of skewing columns.
+
+### 6.4 Tests (Phase C3)
+
+- `TestMultiColumnForcesANSIOnWezTermWithVisibleNote`
+- `TestEvictionKeepsPreviewsVisibleInNonFocusedColumns`
+- `TestPreviewBudgetScalesWithColumnCount`
+- `TestNativePlaceholderRowsMeasureAtDeclaredWidth`
+- Update `TestThreadRefetchesAPreviewTooWideForItsRail`, `TestNativePrefetchIncludesVisiblePosts`, `TestWezRepaintClearsOnlyWhenFrameMoves` for the new accessors (semantics unchanged, single-column).
+
+---
+
+## 7. Phase C4 — configuring columns (decision #8)
+
+**v1 configuration surface: `--columns` flag + optional config key. No in-TUI add/remove.** In-TUI layout editing is UI polish that should ride on a stable base; the flag delivers the whole feature value now.
+
+- Flag on `timelineCmd` and `rootCmd`: `--columns "foryou,following,bookmarks,list:1234567890,search:golang"` — comma-separated column specs, each `foryou | following | bookmarks | list:<id> | search:<query>`. Parser in `cmd/timeline.go` → `[]timeline.ColumnSpec{Kind FeedKind; Query, ListID string}`; `timeline.Run` gains the spec slice (default: one spec derived from the existing feed/query args, preserving every current invocation).
+- Config persistence: `columns: ["foryou", "following"]` (list of the same spec strings) in `~/.xeet.yaml`, read at startup when the flag is absent, written **only** by explicit `xeet columns save` (a tiny subcommand that snapshots nothing at runtime — it just validates and writes the given specs: `xeet columns save "foryou,list:123"`). No implicit writes: the TUI never persists layout on its own (write-on-exit would collide with the A1 write-contention work and surprise users).
+- Cap: max 4 columns (76-min-width terminals rarely fit more; parser rejects >4 with a clear error).
+- `--columns` mutually exclusive with `--following`/`--bookmarks`/`--list` (they are the 1-column shorthands).
+
+### Tests (Phase C4)
+
+- `cmd`: `TestColumnsFlagParsesSpecsAndRejectsUnknownKinds`, `TestColumnsFlagExclusiveWithSingleFeedFlags`, `TestColumnsConfigKeyIsUsedWhenFlagAbsent`
+- PTY (`darwin || linux`, re-exec helper env pattern from `cmd/pty_test.go` / `internal/timeline/pty_test.go`): extend `TestTimelinePTYNavigationResizeAndHelp`-style coverage with a run at 120 cols → resize to 42 → assert single-column fallback text appears and no line exceeds the terminal width.
+
+---
+
+## 8. Phase A1 — multi-account config schema v2 (decision #9)
+
+**This is the migration-risk phase. It lands after columns so it sits on a stable base, and nothing in it touches `pkg/api` — `NewWebClient(cfg)` copies scalars, has no package state, and already supports N clients.**
+
+### 8.1 Schema — one file, nested map keyed by X user id, version key
+
+**The account key is the X user id (`api.Account.ID`, the numeric rest-id), NOT a hash of the cookies.** `sessionFingerprint(authToken, ct0)` (`cmd/doctor.go:84`) hashes the two session cookies — and those cookies ROTATE (that is why `session_expires` exists and why re-running `xeet auth` is the documented fix for a stale session). Keying by fingerprint would mean every cookie refresh of the SAME account creates a new key: duplicate `accounts:` entries, orphaned keyring items, `active` drifting to the newest twin. Handle is also not a key (users rename). The user id never changes, and A2's reordered `verifyAndSave` has it in hand (from `FetchViewer`) at exactly the moment the key is chosen. `sessionFingerprint` survives only as a doctor display diagnostic — never a lookup key.
+
+`~/.xeet.yaml` (same path — a new filename would orphan theme/QIDs and double the migration surface; the `version:` key is the downgrade tripwire):
+
+```yaml
+version: 2
+active: "783214"                 # X user id of the active account
+theme: dracula                   # stays global
+create_tweet_qid: ...            # ALL query-id fields stay global, top-level (decision below)
+...other *_qid...
+accounts:
+  "783214":                      # api.Account.ID (numeric rest-id) — quote it, YAML must keep it a string
+    handle: someuser             # display only; refreshed on every successful viewer fetch, so a
+    session_browser: chrome      #   rename UPDATES the entry instead of forking it
+    session_profile: Default
+    session_domain: .x.com
+    session_expires: 2027-01-01T00:00:00Z
+    session_imported: 2026-07-27T00:00:00Z
+  "legacy":                      # provisional key — only ever present right after migration (§8.2),
+    ...                          #   rekeyed to the real user id on the first successful viewer fetch
+```
+
+- **Query ids stay GLOBAL** — they are X's deployment-wide persisted-query ids scraped from public JS, identical for every account; per-account storage would mean N× discovery for zero benefit and would churn `Config`, `NewWebClient`, `ApplyRefreshedQueryIDs`, and `cmd/setqid.go` for nothing.
+- Keyring (decision #9 cont.): service stays `"xeet"`; per-account keys are `auth_token:<userid>` / `ct0:<userid>` (and `auth_token:legacy` / `ct0:legacy` for the provisional slot). Turn the `keyAuthToken`/`keyCT0` constants into `func authTokenKey(id string) string` etc. — `SecretStore` interface unchanged. The legacy unsuffixed keys are read ONLY by migration and deleted by it.
+- New/changed API in `pkg/config`:
+  - `Config` gains `UserID string` and `Handle string` (both yaml:"-"; filled from the resolved account entry); represents the ACTIVE account, so all 20 `NewConfigManager()`+`Load()` call sites keep working unchanged.
+  - `Load()` → loads file, resolves `active`, pulls that account's secrets. v1 file (no `version:`) with legacy keyring entries → **migrate** (§8.2). `migrateLegacy` (pre-keyring, plaintext `auth_token:` in file) chains into the same path — do not reintroduce top-level `auth_token:` writes.
+  - `LoadAccount(userID string) (*Config, error)` — same as Load but for a named account (A4 uses this).
+  - `Accounts() ([]AccountInfo, error)` — file-only listing (`AccountInfo{UserID, Handle, SessionBrowser, SessionProfile, SessionImported}`); **no keyring, no network** so `doctor --offline` and `accounts` stay cheap.
+  - `SetActive(userID string) error` — validates the account exists, rewrites file.
+  - `SaveAccount(cfg *Config) error` — upserts the account keyed by `cfg.UserID` (keyring pair + accounts entry) and sets it active; errors if `UserID` is empty (only migration may write the `legacy` slot). Keeps the existing snapshot/rollback discipline per key pair.
+  - `RekeyAccount(oldID, newID string) error` — moves the accounts entry and its keyring pair from one key to the other (write new pair → rewrite file with new key + `active` → delete old pair, delete-last for crash recoverability, same discipline as §8.2). Used to promote `legacy` → real user id; if `newID` already exists (the migrated session belongs to an account that was re-authed meanwhile), MERGE: keep the newer `session_imported`, drop the loser's keyring pair.
+  - **`SaveQueryIDs(cfg *Config) error` — REQUIRED, fixes the write-contention bug**: re-read the file, patch ONLY the `*_qid` fields from `cfg`, write back atomically. All eight `Load → use → ApplyRefreshedQueryIDs → Save` call sites (both closures in `internal/timeline/model.go` shown above, `verifyAndSave`, `cmd/whoami.go`, `cmd/post.go`, etc. — grep `ApplyRefreshedQueryIDs`) switch their `Save(cfg)` to `SaveQueryIDs(cfg)`. Without this, a `setLike` holding a stale in-memory `Config` can resurrect a just-logged-out account or clobber a just-added one. `Save` in its full-overwrite form becomes internal to auth/migration paths only.
+  - `EraseAccount(userID string) error` — deletes that account's keyring pair and map entry; if it was active, promote another account or clear `active`. `EraseAll() error` — current `Erase` behavior (all keys, file, legacy key file). `cmd/logout.go` gets `--all`; default logs out only the active account.
+- Downgrade hazard (documented, mitigated, not fully preventable): an old binary saving over a v2 file silently erases `accounts:` (plain `yaml.Unmarshal`, full-marshal `writeFile`, no unknown-key round-trip). Mitigations shipped: the `version:` key (new binaries refuse to *full-overwrite* a file whose version is higher than they know: `Save` checks and errors "config written by a newer xeet"), and `doctor` prints the version + account count so damage is visible. Preserving unknown YAML nodes via `yaml.Node` is explicitly out of scope (high-effort, low-payoff once version-gating exists). Note this limitation in README.
+
+### 8.2 Migration (exact, ordered) — provisional key + rekey
+
+**Decision: migrate OFFLINE under the provisional key `legacy`, and rekey to the real user id on the first successful viewer fetch** — migration must never fail when offline, and the rekey rides on network calls that already happen (`verifyAndSave`, `whoami`'s viewer fetch), so no new failure mode is introduced. (The alternative — one `FetchViewer` call during migration — is allowed as an OPTIMIZATION: attempt it with a short timeout, use the id on success, fall back to `legacy` on any error. Implement the fallback path first; the optimization is optional.)
+
+On `Load()` finding no `version:` key:
+1. Read legacy keyring `auth_token`/`ct0`. If absent and no legacy in-file tokens → write nothing yet; first `SaveAccount` creates v2.
+2. If present: write `auth_token:legacy`/`ct0:legacy`; build the single `accounts:` entry under key `legacy` from the existing top-level `session_*` fields; set `active: legacy`, `version: 2`; write the file **before** deleting the old unsuffixed keyring keys (delete-last so a crash mid-migration leaves a recoverable state, not an orphaned session); then delete the old keys (and the dead `session_cookies`).
+3. Rekey: every code path that completes a successful `FetchViewer` while the active account key is `legacy` (that is `verifyAndSave` and `whoami`; add the check in one shared helper in `pkg/config`, not scattered) calls `RekeyAccount("legacy", account.ID)` and sets `handle`. Until then, `accounts` listing shows `legacy` with its fingerprint as the display id — functional but unnamed.
+4. Handle backfill: migration itself does NOT call the network (modulo the optional optimization above); `handle` is filled by the same viewer fetches that trigger the rekey.
+
+### 8.3 Tests (Phase A1)
+
+`pkg/config/config_test.go` additions (in-memory SecretStore fake already exists):
+- `TestLoadMigratesV1KeyringSessionToV2UnderProvisionalKey` (old unsuffixed keys gone, `auth_token:legacy` present, file has version+accounts+active=legacy, QIDs preserved)
+- `TestMigrationCrashBeforeLegacyDeleteIsRecoverable` (simulate by asserting file+new keys are complete before delete step — order-of-operations test)
+- `TestRekeyAccountMovesEntryAndKeyringPairDeleteLast` (crash between write and delete leaves both readable, new one wins on next Load)
+- `TestRekeyIntoExistingUserIDMergesKeepingNewerSession`
+- `TestSaveAccountRejectsEmptyUserID`
+- `TestSaveQueryIDsPatchesOnlyQIDFields` (mutate accounts on disk between Load and SaveQueryIDs; assert accounts survive)
+- `TestSaveRefusesFileFromNewerVersion`
+- `TestEraseAccountRemovesOnlyThatAccountAndPromotesActive`
+- `TestLoadAccountReturnsRequestedSessionNotActive`
+- `TestPreKeyringLegacyFileMigratesStraightToV2` (chained migration)
+
+**Verify phase alone**: `go test -race ./pkg/config/ ./...`; operator: run new binary once against a real v1 install copy, then `xeet whoami` + `xeet doctor`.
+
+---
+
+## 9. Phase A2 — multi-profile browser import + auth UI
+
+**Goal**: importing can see every logged-in profile, not just the "best" one; `xeet auth` lets you pick which; re-auth of a different account no longer silently replaces the previous one (it now lands in its own slot keyed by X user id).
+
+- `pkg/api`: replace the `betterLoginResult` reduction with collection. New exported entry point `ScanSessions() ([]LoginResult, error)` (or extend the existing scan APIs — follow whatever `cmd/auth_ui.go`'s `scanBrowsersCmd` currently calls) returning ALL per-profile results across `cookies_darwin.go`, `cookies_linux.go`, `cookies_gecko.go` (+ keep `cookies_other.go` stub compiling). `LoginResult.Profile` is already populated per-DB before the collapse — you are deleting a reduction, not building extraction. Keep `betterLoginResult` only as the sort comparator (prefer `x.com` domain → later `LastUsedAt` → later `ExpiresAt` → smaller profile name) so the list is best-first and the plain-mode default (`runAuthPlain`) remains "the best one".
+- Dedup happens at TWO levels, because the true account id is only knowable after a network call:
+  - **Scan time (offline)**: collapse only entries whose cookie pair is byte-identical (same session copied between profiles) — `sessionFingerprint` is fine for THIS, it is comparing the cookies themselves, not identifying the account. Two profiles holding the same account at different cookie ages legitimately remain two picker rows (they ARE two distinct live sessions; the user picks the one to import — the best-first sort puts the fresher one on top).
+  - **Save time (authoritative)**: `verifyAndSave` keys by the user id from `FetchViewer`, so importing either of those rows upserts the SAME `accounts:` entry — the account list can never grow a duplicate per cookie age. This is where the real dedup lives.
+- `cmd/auth_ui.go`: insert phase `authPhaseChooseProfile` between `authPhasePick` (browser) and `authPhaseImport` — skipped when the scan yields exactly one session. Renders profile name + cookie domain + expiry.
+- `cmd/auth.go` `verifyAndSave` reorder (**required**): `Verify` → **`FetchViewer` (now load-bearing: it supplies the account key)** → `cfg.UserID = account.ID`, `cfg.Handle = account.Handle` → `SaveAccount`. The viewer fetch is no longer "a courtesy". On `FetchViewer` FAILURE the save must NOT proceed under a guessed key: retry once, then fail the auth with "verified but could not identify the account; try again" — an unidentified save is exactly the duplicate-slot bug this phase exists to kill. (Exception: the migration `legacy` slot, §8.2, which is owned by `pkg/config`, not this path.) Also stop seeding `candidate := *cfg` from the ACTIVE account's session metadata — build the candidate from the `LoginResult` + global fields only, so a second account does not inherit the first's `session_*` (QIDs/theme are global anyway and stay).
+- `xeet auth` of an already-known user id updates that account's entry and keyring pair in place — cookie refresh for the same account is an UPDATE, never a new slot. This is the safe re-auth story replacing today's unconditional overwrite, and it also resolves a pending `legacy` slot naturally (rekey/merge per §8.2 step 3).
+
+### Tests (Phase A2)
+
+- Per-platform cookie tests already exist — extend each (`cookies_darwin_test.go` etc.) with `Test<Platform>ScanReturnsAllLoggedInProfiles` using two fixture profile DBs.
+- `TestScanCollapsesOnlyByteIdenticalCookiePairs` (same account, different cookie ages ⇒ two rows)
+- `cmd/auth_ui_test.go`: `TestAuthSkipsProfileChoiceWithSingleSession`, `TestAuthProfileChoiceListsAllSessionsBestFirst`
+- `cmd/auth_test.go`: `TestVerifyAndSaveKeysByViewerUserIDAndDoesNotInheritSessionMetadata`, `TestReauthOfKnownAccountUpdatesInPlaceNotNewSlot`, `TestVerifyAndSaveFailsClosedWhenViewerUnidentifiable`
+
+---
+
+## 10. Phase A3 — `xeet accounts` + switch
+
+- New `cmd/accounts.go`:
+  - `xeet accounts` — table: active marker, handle (or user id when handle is empty; `legacy` shown with its fingerprint), browser/profile, imported date. File-only (`Accounts()`), no network, no keyring — same cheapness contract as `doctor --offline`.
+  - `xeet accounts switch <handle|user-id-prefix>` — `SetActive`. Exact match on handle; unique-prefix on user id.
+  - `xeet accounts remove <…>` — `EraseAccount` with a y/N confirm (destructive).
+- `cmd/whoami.go` prints which account (handle + user id) it verified — and this fetch is a rekey trigger for a pending `legacy` slot (§8.2). `cmd/doctor.go` adds account count + active user id (fingerprint stays as the session diagnostic it always was); `--offline` still does zero `Verify` calls (verify only the ACTIVE account in online mode — N live verifies is exactly the slowness the brief forbids).
+- In-TUI: `A` key cycles the ACTIVE account for the whole app (all columns) — full re-`setFeed` on every column (bump every seq; in-flight pages from the old account die on the seq guard). Footer/header shows the active handle when more than one account exists.
+
+### Tests (Phase A3)
+
+- `cmd/accounts_test.go`: `TestAccountsListsWithoutTouchingKeyringOrNetwork` (fake store instrumented), `TestSwitchByHandleAndByUniqueUserIDPrefix`, `TestRemoveActivePromotesNextAccount`
+- `internal/timeline`: `TestAccountCycleResetsEveryColumnAndDropsInFlightPages`
+
+---
+
+## 11. Phase A4 (stretch) — per-column accounts (decision #10)
+
+**Yes, columns can carry different accounts**, and the race is solved the same way feed switches already are: **resolve the account inside the closure from data captured at dispatch time, guarded by seq.**
+
+- `column` gains `accountID string` (X user id; "" = follow the global active account).
+- `fetchPageSeq` gains `accountID string`, captured like `query`/`listID`. Inside the closure: `cfg` comes from `LoadAccount(accountID)` (or `Load()` when empty). A mid-flight account switch on the column bumps `feedSeq` (it goes through `setFeed`), so a page fetched under the old account fails the seq guard and is dropped — identical mechanism, zero new synchronization. `fetchPageSeq` already carries `seq` for exactly this class of problem.
+- Column spec syntax grows an optional prefix: `--columns "@alice:foryou,@bob:following"` (`@handle:` resolved at startup via `Accounts()`; unknown → startup error listing known accounts).
+- `setLike`/reply closures triggered from a column use that column's account (thread the user id the same way); `applyLike` fan-out must NOT cross accounts — fan out only across columns sharing the acting account's id (a like by @alice must not flip @bob's rendered like state; same post id, different per-account like status).
+- `previews` stay shared (images are account-independent). `liking` map keys become `accountID + ":" + postID`.
+- SaveQueryIDs from any account's fetch is fine — QIDs are global by design.
+
+### Tests (Phase A4)
+
+- `TestColumnFetchUsesItsOwnAccountSession` (fake config dir with two accounts; assert auth header per request via the mocked transport)
+- `TestAccountSwitchMidFlightDropsStalePageViaSeqGuard`
+- `TestLikeFanOutStaysWithinTheActingAccount`
+- `cmd`: `TestColumnsFlagParsesAccountPrefixes`
+
+---
+
+## 12. Decisions index (the ten, one line each)
+
+1. **List selection = subcommand + flag + `L` key; metadata fetched per launch, not cached** — three entry points share one `setFeed` funnel so each costs little; caching would churn the config schema right before A1's migration.
+2. **Thread/reply/search/zoom/alt-text stay full-screen overlays; `mode` stays global** — halves the refactor by avoiding per-column key routing and overlay rendering; per-column thread *state* still restores correctly because it lives in the column.
+3. **`column` struct, unexported, `internal/timeline/column.go`, 26 fields as listed in §4.1** — everything guarded by `feedSeq` or indexed parallel to `posts` moves; overlay/global clusters stay on Model.
+4. **Messages carry `colID`; `feedSeq` is per-column** — seq answers "before my last feed switch?", colID answers "whose page?"; one global tagged counter would conflate them and reintroduce the misrouting bug.
+5. **`columnContentWidth(totalWidth, ncols)` + delegating zero-arg method; too-narrow ⇒ render only the columns that fit (≥30 each), sliding window keeps focus visible, footer notes the hidden count** — defined and PTY-tested at 42 cols.
+6. **Preview cache stays shared and post-id-keyed** — equal-split columns share one width so the no-ping-pong invariant survives (this equal-width dependency is an EXPLICIT invariant, commented at both the cache and `columnContentWidth`, §6.2); eviction keep-set unions all visible columns; budget scales `48×cols` cap 144.
+7. **Images: ANSI and Kitty native compose; iTerm2/WezTerm forced to ANSI when cols>1 with a visible note** — relative-cursor-motion escape art cannot survive `JoinHorizontal`, and fixing it needs absolute addressing bubbletea's View contract hides.
+8. **Columns configured by `--columns` flag + config key written only by explicit `xeet columns save`; no in-TUI editing in v1; max 4** — smallest surface that delivers the value; implicit write-on-exit would collide with A1's write-contention fix.
+9. **One `~/.xeet.yaml` with `version: 2`, `accounts:` map keyed by X user id (never the cookie fingerprint — cookies rotate, the user id doesn't), global QIDs, keyring keys `auth_token:<userid>`/`ct0:<userid>`, offline migration under a provisional `legacy` key rekeyed on first viewer fetch** — same file keeps theme/QIDs; version key gates newer-file overwrites; the provisional key keeps migration network-free while the stable id arrives on calls that already happen.
+10. **Per-column accounts: yes (A4); the account's user id captured in the fetch closure at dispatch, mid-flight switches invalidated by the existing per-column seq guard** — the same mechanism that already makes feed switches race-free, no new locking.
+
+---
+
+## 13. Risk register (genuinely unverified — probe, don't guess)
+
+Recovery procedure for every row, exactly as it worked for Bookmarks/Search:
+
+> Run the live test with the gate env var. On a GraphQL 400, **read the error body** — X names the missing/unknown variable or feature switch explicitly. Add exactly what it names to `buildVars` / the features map, nothing more, and re-run. `xeet inspect-har` prints structural keys but **never values**, so a HAR from the operator's browser can confirm variable *names* and feature-switch *keys* safely. A **bodyless 404 with a decrementing `x-rate-limit-remaining` header means the endpoint is alive and a required HEADER is missing** — that is exactly how the `SearchTimeline` per-request `X-Client-Transaction-Id` requirement was found; the fix is flipping `withTransactionID` to `true`, not touching variables.
+
+| # | Risk | Likelihood | Plan |
+|---|---|---|---|
+| R1 | `ListLatestTweetsTimeline` needs more variables than `{listId, count, cursor}` (feature switches, `withCommunity` etc.) | high | Recovery procedure above; expect 1–2 iterations of adding named feature switches. |
+| R2 | `ListsManagementPageTimeline` is the wrong operation name for enumerating lists (candidates: `CombinedLists`, `ListsManagementPageTimeline`) | medium | `discoverOperation` fails ⇒ the name is not in the JS bundle map: grep the operator-provided HAR structural dump for `List` operations, use the one the web client actually fires on x.com/…/lists. |
+| R3 | Lists ops require `X-Client-Transaction-Id` (SearchTimeline precedent) | medium | Bodyless-404 signature ⇒ flip `withTransactionID: true`. One-line change by design. |
+| R4 | Lists-management payload entry shape (list items vs tweet items) differs from the fixture guess | high | Fixture is a guess until first live run; `parseListsPage` walks defensively (skip non-list entries), live test asserts only non-empty id+name. Correct the fixture from the live structural dump, never from invented values. |
+| R5 | go-runewidth / lipgloss width maths break Kitty placeholder columns after a version bump | low | `TestNativePlaceholderRowsMeasureAtDeclaredWidth` (§6.3) fails loudly; fix is a measurement shim, not silent skew. |
+| R6 | Old binary run against a v2 config erases `accounts:` (downgrade) | certain-if-it-happens | Cannot be fully prevented without yaml.Node round-tripping (out of scope). Mitigated: version-gate on full `Save`, doctor visibility, README warning; keyring items survive and re-auth restores. |
+| R7 | Keyring backends that key strictly by (service, account) may treat `auth_token:<userid>` names differently (length/charset limits on some Linux Secret Service impls) | low | User ids are numeric, ≤ 20 digits today; total key ≤ 31 ASCII chars — well inside every backend's limits. If a backend still balks, fall back to service `"xeet:<userid>"` with unchanged key names (one function edit, covered by the fake-store tests). |
+| R8 | Two accounts rate-limit-share per IP; multi-account columns double request volume | medium | Not a code change: existing 429 handling (`statusToError`) surfaces per-column errors independently. Note in README. |
+
+---
+
+## 14. Phase → verification recap
+
+| Phase | Verify with |
+|---|---|
+| L1 | `go test -race ./pkg/api/`; operator: `XEET_LIVE_LISTS=1 go test -run Live ./pkg/api/` |
+| L2 | `go test -race ./internal/timeline/`; manual `L` picker offline error path |
+| L3 | `go test -race ./cmd/`; `xeet lists`, `xeet timeline --list <id>` |
+| C1 | FULL suite green with mechanical-only test edits; hand-check identical behavior |
+| C2 | new layout tests + updated frame invariants; smoke at ≥100 cols |
+| C3 | image-policy tests; smoke in Ghostty (Kitty native, 2 cols) and WezTerm (ANSI fallback note) |
+| C4 | flag/config tests + PTY resize-to-42 fallback |
+| A1 | `pkg/config` migration tests; operator runs against a COPY of a real v1 install |
+| A2 | per-platform multi-profile fixtures; auth picker phase tests |
+| A3 | accounts cmd tests; `A` cycle test |
+| A4 | per-column session tests with instrumented transport |

--- a/SPEC-lists-columns-accounts.md
+++ b/SPEC-lists-columns-accounts.md
@@ -327,6 +327,23 @@ U+10EEEE is Plane-16 PUA (go-runewidth reports width 1) and the row/column diacr
 
 ---
 
+> **Added after the C2 smoke test (2026-07-27).** Two columns render correctly in
+> Ghostty with kitty-graphics images contained inside each column, so the header
+> work below is a real observation rather than a guess: the ASCII cat logo is
+> repeated verbatim per column, costing two rows times the column count and
+> telling the user nothing once several columns are on screen. Deferred from C3
+> to here because what a column header should say is only decidable once columns
+> can carry different feeds — which is this phase.
+>
+> **C4 additionally owns:**
+> - Render the logo **once** for the screen, not once per column.
+> - Per-column header shows what distinguishes that column: its feed label
+>   (`for you`, `following`, `bookmarks`, `search: <q>`, `List: <name>`), and
+>   nothing else.
+> - The focused column must be **unmistakable at a glance**. The C2 accent was
+>   not obviously visible in the smoke test; verify against a real terminal and
+>   strengthen it (reuse existing theme styles — no new theme entries).
+
 ## 7. Phase C4 — configuring columns (decision #8)
 
 **v1 configuration surface: `--columns` flag + optional config key. No in-TUI add/remove.** In-TUI layout editing is UI polish that should ride on a stable base; the flag delivers the whole feature value now.

--- a/cmd/accounts.go
+++ b/cmd/accounts.go
@@ -119,6 +119,42 @@ func runAccountsRemove(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// selectedAccountStore is the config surface a per-invocation --account needs:
+// the roster to resolve the selector against, and the session it names.
+type selectedAccountStore interface {
+	Accounts() ([]config.AccountInfo, error)
+	Load() (*config.Config, error)
+	LoadAccount(string) (*config.Config, error)
+}
+
+// loadAccountSelection resolves --account inside the one invocation that uses
+// it. Switching the active account and then acting is not equivalent: anything
+// else on the machine can move `active` in between, so a caller that meant one
+// account can post as another. An empty selector keeps the active account, so
+// the flag only ever narrows.
+func loadAccountSelection(store selectedAccountStore, selector string) (*config.Config, error) {
+	if strings.TrimSpace(selector) == "" {
+		return store.Load()
+	}
+	accounts, err := store.Accounts()
+	if err != nil {
+		return nil, err
+	}
+	account, err := matchSavedAccount(accounts, selector)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := store.LoadAccount(account.UserID)
+	if err != nil {
+		return nil, fmt.Errorf("load account %s: %w", accountIdentity(account), err)
+	}
+	if cfg.AuthToken == "" || cfg.CT0 == "" {
+		return nil, fmt.Errorf("account %s has no usable session; re-run 'xeet auth' for it",
+			accountIdentity(account))
+	}
+	return cfg, nil
+}
+
 func resolveSavedAccount(selector string) (accountsStore, config.AccountInfo, error) {
 	store, err := openAccountsStore()
 	if err != nil {

--- a/cmd/accounts.go
+++ b/cmd/accounts.go
@@ -127,6 +127,21 @@ type selectedAccountStore interface {
 	LoadAccount(string) (*config.Config, error)
 }
 
+// accountSelectorFrom reads --account as the caller actually passed it. An
+// omitted flag means the active account, which is the documented default. A
+// flag passed with an empty value means the caller built the selector from
+// something that came out blank, and that is the one case where falling
+// through to the active account would post as an account nobody named.
+func accountSelectorFrom(cmd *cobra.Command, value string) (string, error) {
+	if !cmd.Flags().Changed("account") {
+		return "", nil
+	}
+	if strings.TrimSpace(value) == "" {
+		return "", fmt.Errorf("--account was given an empty value; omit the flag to use the active account")
+	}
+	return value, nil
+}
+
 // loadAccountSelection resolves --account inside the one invocation that uses
 // it. Switching the active account and then acting is not equivalent: anything
 // else on the machine can move `active` in between, so a caller that meant one

--- a/cmd/accounts.go
+++ b/cmd/accounts.go
@@ -1,0 +1,218 @@
+package cmd
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/melqtx/xeet/pkg/config"
+
+	"github.com/spf13/cobra"
+)
+
+type accountsStore interface {
+	Accounts() ([]config.AccountInfo, error)
+	SetActive(string) error
+	EraseAccount(string) error
+}
+
+var openAccountsStore = func() (accountsStore, error) {
+	return config.NewConfigManager()
+}
+
+var accountsCmd = &cobra.Command{
+	Use:   "accounts",
+	Short: "list and switch saved x accounts",
+	Args:  cobra.NoArgs,
+	RunE:  runAccounts,
+}
+
+var accountsSwitchCmd = &cobra.Command{
+	Use:   "switch <handle|user-id-prefix>",
+	Short: "make a saved account active",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runAccountsSwitch,
+}
+
+var accountsRemoveCmd = &cobra.Command{
+	Use:   "remove <handle|user-id-prefix>",
+	Short: "remove one saved account",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runAccountsRemove,
+}
+
+func init() {
+	accountsCmd.AddCommand(accountsSwitchCmd, accountsRemoveCmd)
+	rootCmd.AddCommand(accountsCmd)
+}
+
+func runAccounts(cmd *cobra.Command, args []string) error {
+	store, err := openAccountsStore()
+	if err != nil {
+		return err
+	}
+	accounts, err := store.Accounts()
+	if err != nil {
+		return err
+	}
+	if len(accounts) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "no saved accounts; run 'xeet auth' to connect one")
+		return nil
+	}
+
+	table := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+	fmt.Fprintln(table, "ACTIVE\tACCOUNT\tUSER ID\tSESSION\tIMPORTED")
+	for _, account := range accounts {
+		marker := ""
+		if account.Active {
+			marker = "*"
+		}
+		fmt.Fprintf(table, "%s\t%s\t%s\t%s\t%s\n",
+			marker,
+			accountDisplayName(account),
+			account.UserID,
+			accountSessionSource(account),
+			accountImportedDate(account.SessionImported),
+		)
+	}
+	return table.Flush()
+}
+
+func runAccountsSwitch(cmd *cobra.Command, args []string) error {
+	store, account, err := resolveSavedAccount(args[0])
+	if err != nil {
+		return err
+	}
+	if err := store.SetActive(account.UserID); err != nil {
+		return fmt.Errorf("switch account: %w", err)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "active account: %s\n", accountIdentity(account))
+	return nil
+}
+
+func runAccountsRemove(cmd *cobra.Command, args []string) error {
+	store, account, err := resolveSavedAccount(args[0])
+	if err != nil {
+		return err
+	}
+	prefix := ""
+	if account.Active {
+		prefix = "active "
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Remove %saccount %s? [y/N] ", prefix, accountIdentity(account))
+	confirmed, err := readConfirmation(cmd.InOrStdin())
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		fmt.Fprintln(cmd.OutOrStdout(), "not removed")
+		return nil
+	}
+	if err := store.EraseAccount(account.UserID); err != nil {
+		return fmt.Errorf("remove account: %w", err)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "removed account: %s\n", accountIdentity(account))
+	return nil
+}
+
+func resolveSavedAccount(selector string) (accountsStore, config.AccountInfo, error) {
+	store, err := openAccountsStore()
+	if err != nil {
+		return nil, config.AccountInfo{}, err
+	}
+	accounts, err := store.Accounts()
+	if err != nil {
+		return nil, config.AccountInfo{}, err
+	}
+	account, err := matchSavedAccount(accounts, selector)
+	if err != nil {
+		return nil, config.AccountInfo{}, err
+	}
+	return store, account, nil
+}
+
+func matchSavedAccount(accounts []config.AccountInfo, selector string) (config.AccountInfo, error) {
+	selector = strings.TrimSpace(selector)
+	handle := strings.TrimPrefix(selector, "@")
+	var exact []config.AccountInfo
+	for _, account := range accounts {
+		if account.Handle != "" && strings.EqualFold(account.Handle, handle) {
+			exact = append(exact, account)
+		}
+	}
+	if len(exact) == 1 {
+		return exact[0], nil
+	}
+	if len(exact) > 1 {
+		return config.AccountInfo{}, ambiguousAccountError(selector, exact)
+	}
+
+	var prefixes []config.AccountInfo
+	for _, account := range accounts {
+		if strings.HasPrefix(account.UserID, handle) {
+			prefixes = append(prefixes, account)
+		}
+	}
+	if len(prefixes) == 1 {
+		return prefixes[0], nil
+	}
+	if len(prefixes) > 1 {
+		return config.AccountInfo{}, ambiguousAccountError(selector, prefixes)
+	}
+	return config.AccountInfo{}, fmt.Errorf("no saved account matches %q", selector)
+}
+
+func ambiguousAccountError(selector string, matches []config.AccountInfo) error {
+	names := make([]string, len(matches))
+	for i, account := range matches {
+		names[i] = accountIdentity(account)
+	}
+	return fmt.Errorf("account selector %q is ambiguous; matches %s",
+		selector, strings.Join(names, ", "))
+}
+
+func accountDisplayName(account config.AccountInfo) string {
+	if account.Handle != "" {
+		return "@" + account.Handle
+	}
+	return account.UserID
+}
+
+func accountIdentity(account config.AccountInfo) string {
+	name := accountDisplayName(account)
+	if name == account.UserID {
+		return name
+	}
+	return fmt.Sprintf("%s (%s)", name, account.UserID)
+}
+
+func accountSessionSource(account config.AccountInfo) string {
+	switch {
+	case account.SessionBrowser == "":
+		return "-"
+	case account.SessionProfile == "":
+		return account.SessionBrowser
+	default:
+		return account.SessionBrowser + " / " + account.SessionProfile
+	}
+}
+
+func accountImportedDate(imported time.Time) string {
+	if imported.IsZero() {
+		return "-"
+	}
+	return imported.Local().Format("2006-01-02")
+}
+
+func readConfirmation(in io.Reader) (bool, error) {
+	answer, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return false, err
+	}
+	answer = strings.TrimSpace(answer)
+	return strings.EqualFold(answer, "y") || strings.EqualFold(answer, "yes"), nil
+}

--- a/cmd/accounts_test.go
+++ b/cmd/accounts_test.go
@@ -1,0 +1,166 @@
+package cmd
+
+import (
+	"bytes"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/melqtx/xeet/pkg/config"
+
+	"github.com/spf13/cobra"
+)
+
+type fakeAccountsStore struct {
+	accounts      []config.AccountInfo
+	accountReads  int
+	activeWrites  []string
+	removedWrites []string
+}
+
+func (f *fakeAccountsStore) Accounts() ([]config.AccountInfo, error) {
+	f.accountReads++
+	return append([]config.AccountInfo(nil), f.accounts...), nil
+}
+
+func (f *fakeAccountsStore) SetActive(userID string) error {
+	f.activeWrites = append(f.activeWrites, userID)
+	for i := range f.accounts {
+		f.accounts[i].Active = f.accounts[i].UserID == userID
+	}
+	return nil
+}
+
+func (f *fakeAccountsStore) EraseAccount(userID string) error {
+	f.removedWrites = append(f.removedWrites, userID)
+	removedActive := false
+	kept := f.accounts[:0]
+	for _, account := range f.accounts {
+		if account.UserID == userID {
+			removedActive = account.Active
+			continue
+		}
+		kept = append(kept, account)
+	}
+	f.accounts = kept
+	if removedActive && len(f.accounts) > 0 {
+		sort.Slice(f.accounts, func(i, j int) bool {
+			return f.accounts[i].UserID < f.accounts[j].UserID
+		})
+		f.accounts[0].Active = true
+	}
+	return nil
+}
+
+func useFakeAccountsStore(t *testing.T, store *fakeAccountsStore) {
+	t.Helper()
+	previous := openAccountsStore
+	openAccountsStore = func() (accountsStore, error) { return store, nil }
+	t.Cleanup(func() { openAccountsStore = previous })
+}
+
+func testAccountsCommand(out *bytes.Buffer) *cobra.Command {
+	command := &cobra.Command{}
+	command.SetOut(out)
+	return command
+}
+
+func TestAccountsListsWithoutTouchingKeyringOrNetwork(t *testing.T) {
+	store := &fakeAccountsStore{accounts: []config.AccountInfo{
+		{
+			UserID: "42", Handle: "alice", Active: true,
+			SessionBrowser: "Chrome", SessionProfile: "Default",
+			SessionImported: time.Date(2026, 7, 27, 12, 0, 0, 0, time.Local),
+		},
+		{UserID: "84", SessionBrowser: "Firefox"},
+	}}
+	useFakeAccountsStore(t, store)
+	var out bytes.Buffer
+
+	if err := runAccounts(testAccountsCommand(&out), nil); err != nil {
+		t.Fatal(err)
+	}
+	want := "" +
+		"ACTIVE  ACCOUNT  USER ID  SESSION           IMPORTED\n" +
+		"*       @alice   42       Chrome / Default  2026-07-27\n" +
+		"        84       84       Firefox           -\n"
+	if got := out.String(); got != want {
+		t.Fatalf("accounts output =\n%q\nwant\n%q", got, want)
+	}
+	if store.accountReads != 1 || len(store.activeWrites) != 0 || len(store.removedWrites) != 0 {
+		t.Fatalf("list touched more than file-only metadata: %+v", store)
+	}
+}
+
+func TestSwitchByHandleAndByUniqueUserIDPrefix(t *testing.T) {
+	store := &fakeAccountsStore{accounts: []config.AccountInfo{
+		{UserID: "1560376068", Handle: "Rnmtsu", Active: true},
+		{UserID: "166602457", Handle: "anchangzoxxx"},
+	}}
+	useFakeAccountsStore(t, store)
+
+	var handleOut bytes.Buffer
+	if err := runAccountsSwitch(testAccountsCommand(&handleOut), []string{"ANCHANGZOXXX"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := store.activeWrites; len(got) != 1 || got[0] != "166602457" {
+		t.Fatalf("handle switch writes = %v", got)
+	}
+
+	var prefixOut bytes.Buffer
+	if err := runAccountsSwitch(testAccountsCommand(&prefixOut), []string{"15603"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := store.activeWrites; len(got) != 2 || got[1] != "1560376068" {
+		t.Fatalf("prefix switch writes = %v", got)
+	}
+
+	before := len(store.activeWrites)
+	err := runAccountsSwitch(testAccountsCommand(&bytes.Buffer{}), []string{"1"})
+	if err == nil || !strings.Contains(err.Error(), "ambiguous") ||
+		len(store.activeWrites) != before {
+		t.Fatalf("ambiguous prefix returned %v and writes %v", err, store.activeWrites)
+	}
+}
+
+func TestRemoveActivePromotesNextAccount(t *testing.T) {
+	store := &fakeAccountsStore{accounts: []config.AccountInfo{
+		{UserID: "42", Handle: "alice", Active: true},
+		{UserID: "84", Handle: "bob"},
+	}}
+	useFakeAccountsStore(t, store)
+	var out bytes.Buffer
+	command := testAccountsCommand(&out)
+	command.SetIn(strings.NewReader("y\n"))
+
+	if err := runAccountsRemove(command, []string{"alice"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := store.removedWrites; len(got) != 1 || got[0] != "42" {
+		t.Fatalf("removed accounts = %v", got)
+	}
+	if len(store.accounts) != 1 || store.accounts[0].UserID != "84" || !store.accounts[0].Active {
+		t.Fatalf("remaining accounts = %+v", store.accounts)
+	}
+	if got := out.String(); got != "Remove active account @alice (42)? [y/N] removed account: @alice (42)\n" {
+		t.Fatalf("remove output = %q", got)
+	}
+}
+
+func TestRemoveDefaultsToNo(t *testing.T) {
+	store := &fakeAccountsStore{accounts: []config.AccountInfo{
+		{UserID: "42", Handle: "alice", Active: true},
+	}}
+	useFakeAccountsStore(t, store)
+	var out bytes.Buffer
+	command := testAccountsCommand(&out)
+	command.SetIn(strings.NewReader("\n"))
+
+	if err := runAccountsRemove(command, []string{"42"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.removedWrites) != 0 {
+		t.Fatalf("default confirmation removed %v", store.removedWrites)
+	}
+}

--- a/cmd/accounts_test.go
+++ b/cmd/accounts_test.go
@@ -252,3 +252,39 @@ func TestAccountSelectorRejectsUnknownAndSessionlessAccounts(t *testing.T) {
 		t.Fatalf("sessionless account error lacks the recovery step: %v", err)
 	}
 }
+
+func accountFlagCommand(value *string) *cobra.Command {
+	cmd := &cobra.Command{Use: "stub", RunE: func(*cobra.Command, []string) error { return nil }}
+	cmd.Flags().StringVar(value, "account", "", "saved account")
+	return cmd
+}
+
+func TestBlankAccountFlagIsRejectedRatherThanFallingBack(t *testing.T) {
+	for _, blank := range []string{"", "   "} {
+		var value string
+		cmd := accountFlagCommand(&value)
+		if err := cmd.ParseFlags([]string{"--account", blank}); err != nil {
+			t.Fatal(err)
+		}
+		selector, err := accountSelectorFrom(cmd, value)
+		if err == nil {
+			t.Fatalf("--account %q resolved to %q instead of failing; a caller whose "+
+				"selector came out blank would act as the active account", blank, selector)
+		}
+		if !strings.Contains(err.Error(), "omit the flag") {
+			t.Fatalf("blank --account error does not say how to mean the active account: %v", err)
+		}
+	}
+}
+
+func TestOmittedAccountFlagStillMeansTheActiveAccount(t *testing.T) {
+	var value string
+	cmd := accountFlagCommand(&value)
+	if err := cmd.ParseFlags(nil); err != nil {
+		t.Fatal(err)
+	}
+	selector, err := accountSelectorFrom(cmd, value)
+	if err != nil || selector != "" {
+		t.Fatalf("omitted --account gave (%q, %v), want the active-account fallthrough", selector, err)
+	}
+}

--- a/cmd/accounts_test.go
+++ b/cmd/accounts_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -162,5 +164,91 @@ func TestRemoveDefaultsToNo(t *testing.T) {
 	}
 	if len(store.removedWrites) != 0 {
 		t.Fatalf("default confirmation removed %v", store.removedWrites)
+	}
+}
+
+type fakeSelectionStore struct {
+	accounts     []config.AccountInfo
+	sessions     map[string]*config.Config
+	active       *config.Config
+	activeReads  int
+	accountReads []string
+}
+
+func (f *fakeSelectionStore) Accounts() ([]config.AccountInfo, error) {
+	return append([]config.AccountInfo(nil), f.accounts...), nil
+}
+
+func (f *fakeSelectionStore) Load() (*config.Config, error) {
+	f.activeReads++
+	return f.active, nil
+}
+
+func (f *fakeSelectionStore) LoadAccount(userID string) (*config.Config, error) {
+	f.accountReads = append(f.accountReads, userID)
+	cfg, ok := f.sessions[userID]
+	if !ok {
+		return nil, fmt.Errorf("no session for %s", userID)
+	}
+	return cfg, nil
+}
+
+func newSelectionStore() *fakeSelectionStore {
+	return &fakeSelectionStore{
+		accounts: []config.AccountInfo{
+			{UserID: "42", Handle: "alice", Active: true},
+			{UserID: "84", Handle: "bob"},
+		},
+		sessions: map[string]*config.Config{
+			"42": {UserID: "42", Handle: "alice", AuthToken: "alice-auth", CT0: "alice-csrf"},
+			"84": {UserID: "84", Handle: "bob", AuthToken: "bob-auth", CT0: "bob-csrf"},
+		},
+		active: &config.Config{UserID: "42", Handle: "alice", AuthToken: "alice-auth", CT0: "alice-csrf"},
+	}
+}
+
+func TestAccountSelectorNeverReadsTheActiveAccount(t *testing.T) {
+	store := newSelectionStore()
+	cfg, err := loadAccountSelection(store, "@bob")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AuthToken != "bob-auth" {
+		t.Fatalf("selector resolved to %q, want bob's session", cfg.AuthToken)
+	}
+	if store.activeReads != 0 {
+		t.Fatalf("selector consulted the active account %d times; the flag exists so it cannot", store.activeReads)
+	}
+	if !reflect.DeepEqual(store.accountReads, []string{"84"}) {
+		t.Fatalf("loaded accounts %v, want only 84", store.accountReads)
+	}
+}
+
+func TestEmptyAccountSelectorKeepsTheActiveAccount(t *testing.T) {
+	store := newSelectionStore()
+	cfg, err := loadAccountSelection(store, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AuthToken != "alice-auth" || store.activeReads != 1 || len(store.accountReads) != 0 {
+		t.Fatalf("empty selector did not fall through to the active account: %+v", store)
+	}
+}
+
+func TestAccountSelectorRejectsUnknownAndSessionlessAccounts(t *testing.T) {
+	store := newSelectionStore()
+	if _, err := loadAccountSelection(store, "@nobody"); err == nil {
+		t.Fatal("unknown selector was accepted")
+	} else if !strings.Contains(err.Error(), "@nobody") {
+		t.Fatalf("unknown selector error does not name it: %v", err)
+	}
+
+	store.sessions["84"] = &config.Config{UserID: "84", Handle: "bob"}
+	_, err := loadAccountSelection(store, "@bob")
+	if err == nil {
+		t.Fatal("an account with no keyring pair was accepted")
+	}
+	if !strings.Contains(err.Error(), "xeet auth") {
+		t.Fatalf("sessionless account error lacks the recovery step: %v", err)
 	}
 }

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -83,6 +83,19 @@ func (c connection) source() string {
 	return c.browser
 }
 
+type authConfigStore interface {
+	Load() (*config.Config, error)
+	RecordViewer(userID, handle string) error
+	SaveAccount(*config.Config) error
+	SaveQueryIDs(*config.Config) error
+}
+
+type authSessionClient interface {
+	Verify(context.Context) error
+	FetchViewer(context.Context) (*api.Account, error)
+	ApplyRefreshedQueryIDs(*config.Config) bool
+}
+
 // verifyAndSave checks the imported cookies against X before writing them.
 // Verifying first is what keeps a stale or wrong browser profile from
 // overwriting an existing working session.
@@ -91,39 +104,60 @@ func verifyAndSave(ctx context.Context, result *api.LoginResult, browser string)
 	if err != nil {
 		return connection{}, err
 	}
+	return verifyAndSaveWith(ctx, result, browser, configMgr, func(cfg *config.Config) authSessionClient {
+		return api.NewWebClient(cfg)
+	}, time.Now)
+}
+
+func verifyAndSaveWith(
+	ctx context.Context,
+	result *api.LoginResult,
+	browser string,
+	configMgr authConfigStore,
+	newClient func(*config.Config) authSessionClient,
+	now func() time.Time,
+) (connection, error) {
+	if result == nil {
+		return connection{}, fmt.Errorf("no browser session was imported")
+	}
 	cfg, err := configMgr.Load()
 	if err != nil {
 		cfg = &config.Config{}
 	}
-	candidate := *cfg
-	candidate.AuthToken = result.AuthToken
-	candidate.CT0 = result.CT0
-	candidate.SessionBrowser = browser
-	candidate.SessionProfile = result.Profile
-	candidate.SessionDomain = result.CookieDomain
-	candidate.SessionExpires = result.ExpiresAt
-	candidate.SessionImported = time.Now()
+	candidate := authCandidate(cfg, result, browser, now())
 
 	verifyCtx, cancel := context.WithTimeout(ctx, 45*time.Second)
-	defer cancel()
-	client := api.NewWebClient(&candidate)
+	client := newClient(&candidate)
 	if err := client.Verify(verifyCtx); err != nil {
+		cancel()
 		return connection{}, fmt.Errorf("session found in %s but X rejected verification: %w", browser, err)
 	}
+	cancel()
 	client.ApplyRefreshedQueryIDs(&candidate)
 
-	viewerCtx, cancelViewer := context.WithTimeout(ctx, 20*time.Second)
-	defer cancelViewer()
-	account, err := client.FetchViewer(viewerCtx)
-	if err != nil {
-		return connection{}, fmt.Errorf("session verified but xeet could not identify the account: %w", err)
+	var account *api.Account
+	var viewerErr error
+	for range 2 {
+		viewerCtx, cancelViewer := context.WithTimeout(ctx, 20*time.Second)
+		account, viewerErr = client.FetchViewer(viewerCtx)
+		cancelViewer()
+		if viewerErr == nil && account != nil && account.ID != "" {
+			break
+		}
+		if viewerErr == nil {
+			viewerErr = fmt.Errorf("x returned no account identity for this session")
+		}
 	}
-	if err := configMgr.RecordViewer(account.ID, account.Handle); err != nil {
-		return connection{}, err
+	if viewerErr != nil || account == nil || account.ID == "" {
+		return connection{}, fmt.Errorf("session verified but xeet could not identify the account; try again: %w", viewerErr)
 	}
+
 	candidate.UserID = account.ID
 	candidate.Handle = account.Handle
 	client.ApplyRefreshedQueryIDs(&candidate)
+	if err := configMgr.RecordViewer(account.ID, account.Handle); err != nil {
+		return connection{}, err
+	}
 	if err := configMgr.SaveAccount(&candidate); err != nil {
 		return connection{}, err
 	}
@@ -131,6 +165,31 @@ func verifyAndSave(ctx context.Context, result *api.LoginResult, browser string)
 		return connection{}, err
 	}
 	return connection{browser: browser, profile: result.Profile, handle: account.Handle}, nil
+}
+
+func authCandidate(global *config.Config, result *api.LoginResult, browser string, imported time.Time) config.Config {
+	return config.Config{
+		AuthToken:                      result.AuthToken,
+		CT0:                            result.CT0,
+		CreateTweetQID:                 global.CreateTweetQID,
+		HomeTimelineQID:                global.HomeTimelineQID,
+		HomeLatestTimelineQID:          global.HomeLatestTimelineQID,
+		BookmarksQID:                   global.BookmarksQID,
+		SearchTimelineQID:              global.SearchTimelineQID,
+		ListLatestTweetsTimelineQID:    global.ListLatestTweetsTimelineQID,
+		ListsManagementPageTimelineQID: global.ListsManagementPageTimelineQID,
+		FavoriteTweetQID:               global.FavoriteTweetQID,
+		UnfavoriteTweetQID:             global.UnfavoriteTweetQID,
+		ViewerQID:                      global.ViewerQID,
+		TweetDetailQID:                 global.TweetDetailQID,
+		Theme:                          global.Theme,
+		Columns:                        append([]string(nil), global.Columns...),
+		SessionBrowser:                 browser,
+		SessionProfile:                 result.Profile,
+		SessionDomain:                  result.CookieDomain,
+		SessionExpires:                 result.ExpiresAt,
+		SessionImported:                imported,
+	}
 }
 
 // runAuthPlain is the scripted path: no picker, no spinner, one line per step.

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -111,24 +111,26 @@ func verifyAndSave(ctx context.Context, result *api.LoginResult, browser string)
 		return connection{}, fmt.Errorf("session found in %s but X rejected verification: %w", browser, err)
 	}
 	client.ApplyRefreshedQueryIDs(&candidate)
-	if err := configMgr.Save(&candidate); err != nil {
-		return connection{}, err
-	}
 
-	conn := connection{browser: browser, profile: result.Profile}
-	// The handle is a courtesy. The session is already saved and usable, so a
-	// failure to name the account is not worth reporting.
 	viewerCtx, cancelViewer := context.WithTimeout(ctx, 20*time.Second)
 	defer cancelViewer()
-	if account, err := client.FetchViewer(viewerCtx); err == nil {
-		conn.handle = account.Handle
-		// FetchViewer may have discovered a fresher viewer query id; caching it
-		// now saves `xeet whoami` a discovery round trip later.
-		if client.ApplyRefreshedQueryIDs(&candidate) {
-			_ = configMgr.Save(&candidate)
-		}
+	account, err := client.FetchViewer(viewerCtx)
+	if err != nil {
+		return connection{}, fmt.Errorf("session verified but xeet could not identify the account: %w", err)
 	}
-	return conn, nil
+	if err := configMgr.RecordViewer(account.ID, account.Handle); err != nil {
+		return connection{}, err
+	}
+	candidate.UserID = account.ID
+	candidate.Handle = account.Handle
+	client.ApplyRefreshedQueryIDs(&candidate)
+	if err := configMgr.SaveAccount(&candidate); err != nil {
+		return connection{}, err
+	}
+	if err := configMgr.SaveQueryIDs(&candidate); err != nil {
+		return connection{}, err
+	}
+	return connection{browser: browser, profile: result.Profile, handle: account.Handle}, nil
 }
 
 // runAuthPlain is the scripted path: no picker, no spinner, one line per step.

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -14,7 +14,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var authBrowser string
+var (
+	authBrowser string
+	authProfile string
+)
 
 var authCmd = &cobra.Command{
 	Use:   "auth",
@@ -25,14 +28,16 @@ no password to type and no API key to create.
 The picker marks the browsers xeet can already see a session in, and whichever
 one you choose is verified with X before anything is saved, so a stale profile
 can never overwrite a session that works.`,
-	Example: `  xeet auth                     # pick from the browsers on this machine
-  xeet auth --browser Firefox   # skip the picker`,
+	Example: `  xeet auth                                    # pick from the browsers on this machine
+  xeet auth --browser Firefox                  # skip the picker
+  xeet auth --browser Chrome --profile "Profile 8"   # and a specific profile`,
 	Args: cobra.NoArgs,
 	RunE: runAuth,
 }
 
 func init() {
 	authCmd.Flags().StringVar(&authBrowser, "browser", "", "browser to read the session from (skips the picker)")
+	authCmd.Flags().StringVar(&authProfile, "profile", "", "browser profile to read, when several are signed in")
 	rootCmd.AddCommand(authCmd)
 }
 
@@ -55,7 +60,42 @@ func runAuth(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("no terminal to show the picker on; name a browser with --browser (%s)",
 			strings.Join(api.SupportedBrowsers(), ", "))
 	}
-	return runAuthPlain(cmd.Context(), cmd.OutOrStdout(), browser)
+	return runAuthPlain(cmd.Context(), cmd.OutOrStdout(), browser, authProfile)
+}
+
+// pickScriptedSession resolves which imported session the scripted path should
+// use. With several signed-in profiles and no --profile it lists them instead of
+// choosing: picking the "best" silently is how a second account used to vanish.
+func pickScriptedSession(sessions []api.LoginResult, browser, profile string) (*api.LoginResult, error) {
+	if len(sessions) == 0 {
+		return nil, fmt.Errorf("no logged-in x.com session found in %s", browser)
+	}
+	if profile != "" {
+		for i := range sessions {
+			if strings.EqualFold(sessions[i].Profile, profile) {
+				return &sessions[i], nil
+			}
+		}
+		return nil, fmt.Errorf("no x.com session in %s profile %q (found: %s)",
+			browser, profile, strings.Join(sessionProfiles(sessions), ", "))
+	}
+	if len(sessions) > 1 {
+		return nil, fmt.Errorf("%s has %d signed-in profiles; name one with --profile (%s)",
+			browser, len(sessions), strings.Join(sessionProfiles(sessions), ", "))
+	}
+	return &sessions[0], nil
+}
+
+func sessionProfiles(sessions []api.LoginResult) []string {
+	names := make([]string, 0, len(sessions))
+	for i := range sessions {
+		name := sessions[i].Profile
+		if name == "" {
+			name = "(unnamed)"
+		}
+		names = append(names, name)
+	}
+	return names
 }
 
 // matchBrowser accepts any capitalization of a supported browser name.
@@ -193,9 +233,13 @@ func authCandidate(global *config.Config, result *api.LoginResult, browser strin
 }
 
 // runAuthPlain is the scripted path: no picker, no spinner, one line per step.
-func runAuthPlain(ctx context.Context, out io.Writer, browser string) error {
+func runAuthPlain(ctx context.Context, out io.Writer, browser, profile string) error {
 	fmt.Fprintf(out, "Reading your session from %s (your OS may ask to unlock its keyring)...\n", browser)
-	result, resolved, err := api.ImportBrowserSession(browser)
+	sessions, resolved, err := api.ImportBrowserSessions(browser)
+	if err != nil {
+		return err
+	}
+	result, err := pickScriptedSession(sessions, resolved, profile)
 	if err != nil {
 		return err
 	}

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -1,0 +1,169 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/melqtx/xeet/pkg/api"
+	"github.com/melqtx/xeet/pkg/config"
+)
+
+type fakeAuthConfigStore struct {
+	loaded           *config.Config
+	accounts         map[string]config.Config
+	events           *[]string
+	saved            *config.Config
+	saveAccountCalls int
+}
+
+func (f *fakeAuthConfigStore) Load() (*config.Config, error) {
+	cfg := *f.loaded
+	cfg.Columns = append([]string(nil), f.loaded.Columns...)
+	return &cfg, nil
+}
+
+func (f *fakeAuthConfigStore) RecordViewer(userID, handle string) error {
+	*f.events = append(*f.events, "record-viewer")
+	return nil
+}
+
+func (f *fakeAuthConfigStore) SaveAccount(cfg *config.Config) error {
+	*f.events = append(*f.events, "save-account")
+	f.saveAccountCalls++
+	saved := *cfg
+	saved.Columns = append([]string(nil), cfg.Columns...)
+	f.saved = &saved
+	if f.accounts == nil {
+		f.accounts = make(map[string]config.Config)
+	}
+	f.accounts[cfg.UserID] = saved
+	return nil
+}
+
+func (f *fakeAuthConfigStore) SaveQueryIDs(cfg *config.Config) error {
+	*f.events = append(*f.events, "save-query-ids")
+	return nil
+}
+
+type fakeAuthSessionClient struct {
+	events        *[]string
+	verifyErr     error
+	viewer        *api.Account
+	viewerErr     error
+	fetchAttempts int
+}
+
+func (f *fakeAuthSessionClient) Verify(context.Context) error {
+	*f.events = append(*f.events, "verify")
+	return f.verifyErr
+}
+
+func (f *fakeAuthSessionClient) FetchViewer(context.Context) (*api.Account, error) {
+	*f.events = append(*f.events, "fetch-viewer")
+	f.fetchAttempts++
+	return f.viewer, f.viewerErr
+}
+
+func (f *fakeAuthSessionClient) ApplyRefreshedQueryIDs(*config.Config) bool { return false }
+
+func TestVerifyAndSaveKeysByViewerUserIDAndDoesNotInheritSessionMetadata(t *testing.T) {
+	events := []string{}
+	loaded := &config.Config{
+		AuthToken: "old-auth", CT0: "old-ct0", UserID: "1560376068", Handle: "first",
+		HomeTimelineQID: "home-qid", ViewerQID: "viewer-qid", Theme: "dracula",
+		Columns:         []string{"foryou", "following"},
+		SessionBrowser:  "Firefox",
+		SessionProfile:  "old-profile",
+		SessionDomain:   "twitter.com",
+		SessionExpires:  time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		SessionImported: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	store := &fakeAuthConfigStore{loaded: loaded, events: &events}
+	client := &fakeAuthSessionClient{
+		events: &events,
+		viewer: &api.Account{ID: "42", Handle: "second"},
+	}
+	imported := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	result := &api.LoginResult{
+		AuthToken: "new-auth", CT0: "new-ct0", Profile: "Profile 8",
+		CookieDomain: "x.com", ExpiresAt: imported.Add(24 * time.Hour),
+	}
+
+	conn, err := verifyAndSaveWith(context.Background(), result, "Chrome", store,
+		func(cfg *config.Config) authSessionClient { return client },
+		func() time.Time { return imported })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conn.handle != "second" || store.saved == nil {
+		t.Fatalf("connection=%+v saved=%+v", conn, store.saved)
+	}
+	if store.saved.UserID != "42" || store.saved.Handle != "second" {
+		t.Fatalf("saved identity = %q @%s, want viewer identity 42 @second", store.saved.UserID, store.saved.Handle)
+	}
+	if store.saved.AuthToken != "new-auth" || store.saved.CT0 != "new-ct0" ||
+		store.saved.SessionBrowser != "Chrome" || store.saved.SessionProfile != "Profile 8" ||
+		store.saved.SessionDomain != "x.com" || !store.saved.SessionImported.Equal(imported) {
+		t.Fatalf("saved session inherited active-account metadata: %+v", store.saved)
+	}
+	if store.saved.HomeTimelineQID != "home-qid" || store.saved.ViewerQID != "viewer-qid" ||
+		store.saved.Theme != "dracula" || len(store.saved.Columns) != 2 {
+		t.Fatalf("global settings were not retained: %+v", store.saved)
+	}
+	wantOrder := "verify,fetch-viewer,record-viewer,save-account,save-query-ids"
+	if got := strings.Join(events, ","); got != wantOrder {
+		t.Fatalf("auth order = %s, want %s", got, wantOrder)
+	}
+}
+
+func TestReauthOfKnownAccountUpdatesInPlaceNotNewSlot(t *testing.T) {
+	events := []string{}
+	old := config.Config{UserID: "42", AuthToken: "old-auth", CT0: "old-ct0"}
+	store := &fakeAuthConfigStore{
+		loaded:   &old,
+		accounts: map[string]config.Config{"42": old},
+		events:   &events,
+	}
+	client := &fakeAuthSessionClient{
+		events: &events,
+		viewer: &api.Account{ID: "42", Handle: "renamed"},
+	}
+	result := &api.LoginResult{AuthToken: "new-auth", CT0: "new-ct0", Profile: "Default"}
+
+	if _, err := verifyAndSaveWith(context.Background(), result, "Chrome", store,
+		func(cfg *config.Config) authSessionClient { return client }, time.Now); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.accounts) != 1 {
+		t.Fatalf("reauth created %d account slots, want 1", len(store.accounts))
+	}
+	updated := store.accounts["42"]
+	if updated.AuthToken != "new-auth" || updated.Handle != "renamed" {
+		t.Fatalf("known account was not updated in place: %+v", updated)
+	}
+}
+
+func TestVerifyAndSaveFailsClosedWhenViewerUnidentifiable(t *testing.T) {
+	events := []string{}
+	store := &fakeAuthConfigStore{loaded: &config.Config{}, events: &events}
+	client := &fakeAuthSessionClient{
+		events:    &events,
+		viewerErr: errors.New("identity endpoint unavailable"),
+	}
+	result := &api.LoginResult{AuthToken: "auth", CT0: "ct0"}
+
+	_, err := verifyAndSaveWith(context.Background(), result, "Chrome", store,
+		func(cfg *config.Config) authSessionClient { return client }, time.Now)
+	if err == nil || !strings.Contains(err.Error(), "verified but xeet could not identify the account; try again") {
+		t.Fatalf("error = %v, want fail-closed identification guidance", err)
+	}
+	if client.fetchAttempts != 2 {
+		t.Fatalf("FetchViewer attempts = %d, want one retry", client.fetchAttempts)
+	}
+	if store.saveAccountCalls != 0 {
+		t.Fatalf("SaveAccount called %d times without a viewer id", store.saveAccountCalls)
+	}
+}

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -167,3 +167,50 @@ func TestVerifyAndSaveFailsClosedWhenViewerUnidentifiable(t *testing.T) {
 		t.Fatalf("SaveAccount called %d times without a viewer id", store.saveAccountCalls)
 	}
 }
+
+func TestScriptedAuthNamesTheProfilesInsteadOfChoosingOne(t *testing.T) {
+	sessions := []api.LoginResult{
+		{Profile: "Default", AuthToken: "a", CT0: "b"},
+		{Profile: "Profile 8", AuthToken: "c", CT0: "d"},
+	}
+	_, err := pickScriptedSession(sessions, "Chrome", "")
+	if err == nil {
+		t.Fatal("several signed-in profiles must not be resolved silently; that is how a second account disappears")
+	}
+	for _, want := range []string{"--profile", "Default", "Profile 8"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not tell the user about %q", err, want)
+		}
+	}
+}
+
+func TestScriptedAuthSelectsTheNamedProfileCaseInsensitively(t *testing.T) {
+	sessions := []api.LoginResult{
+		{Profile: "Default", AuthToken: "a", CT0: "b"},
+		{Profile: "Profile 8", AuthToken: "c", CT0: "d"},
+	}
+	got, err := pickScriptedSession(sessions, "Chrome", "profile 8")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AuthToken != "c" {
+		t.Fatalf("selected %+v, want the Profile 8 session", got)
+	}
+}
+
+func TestScriptedAuthUsesTheOnlyProfileWithoutBeingAsked(t *testing.T) {
+	got, err := pickScriptedSession([]api.LoginResult{{Profile: "Default", AuthToken: "a"}}, "Chrome", "")
+	if err != nil {
+		t.Fatalf("a single profile needs no --profile: %v", err)
+	}
+	if got.AuthToken != "a" {
+		t.Fatalf("selected %+v", got)
+	}
+}
+
+func TestScriptedAuthReportsAnUnknownProfileWithWhatExists(t *testing.T) {
+	_, err := pickScriptedSession([]api.LoginResult{{Profile: "Default"}}, "Chrome", "Profile 9")
+	if err == nil || !strings.Contains(err.Error(), "Default") {
+		t.Fatalf("error = %v; it should name the profiles that do have sessions", err)
+	}
+}

--- a/cmd/auth_ui.go
+++ b/cmd/auth_ui.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/melqtx/xeet/internal/ui"
 	"github.com/melqtx/xeet/pkg/api"
@@ -18,6 +19,7 @@ type authPhase int
 
 const (
 	authPhasePick authPhase = iota
+	authPhaseChooseProfile
 	authPhaseImport
 	authPhaseVerify
 	authPhaseDone
@@ -39,6 +41,8 @@ type authPicker struct {
 	cursor   int
 	spinner  spinner.Model
 	chosen   string
+	sessions []api.LoginResult
+	profile  int
 	conn     connection
 	err      error
 	width    int
@@ -47,8 +51,8 @@ type authPicker struct {
 
 type browsersScannedMsg []string
 
-type sessionImportedMsg struct {
-	result  *api.LoginResult
+type sessionsImportedMsg struct {
+	results []api.LoginResult
 	browser string
 	err     error
 }
@@ -82,7 +86,7 @@ func newAuthPicker(ctx context.Context, cancel context.CancelFunc, styles ui.Sty
 
 func (p authPicker) Init() tea.Cmd {
 	if p.phase == authPhaseImport {
-		return tea.Batch(p.spinner.Tick, importSessionCmd(p.chosen))
+		return tea.Batch(p.spinner.Tick, importSessionsCmd(p.chosen))
 	}
 	return tea.Batch(p.spinner.Tick, scanBrowsersCmd())
 }
@@ -94,13 +98,13 @@ func scanBrowsersCmd() tea.Cmd {
 	return func() tea.Msg { return browsersScannedMsg(api.DetectBrowsers()) }
 }
 
-func importSessionCmd(browser string) tea.Cmd {
+func importSessionsCmd(browser string) tea.Cmd {
 	return func() tea.Msg {
-		result, resolved, err := api.ImportBrowserSession(browser)
+		results, resolved, err := api.ImportBrowserSessions(browser)
 		if resolved == "" {
 			resolved = browser
 		}
-		return sessionImportedMsg{result: result, browser: resolved, err: err}
+		return sessionsImportedMsg{results: results, browser: resolved, err: err}
 	}
 }
 
@@ -134,13 +138,26 @@ func (p authPicker) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		return p, nil
-	case sessionImportedMsg:
+	case sessionsImportedMsg:
 		if msg.err != nil {
 			p.phase, p.err = authPhaseFail, msg.err
 			return p, nil
 		}
+		if len(msg.results) == 0 {
+			p.phase = authPhaseFail
+			p.err = fmt.Errorf("no logged-in x.com session found in %s", msg.browser)
+			return p, nil
+		}
+		p.chosen = msg.browser
+		p.sessions = append([]api.LoginResult(nil), msg.results...)
+		p.profile = 0
+		if len(p.sessions) > 1 {
+			p.phase = authPhaseChooseProfile
+			return p, nil
+		}
 		p.phase = authPhaseVerify
-		return p, verifyCmd(p.ctx, msg.result, msg.browser)
+		result := p.sessions[0]
+		return p, verifyCmd(p.ctx, &result, msg.browser)
 	case sessionSavedMsg:
 		if msg.err != nil {
 			p.phase, p.err = authPhaseFail, msg.err
@@ -171,8 +188,30 @@ func (p authPicker) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			p.chosen = p.browsers[p.cursor]
 			p.phase = authPhaseImport
 			p.err = nil
-			return p, tea.Batch(p.spinner.Tick, importSessionCmd(p.chosen))
+			return p, tea.Batch(p.spinner.Tick, importSessionsCmd(p.chosen))
 		case "esc", "q", "ctrl+c":
+			p.quit = true
+			return p, tea.Quit
+		}
+	case authPhaseChooseProfile:
+		switch key {
+		case "up", "k":
+			if p.profile > 0 {
+				p.profile--
+			}
+		case "down", "j":
+			if p.profile < len(p.sessions)-1 {
+				p.profile++
+			}
+		case "enter":
+			result := p.sessions[p.profile]
+			p.phase = authPhaseVerify
+			return p, verifyCmd(p.ctx, &result, p.chosen)
+		case "esc":
+			p.phase = authPhasePick
+			p.sessions = nil
+			p.profile = 0
+		case "q", "ctrl+c":
 			p.quit = true
 			return p, tea.Quit
 		}
@@ -218,6 +257,8 @@ func (p authPicker) View() string {
 
 	caption := "let's get you connected"
 	switch p.phase {
+	case authPhaseChooseProfile:
+		caption = "choose a profile"
 	case authPhaseImport, authPhaseVerify:
 		caption = "hold on tight"
 	case authPhaseDone:
@@ -228,6 +269,8 @@ func (p authPicker) View() string {
 	head := s.RenderLogo(w) + "\n" + s.RenderMascot(w, caption) + "\n\n"
 
 	switch p.phase {
+	case authPhaseChooseProfile:
+		return head + p.renderProfilePick(w)
 	case authPhaseImport:
 		return head + p.renderWorking(w, "reading your x.com session from "+p.chosen+"…",
 			"your OS may ask to unlock its keyring")
@@ -240,6 +283,33 @@ func (p authPicker) View() string {
 	default:
 		return head + p.renderPick(w)
 	}
+}
+
+func (p authPicker) renderProfilePick(width int) string {
+	s := p.styles
+	rows := []string{s.Body.Render("which signed-in profile should xeet connect?"), ""}
+	for i, session := range p.sessions {
+		profile := session.Profile
+		if profile == "" {
+			profile = "unknown profile"
+		}
+		domain := session.CookieDomain
+		if domain == "" {
+			domain = "unknown domain"
+		}
+		expiry := "expiry unknown"
+		if !session.ExpiresAt.IsZero() {
+			expiry = "expires " + session.ExpiresAt.Local().Format(time.RFC3339)
+		}
+		label := fmt.Sprintf("%s  ·  %s  ·  %s", profile, domain, expiry)
+		if i == p.profile {
+			rows = append(rows, s.Accent.Render("  › ")+s.Body.Bold(true).Render(label))
+			continue
+		}
+		rows = append(rows, "    "+s.Dim.Render(label))
+	}
+	rows = append(rows, "", s.Dim.Render("↑↓ / j k  move   ·   enter  connect   ·   esc  browsers"))
+	return lipgloss.NewStyle().Width(width).Render(lipgloss.JoinVertical(lipgloss.Left, rows...)) + "\n"
 }
 
 func (p authPicker) renderPick(width int) string {

--- a/cmd/auth_ui_test.go
+++ b/cmd/auth_ui_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/melqtx/xeet/internal/ui"
 	"github.com/melqtx/xeet/pkg/api"
@@ -101,7 +102,7 @@ func TestAuthPickerOffersAnotherBrowserAfterAFailure(t *testing.T) {
 	p := newTestAuthPicker(t, "")
 	p = updateAuth(t, p, browsersScannedMsg{})
 	p = updateAuth(t, p, key("enter"))
-	p = updateAuth(t, p, sessionImportedMsg{err: errors.New("no logged-in x.com session found in Chrome")})
+	p = updateAuth(t, p, sessionsImportedMsg{err: errors.New("no logged-in x.com session found in Chrome")})
 
 	if p.phase != authPhaseFail {
 		t.Fatalf("phase is %v, want fail", p.phase)
@@ -122,7 +123,7 @@ func TestAuthPickerOffersAnotherBrowserAfterAFailure(t *testing.T) {
 
 func TestAuthPickerVerifiesBeforeItCelebrates(t *testing.T) {
 	p := newTestAuthPicker(t, "Chrome")
-	p = updateAuth(t, p, sessionImportedMsg{result: &api.LoginResult{}, browser: "Chrome"})
+	p = updateAuth(t, p, sessionsImportedMsg{results: []api.LoginResult{{}}, browser: "Chrome"})
 	if p.phase != authPhaseVerify {
 		t.Fatalf("phase is %v, want verify after a successful import", p.phase)
 	}
@@ -134,6 +135,49 @@ func TestAuthPickerVerifiesBeforeItCelebrates(t *testing.T) {
 	}
 	if !strings.Contains(view, `Chrome profile "Default"`) {
 		t.Errorf("the success panel should say where the session came from:\n%s", view)
+	}
+}
+
+func TestAuthSkipsProfileChoiceWithSingleSession(t *testing.T) {
+	p := newTestAuthPicker(t, "Chrome")
+	p = updateAuth(t, p, sessionsImportedMsg{
+		results: []api.LoginResult{{Profile: "Default", CookieDomain: "x.com"}},
+		browser: "Chrome",
+	})
+
+	if p.phase != authPhaseVerify {
+		t.Fatalf("phase is %v, want verify without a one-row profile picker", p.phase)
+	}
+}
+
+func TestAuthProfileChoiceListsAllSessionsBestFirst(t *testing.T) {
+	now := time.Now()
+	p := newTestAuthPicker(t, "Chrome")
+	p = updateAuth(t, p, sessionsImportedMsg{
+		results: []api.LoginResult{
+			{Profile: "Profile 8", CookieDomain: "x.com", ExpiresAt: now.Add(2 * time.Hour)},
+			{Profile: "Default", CookieDomain: "x.com", ExpiresAt: now.Add(time.Hour)},
+		},
+		browser: "Chrome",
+	})
+
+	if p.phase != authPhaseChooseProfile {
+		t.Fatalf("phase is %v, want profile choice", p.phase)
+	}
+	view := p.View()
+	first := strings.Index(view, "Profile 8")
+	second := strings.Index(view, "Default")
+	if first < 0 || second < 0 || first >= second {
+		t.Fatalf("profile rows are not best-first:\n%s", view)
+	}
+	if !strings.Contains(view, "x.com") || !strings.Contains(view, "expires ") {
+		t.Fatalf("profile rows must show domain and expiry:\n%s", view)
+	}
+
+	p = updateAuth(t, p, key("down"))
+	p = updateAuth(t, p, key("enter"))
+	if p.phase != authPhaseVerify || p.profile != 1 {
+		t.Fatalf("selection did not advance to verification: phase=%v profile=%d", p.phase, p.profile)
 	}
 }
 

--- a/cmd/columns.go
+++ b/cmd/columns.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/melqtx/xeet/pkg/config"
+
+	"github.com/spf13/cobra"
+)
+
+var columnsCmd = &cobra.Command{
+	Use:   "columns",
+	Short: "manage the saved multi-column layout",
+}
+
+var columnsSaveCmd = &cobra.Command{
+	Use:     `save "spec[,spec...]"`,
+	Short:   "save the default column feeds",
+	Example: `  xeet columns save "foryou,list:123"`,
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		_, canonical, err := parseColumnSpecList(args[0])
+		if err != nil {
+			return fmt.Errorf("invalid columns layout %q (%v)", args[0], err)
+		}
+		mgr, err := config.NewConfigManager()
+		if err != nil {
+			return err
+		}
+		if err := mgr.SaveColumns(canonical); err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "saved %d columns\n", len(canonical))
+		return nil
+	},
+}
+
+func init() {
+	columnsCmd.AddCommand(columnsSaveCmd)
+	rootCmd.AddCommand(columnsCmd)
+}

--- a/cmd/columns.go
+++ b/cmd/columns.go
@@ -19,13 +19,17 @@ var columnsSaveCmd = &cobra.Command{
 	Example: `  xeet columns save "foryou,list:123"`,
 	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		_, canonical, err := parseColumnSpecList(args[0])
-		if err != nil {
-			return fmt.Errorf("invalid columns layout %q (%v)", args[0], err)
-		}
 		mgr, err := config.NewConfigManager()
 		if err != nil {
 			return err
+		}
+		accounts, err := mgr.Accounts()
+		if err != nil {
+			return err
+		}
+		_, canonical, err := parseColumnSpecList(args[0], accounts)
+		if err != nil {
+			return fmt.Errorf("invalid columns layout %q (%v)", args[0], err)
 		}
 		if err := mgr.SaveColumns(canonical); err != nil {
 			return err

--- a/cmd/columns_test.go
+++ b/cmd/columns_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/melqtx/xeet/internal/timeline"
+	"github.com/melqtx/xeet/pkg/config"
 )
 
 func TestColumnsFlagRegisteredSeparatelyOnRootAndTimeline(t *testing.T) {
@@ -57,7 +58,7 @@ func TestColumnsFlagAcceptsCountsAndFeedSpecs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, ownsFeeds, err := parseColumnsFlag(tt.value, tt.base)
+			got, ownsFeeds, err := parseColumnsFlag(tt.value, tt.base, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -70,16 +71,48 @@ func TestColumnsFlagAcceptsCountsAndFeedSpecs(t *testing.T) {
 
 func TestColumnsFlagRejectsUnknownKindsAndMoreThanFour(t *testing.T) {
 	for _, value := range []string{"0", "5", "nonsense", "search:", "list:not-a-number", "foryou,following,bookmarks,list:1,search:go"} {
-		_, _, err := parseColumnsFlag(value, timeline.ColumnSpec{Kind: timeline.FeedForYou})
+		_, _, err := parseColumnsFlag(value, timeline.ColumnSpec{Kind: timeline.FeedForYou}, nil)
 		if err == nil || !strings.Contains(err.Error(), "invalid --columns value") {
 			t.Fatalf("--columns %q returned %v", value, err)
 		}
 	}
 }
 
+func TestColumnsFlagParsesAccountPrefixes(t *testing.T) {
+	accounts := []config.AccountInfo{
+		{UserID: "42", Handle: "alice"},
+		{UserID: "84", Handle: "bob"},
+	}
+	got, ownsFeeds, err := parseColumnsFlag(
+		"@alice:foryou,@bob:following",
+		timeline.ColumnSpec{Kind: timeline.FeedForYou},
+		accounts,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []timeline.ColumnSpec{
+		{Kind: timeline.FeedForYou, AccountID: "42"},
+		{Kind: timeline.FeedFollowing, AccountID: "84"},
+	}
+	if !ownsFeeds || !reflect.DeepEqual(got, want) {
+		t.Fatalf("account-prefixed columns = %v, %v; want %v, true", got, ownsFeeds, want)
+	}
+
+	_, _, err = parseColumnsFlag(
+		"@carol:foryou",
+		timeline.ColumnSpec{Kind: timeline.FeedForYou},
+		accounts,
+	)
+	if err == nil || !strings.Contains(err.Error(), "unknown column account @carol") ||
+		!strings.Contains(err.Error(), "@alice, @bob") {
+		t.Fatalf("unknown account error did not list known accounts: %v", err)
+	}
+}
+
 func TestColumnsFeedSpecsAreExclusiveWithSingleFeedFlagsButCountsAreNot(t *testing.T) {
 	base := timeline.ColumnSpec{Kind: timeline.FeedBookmarks}
-	specs, err := resolveColumnSpecs("2", true, nil, base, true)
+	specs, err := resolveColumnSpecs("2", true, nil, base, true, nil)
 	if err != nil {
 		t.Fatalf("--columns 2 --bookmarks returned %v", err)
 	}
@@ -87,7 +120,7 @@ func TestColumnsFeedSpecsAreExclusiveWithSingleFeedFlagsButCountsAreNot(t *testi
 		t.Fatalf("--columns 2 --bookmarks = %v", specs)
 	}
 
-	if _, err := resolveColumnSpecs("foryou,bookmarks", true, nil, base, true); err == nil ||
+	if _, err := resolveColumnSpecs("foryou,bookmarks", true, nil, base, true, nil); err == nil ||
 		!strings.Contains(err.Error(), "cannot be used") {
 		t.Fatalf("feed specs with --bookmarks returned %v", err)
 	}
@@ -101,6 +134,7 @@ func TestColumnsConfigKeyIsUsedWhenFlagAbsent(t *testing.T) {
 		[]string{"following", "search:golang"},
 		base,
 		false,
+		nil,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -122,6 +156,7 @@ func TestExplicitSingleFeedFlagOverridesSavedColumns(t *testing.T) {
 		[]string{"foryou", "following"},
 		base,
 		true,
+		nil,
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/columns_test.go
+++ b/cmd/columns_test.go
@@ -55,6 +55,11 @@ func TestColumnsFlagAcceptsCountsAndFeedSpecs(t *testing.T) {
 			},
 			ownsFeeds: true,
 		},
+		{
+			name: "notifications selects the notifications feed", value: "notifications",
+			want:      []timeline.ColumnSpec{{Kind: timeline.FeedNotifications}},
+			ownsFeeds: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/columns_test.go
+++ b/cmd/columns_test.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/melqtx/xeet/internal/timeline"
+)
+
+func TestColumnsFlagRegisteredSeparatelyOnRootAndTimeline(t *testing.T) {
+	rootColumnsFlag := rootCmd.Flags().Lookup("columns")
+	timelineColumnsFlag := timelineCmd.Flags().Lookup("columns")
+	if rootColumnsFlag == nil || timelineColumnsFlag == nil {
+		t.Fatalf("--columns must be registered separately on root and timeline: root=%v timeline=%v", rootColumnsFlag, timelineColumnsFlag)
+	}
+	if rootColumnsFlag == timelineColumnsFlag {
+		t.Fatal("root and timeline unexpectedly share one --columns flag")
+	}
+	if rootColumnsFlag.DefValue != "1" || timelineColumnsFlag.DefValue != "1" {
+		t.Fatalf("--columns defaults are root=%q timeline=%q, want 1", rootColumnsFlag.DefValue, timelineColumnsFlag.DefValue)
+	}
+}
+
+func TestColumnsFlagRejectsValuesOutsideOneToFour(t *testing.T) {
+	for _, columns := range []int{-1, 0, 5, 20} {
+		err := runTimeline(context.Background(), "off", timeline.FeedForYou, "", "", columns)
+		if err == nil || !strings.Contains(err.Error(), "invalid --columns value") ||
+			!strings.Contains(err.Error(), "1 to 4") {
+			t.Fatalf("--columns %d returned %v", columns, err)
+		}
+	}
+}

--- a/cmd/columns_test.go
+++ b/cmd/columns_test.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
-	"context"
+	"bytes"
+	"os"
+	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -22,12 +25,149 @@ func TestColumnsFlagRegisteredSeparatelyOnRootAndTimeline(t *testing.T) {
 	}
 }
 
-func TestColumnsFlagRejectsValuesOutsideOneToFour(t *testing.T) {
-	for _, columns := range []int{-1, 0, 5, 20} {
-		err := runTimeline(context.Background(), "off", timeline.FeedForYou, "", "", columns)
-		if err == nil || !strings.Contains(err.Error(), "invalid --columns value") ||
-			!strings.Contains(err.Error(), "1 to 4") {
-			t.Fatalf("--columns %d returned %v", columns, err)
+func TestColumnsFlagAcceptsCountsAndFeedSpecs(t *testing.T) {
+	bookmarks := timeline.ColumnSpec{Kind: timeline.FeedBookmarks}
+	tests := []struct {
+		name      string
+		value     string
+		base      timeline.ColumnSpec
+		want      []timeline.ColumnSpec
+		ownsFeeds bool
+	}{
+		{
+			name: "count repeats selected feed", value: "2", base: bookmarks,
+			want: []timeline.ColumnSpec{bookmarks, bookmarks},
+		},
+		{
+			name: "feed list selects each feed", value: "foryou,bookmarks",
+			want: []timeline.ColumnSpec{
+				{Kind: timeline.FeedForYou},
+				{Kind: timeline.FeedBookmarks},
+			},
+			ownsFeeds: true,
+		},
+		{
+			name: "parameterized feeds preserve values", value: "list:1234567890,search:golang",
+			want: []timeline.ColumnSpec{
+				{Kind: timeline.FeedList, ListID: "1234567890"},
+				{Kind: timeline.FeedSearch, Query: "golang"},
+			},
+			ownsFeeds: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ownsFeeds, err := parseColumnsFlag(tt.value, tt.base)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, tt.want) || ownsFeeds != tt.ownsFeeds {
+				t.Fatalf("parseColumnsFlag(%q) = %v, %v; want %v, %v", tt.value, got, ownsFeeds, tt.want, tt.ownsFeeds)
+			}
+		})
+	}
+}
+
+func TestColumnsFlagRejectsUnknownKindsAndMoreThanFour(t *testing.T) {
+	for _, value := range []string{"0", "5", "nonsense", "search:", "list:not-a-number", "foryou,following,bookmarks,list:1,search:go"} {
+		_, _, err := parseColumnsFlag(value, timeline.ColumnSpec{Kind: timeline.FeedForYou})
+		if err == nil || !strings.Contains(err.Error(), "invalid --columns value") {
+			t.Fatalf("--columns %q returned %v", value, err)
 		}
+	}
+}
+
+func TestColumnsFeedSpecsAreExclusiveWithSingleFeedFlagsButCountsAreNot(t *testing.T) {
+	base := timeline.ColumnSpec{Kind: timeline.FeedBookmarks}
+	specs, err := resolveColumnSpecs("2", true, nil, base, true)
+	if err != nil {
+		t.Fatalf("--columns 2 --bookmarks returned %v", err)
+	}
+	if !reflect.DeepEqual(specs, []timeline.ColumnSpec{base, base}) {
+		t.Fatalf("--columns 2 --bookmarks = %v", specs)
+	}
+
+	if _, err := resolveColumnSpecs("foryou,bookmarks", true, nil, base, true); err == nil ||
+		!strings.Contains(err.Error(), "cannot be used") {
+		t.Fatalf("feed specs with --bookmarks returned %v", err)
+	}
+}
+
+func TestColumnsConfigKeyIsUsedWhenFlagAbsent(t *testing.T) {
+	base := timeline.ColumnSpec{Kind: timeline.FeedForYou}
+	got, err := resolveColumnSpecs(
+		"1",
+		false,
+		[]string{"following", "search:golang"},
+		base,
+		false,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []timeline.ColumnSpec{
+		{Kind: timeline.FeedFollowing},
+		{Kind: timeline.FeedSearch, Query: "golang"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("configured columns = %v, want %v", got, want)
+	}
+}
+
+func TestExplicitSingleFeedFlagOverridesSavedColumns(t *testing.T) {
+	base := timeline.ColumnSpec{Kind: timeline.FeedBookmarks}
+	got, err := resolveColumnSpecs(
+		"1",
+		false,
+		[]string{"foryou", "following"},
+		base,
+		true,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, []timeline.ColumnSpec{base}) {
+		t.Fatalf("explicit bookmarks resolved to %v", got)
+	}
+}
+
+func TestColumnsSaveCommandValidatesAndWritesCanonicalSpecs(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	var out bytes.Buffer
+	columnsSaveCmd.SetOut(&out)
+	defer columnsSaveCmd.SetOut(nil)
+
+	if err := columnsSaveCmd.RunE(columnsSaveCmd, []string{" foryou, list:123 "}); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, ".xeet.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(data)
+	for _, want := range []string{"columns:", "- foryou", "- list:123"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("saved config is missing %q:\n%s", want, body)
+		}
+	}
+	if got := out.String(); got != "saved 2 columns\n" {
+		t.Fatalf("save output = %q", got)
+	}
+}
+
+func TestColumnsCommandIsRegistered(t *testing.T) {
+	found := false
+	for _, command := range rootCmd.Commands() {
+		if command.Name() == "columns" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("columns command is not registered")
+	}
+	if columnsSaveCmd.Parent() != columnsCmd {
+		t.Fatal("columns save is not registered under columns")
 	}
 }

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -42,7 +42,17 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	if cfg.AuthToken == "" || cfg.CT0 == "" {
 		return fmt.Errorf("no saved session; run 'xeet auth' first")
 	}
+	version, err := manager.Version()
+	if err != nil {
+		return err
+	}
+	accounts, err := manager.Accounts()
+	if err != nil {
+		return err
+	}
 
+	fmt.Fprintf(cmd.OutOrStdout(), "config version: %d\n", version)
+	fmt.Fprintf(cmd.OutOrStdout(), "accounts: %d\n", len(accounts))
 	fmt.Fprintln(cmd.OutOrStdout(), "saved session: present")
 	fmt.Fprintf(cmd.OutOrStdout(), "fingerprint: %s\n", sessionFingerprint(cfg.AuthToken, cfg.CT0))
 	fmt.Fprintf(cmd.OutOrStdout(), "source: %s\n", sessionSource(cfg))

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -53,6 +53,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 
 	fmt.Fprintf(cmd.OutOrStdout(), "config version: %d\n", version)
 	fmt.Fprintf(cmd.OutOrStdout(), "accounts: %d\n", len(accounts))
+	fmt.Fprintf(cmd.OutOrStdout(), "active account: %s\n", cfg.UserID)
 	fmt.Fprintln(cmd.OutOrStdout(), "saved session: present")
 	fmt.Fprintf(cmd.OutOrStdout(), "fingerprint: %s\n", sessionFingerprint(cfg.AuthToken, cfg.CT0))
 	fmt.Fprintf(cmd.OutOrStdout(), "source: %s\n", sessionSource(cfg))

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -1,0 +1,249 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/melqtx/xeet/pkg/api"
+	"github.com/melqtx/xeet/pkg/config"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	fetchText    bool
+	fetchReplies int
+	fetchAccount string
+)
+
+var fetchCmd = &cobra.Command{
+	Use:   "fetch <url-or-id>",
+	Short: "fetch a single post as JSON, for scripts and agents",
+	Long: `Fetch one post without opening the interface and print it as JSON on
+stdout — the shape scripts and AI agents can consume directly. The argument is
+a post URL (x.com or twitter.com) or a bare status id. Progress and errors go
+to stderr, so stdout stays pipe-clean; a missing or invisible post exits
+non-zero. Pass --text for a human-readable rendering instead, and --replies N
+to include up to N replies in the output.`,
+	Example: `  xeet fetch https://x.com/alice/status/1234567890
+  xeet fetch 1234567890 | jq .text
+  xeet fetch https://twitter.com/alice/status/123 --text
+  xeet fetch https://x.com/alice/status/123 --replies 5`,
+	Args: cobra.ExactArgs(1),
+	RunE: runFetch,
+}
+
+func init() {
+	fetchCmd.Flags().BoolVar(&fetchText, "text", false, "print a human-readable rendering instead of JSON")
+	fetchCmd.Flags().IntVar(&fetchReplies, "replies", 0, "include up to N replies in the output")
+	fetchCmd.Flags().StringVar(&fetchAccount, "account", "", "saved account to read as (handle or user id); defaults to the active one")
+	rootCmd.AddCommand(fetchCmd)
+}
+
+// The JSON schema is defined here rather than marshalling api.TimelinePost
+// directly: agents build on these keys, so they must not shift when the
+// internal struct does.
+type fetchAuthor struct {
+	Name   string `json:"name"`
+	Handle string `json:"handle"`
+}
+
+type fetchMedia struct {
+	URL     string `json:"url"`
+	Type    string `json:"type"`
+	AltText string `json:"alt_text,omitempty"`
+}
+
+type fetchArticle struct {
+	Title string `json:"title,omitempty"`
+	Text  string `json:"text"`
+}
+
+type fetchPost struct {
+	ID             string        `json:"id"`
+	URL            string        `json:"url"`
+	Author         fetchAuthor   `json:"author"`
+	CreatedAt      string        `json:"created_at,omitempty"`
+	Text           string        `json:"text"`
+	Article        *fetchArticle `json:"article,omitempty"`
+	ReplyCount     int           `json:"reply_count"`
+	RepostCount    int           `json:"repost_count"`
+	LikeCount      int           `json:"like_count"`
+	ViewCount      string        `json:"view_count,omitempty"`
+	Media          []fetchMedia  `json:"media,omitempty"`
+	Liked          bool          `json:"liked"`
+	Reposted       bool          `json:"reposted"`
+	Bookmarked     bool          `json:"bookmarked"`
+	InReplyToID    string        `json:"in_reply_to_id,omitempty"`
+	ConversationID string        `json:"conversation_id,omitempty"`
+	Replies        []fetchPost   `json:"replies,omitempty"`
+}
+
+func fetchPostFrom(post api.TimelinePost) fetchPost {
+	out := fetchPost{
+		ID:             post.ID,
+		URL:            fmt.Sprintf("https://x.com/%s/status/%s", post.Handle, post.ID),
+		Author:         fetchAuthor{Name: post.AuthorName, Handle: post.Handle},
+		Text:           post.Text,
+		ReplyCount:     post.ReplyCount,
+		RepostCount:    post.RepostCount,
+		LikeCount:      post.LikeCount,
+		ViewCount:      post.ViewCount,
+		Liked:          post.Liked,
+		Reposted:       post.Reposted,
+		Bookmarked:     post.Bookmarked,
+		InReplyToID:    post.InReplyToID,
+		ConversationID: post.ConversationID,
+	}
+	if !post.CreatedAt.IsZero() {
+		out.CreatedAt = post.CreatedAt.UTC().Format(time.RFC3339)
+	}
+	if post.Article != nil {
+		out.Article = &fetchArticle{Title: post.Article.Title, Text: post.Article.Text}
+	}
+	for _, media := range post.Media {
+		out.Media = append(out.Media, fetchMedia{URL: media.URL, Type: media.Type, AltText: media.AltText})
+	}
+	return out
+}
+
+func renderFetchJSON(focal api.TimelinePost, replies []api.TimelinePost) ([]byte, error) {
+	out := fetchPostFrom(focal)
+	for _, reply := range replies {
+		out.Replies = append(out.Replies, fetchPostFrom(reply))
+	}
+	return json.MarshalIndent(out, "", "  ")
+}
+
+func renderFetchText(focal api.TimelinePost, replies []api.TimelinePost) string {
+	var b strings.Builder
+	writePost := func(post api.TimelinePost, indent string) {
+		stamp := ""
+		if !post.CreatedAt.IsZero() {
+			stamp = " · " + post.CreatedAt.UTC().Format("2006-01-02 15:04 UTC")
+		}
+		fmt.Fprintf(&b, "%s%s (@%s)%s\n%s\n", indent, post.AuthorName, post.Handle, stamp, indent+post.Text)
+		if post.Article != nil {
+			if post.Article.Title != "" {
+				fmt.Fprintf(&b, "%s\n%s[Article: %s]\n", indent, indent, post.Article.Title)
+			}
+			fmt.Fprintf(&b, "%s%s\n", indent, post.Article.Text)
+		}
+		fmt.Fprintf(&b, "%s♥ %d · ⟳ %d · 💬 %d", indent, post.LikeCount, post.RepostCount, post.ReplyCount)
+		if post.ViewCount != "" {
+			fmt.Fprintf(&b, " · views %s", post.ViewCount)
+		}
+		fmt.Fprintf(&b, "\n%shttps://x.com/%s/status/%s\n", indent, post.Handle, post.ID)
+	}
+	writePost(focal, "")
+	for _, reply := range replies {
+		fmt.Fprintln(&b)
+		writePost(reply, "  ↳ ")
+	}
+	return b.String()
+}
+
+// tweetIDFromArg accepts a bare status id or an x.com/twitter.com status URL
+// and returns the id. Host matching is exact after stripping www./mobile. —
+// a lookalike domain must fail rather than fetch under our session.
+func tweetIDFromArg(arg string) (string, error) {
+	arg = strings.TrimSpace(arg)
+	if arg == "" {
+		return "", fmt.Errorf("pass a post URL or status id")
+	}
+	if isStatusID(arg) {
+		return arg, nil
+	}
+	parsed, err := url.Parse(arg)
+	if err != nil {
+		return "", fmt.Errorf("parse %q: %w", arg, err)
+	}
+	host := strings.ToLower(parsed.Hostname())
+	host = strings.TrimPrefix(host, "www.")
+	host = strings.TrimPrefix(host, "mobile.")
+	if host != "x.com" && host != "twitter.com" {
+		return "", fmt.Errorf("not an x.com or twitter.com URL: %s", arg)
+	}
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	for i, part := range parts {
+		if (part == "status" || part == "statuses") && i+1 < len(parts) && isStatusID(parts[i+1]) {
+			return parts[i+1], nil
+		}
+	}
+	return "", fmt.Errorf("no status id found in URL: %s", arg)
+}
+
+func isStatusID(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func runFetch(cmd *cobra.Command, args []string) error {
+	id, err := tweetIDFromArg(args[0])
+	if err != nil {
+		return err
+	}
+	configMgr, err := config.NewConfigManager()
+	if err != nil {
+		return err
+	}
+	selector, err := accountSelectorFrom(cmd, fetchAccount)
+	if err != nil {
+		return err
+	}
+	cfg, err := loadAccountSelection(configMgr, selector)
+	if err != nil {
+		return err
+	}
+	if cfg.AuthToken == "" {
+		return fmt.Errorf("run 'xeet auth' first")
+	}
+
+	client := api.NewWebClient(cfg)
+	count := 1
+	if fetchReplies > 0 {
+		count = fetchReplies + 1
+	}
+	page, err := client.FetchTweetDetail(cmd.Context(), id, "", count)
+	if err != nil {
+		return err
+	}
+	// Cache freshly discovered operation ids so later commands avoid discovery.
+	if client.ApplyRefreshedQueryIDs(cfg) {
+		_ = configMgr.SaveQueryIDs(cfg)
+	}
+	if len(page.Posts) == 0 || page.Posts[0].ID != id {
+		return fmt.Errorf("post %s not found or not visible to this account", id)
+	}
+	focal := page.Posts[0].TimelinePost
+	var replies []api.TimelinePost
+	if fetchReplies > 0 {
+		for _, reply := range page.Posts[1:] {
+			if len(replies) == fetchReplies {
+				break
+			}
+			replies = append(replies, reply.TimelinePost)
+		}
+	}
+
+	if fetchText {
+		fmt.Fprint(cmd.OutOrStdout(), renderFetchText(focal, replies))
+		return nil
+	}
+	data, err := renderFetchJSON(focal, replies)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), string(data))
+	return nil
+}

--- a/cmd/fetch_test.go
+++ b/cmd/fetch_test.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/melqtx/xeet/pkg/api"
+)
+
+func TestTweetIDFromArg(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{name: "bare id", arg: "1234567890", want: "1234567890"},
+		{name: "x.com status", arg: "https://x.com/alice/status/1234567890", want: "1234567890"},
+		{name: "twitter.com status", arg: "https://twitter.com/alice/status/1234567890", want: "1234567890"},
+		{name: "www prefix", arg: "https://www.x.com/alice/status/1234567890", want: "1234567890"},
+		{name: "mobile prefix", arg: "https://mobile.twitter.com/alice/status/1234567890", want: "1234567890"},
+		{name: "statuses plural", arg: "https://x.com/alice/statuses/1234567890", want: "1234567890"},
+		{name: "tracking query", arg: "https://x.com/alice/status/1234567890?s=20&t=abc", want: "1234567890"},
+		{name: "photo suffix", arg: "https://x.com/alice/status/1234567890/photo/1", want: "1234567890"},
+		{name: "analytics suffix", arg: "https://x.com/alice/status/1234567890/analytics", want: "1234567890"},
+		{name: "http scheme", arg: "http://x.com/alice/status/1234567890", want: "1234567890"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := tweetIDFromArg(test.arg)
+			if err != nil {
+				t.Fatalf("tweetIDFromArg(%q): %v", test.arg, err)
+			}
+			if got != test.want {
+				t.Fatalf("tweetIDFromArg(%q) = %q, want %q", test.arg, got, test.want)
+			}
+		})
+	}
+}
+
+func TestTweetIDFromArgRejectsNonStatusInput(t *testing.T) {
+	for _, arg := range []string{
+		"",
+		"   ",
+		"not-a-url",
+		"https://example.com/alice/status/123",
+		"https://xcom.evil.example/alice/status/123",
+		"https://x.com/alice",
+		"https://x.com/home",
+		"https://x.com/alice/status/abc",
+	} {
+		if id, err := tweetIDFromArg(arg); err == nil {
+			t.Fatalf("tweetIDFromArg(%q) = %q, want error", arg, id)
+		}
+	}
+}
+
+func TestRenderFetchJSONEmitsStableAgentSchema(t *testing.T) {
+	focal := api.TimelinePost{
+		ID:         "123",
+		Text:       "hello agents",
+		AuthorName: "Alice",
+		Handle:     "alice",
+		CreatedAt:  time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC),
+		ReplyCount: 2, RepostCount: 3, LikeCount: 4,
+		ViewCount:  "55",
+		Media:      []api.TimelineMedia{{URL: "https://pbs.twimg.com/media/abc", Type: "photo", AltText: "a cat"}},
+		Article:    &api.TimelineArticle{Title: "My Article", Text: "the full body"},
+		Bookmarked: true,
+	}
+	replies := []api.TimelinePost{{ID: "124", Text: "first reply", Handle: "bob", InReplyToID: "123"}}
+
+	data, err := renderFetchJSON(focal, replies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, data)
+	}
+	if decoded["id"] != "123" || decoded["url"] != "https://x.com/alice/status/123" {
+		t.Fatalf("id/url wrong: %v", decoded)
+	}
+	author, _ := decoded["author"].(map[string]any)
+	if author["handle"] != "alice" || author["name"] != "Alice" {
+		t.Fatalf("author wrong: %v", author)
+	}
+	if decoded["created_at"] != "2026-07-20T10:00:00Z" {
+		t.Fatalf("created_at = %v", decoded["created_at"])
+	}
+	article, _ := decoded["article"].(map[string]any)
+	if article["title"] != "My Article" || article["text"] != "the full body" {
+		t.Fatalf("article wrong: %v", article)
+	}
+	media, _ := decoded["media"].([]any)
+	if len(media) != 1 || media[0].(map[string]any)["alt_text"] != "a cat" {
+		t.Fatalf("media wrong: %v", media)
+	}
+	replyList, _ := decoded["replies"].([]any)
+	if len(replyList) != 1 || replyList[0].(map[string]any)["in_reply_to_id"] != "123" {
+		t.Fatalf("replies wrong: %v", replyList)
+	}
+	if decoded["bookmarked"] != true || decoded["reply_count"] != float64(2) {
+		t.Fatalf("flags/counts wrong: %v", decoded)
+	}
+}
+
+func TestRenderFetchJSONOmitsAbsentArticleAndReplies(t *testing.T) {
+	data, err := renderFetchJSON(api.TimelinePost{ID: "1", Text: "plain", Handle: "alice"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := decoded["article"]; ok {
+		t.Fatalf("article key should be omitted: %s", data)
+	}
+	if _, ok := decoded["replies"]; ok {
+		t.Fatalf("replies key should be omitted: %s", data)
+	}
+}
+
+func TestRenderFetchTextIncludesBodyCountsAndURL(t *testing.T) {
+	focal := api.TimelinePost{
+		ID: "123", Text: "hello", AuthorName: "Alice", Handle: "alice",
+		CreatedAt: time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC),
+		LikeCount: 4, RepostCount: 3, ReplyCount: 2, ViewCount: "55",
+		Article: &api.TimelineArticle{Title: "My Article", Text: "the full body"},
+	}
+	out := renderFetchText(focal, []api.TimelinePost{{ID: "124", Text: "reply", AuthorName: "Bob", Handle: "bob"}})
+	for _, want := range []string{
+		"Alice (@alice)", "hello", "[Article: My Article]", "the full body",
+		"♥ 4 · ⟳ 3 · 💬 2", "views 55", "https://x.com/alice/status/123", "↳", "Bob (@bob)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("text output missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -20,7 +20,7 @@ var commandGroups = []struct {
 	names []string
 }{
 	{"start here", []string{"auth", "whoami", "doctor", "logout"}},
-	{"every day", []string{"timeline", "search", "post", "theme"}},
+	{"every day", []string{"timeline", "lists", "search", "post", "theme"}},
 	{"extras", []string{"version", "inspect-har", "completion", "help"}},
 }
 

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -20,7 +20,7 @@ var commandGroups = []struct {
 	names []string
 }{
 	{"start here", []string{"auth", "whoami", "doctor", "logout"}},
-	{"every day", []string{"timeline", "lists", "search", "post", "theme"}},
+	{"every day", []string{"timeline", "lists", "search", "columns", "post", "theme"}},
 	{"extras", []string{"version", "inspect-har", "completion", "help"}},
 }
 

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -19,7 +19,7 @@ var commandGroups = []struct {
 	title string
 	names []string
 }{
-	{"start here", []string{"auth", "whoami", "doctor", "logout"}},
+	{"start here", []string{"auth", "accounts", "whoami", "doctor", "logout"}},
 	{"every day", []string{"timeline", "lists", "search", "columns", "post", "theme"}},
 	{"extras", []string{"version", "inspect-har", "completion", "help"}},
 }

--- a/cmd/help_test.go
+++ b/cmd/help_test.go
@@ -32,7 +32,7 @@ func TestRootHelpListsEveryVisibleCommand(t *testing.T) {
 	}
 }
 
-func TestListsCommandAppearsWithTimelineAndSearch(t *testing.T) {
+func TestFeedCommandsAppearTogetherInEveryDayHelp(t *testing.T) {
 	for _, group := range groupCommands(rootCmd) {
 		if group.title != "every day" {
 			continue
@@ -41,7 +41,7 @@ func TestListsCommandAppearsWithTimelineAndSearch(t *testing.T) {
 		for _, command := range group.commands {
 			seen[command.Name()] = true
 		}
-		for _, want := range []string{"timeline", "lists", "search"} {
+		for _, want := range []string{"timeline", "lists", "search", "columns"} {
 			if !seen[want] {
 				t.Fatalf("%q is missing from the every day help group: %v", want, seen)
 			}

--- a/cmd/help_test.go
+++ b/cmd/help_test.go
@@ -51,6 +51,21 @@ func TestFeedCommandsAppearTogetherInEveryDayHelp(t *testing.T) {
 	t.Fatal("root help has no every day command group")
 }
 
+func TestAccountsAppearsInStartHereHelp(t *testing.T) {
+	for _, group := range groupCommands(rootCmd) {
+		if group.title != "start here" {
+			continue
+		}
+		for _, command := range group.commands {
+			if command.Name() == "accounts" {
+				return
+			}
+		}
+		t.Fatalf("accounts is missing from the start here help group: %v", group.commands)
+	}
+	t.Fatal("root help has no start here command group")
+}
+
 func TestRootHelpHidesHiddenCommands(t *testing.T) {
 	tidyGeneratedCommands()
 	var buf bytes.Buffer

--- a/cmd/help_test.go
+++ b/cmd/help_test.go
@@ -32,6 +32,25 @@ func TestRootHelpListsEveryVisibleCommand(t *testing.T) {
 	}
 }
 
+func TestListsCommandAppearsWithTimelineAndSearch(t *testing.T) {
+	for _, group := range groupCommands(rootCmd) {
+		if group.title != "every day" {
+			continue
+		}
+		seen := map[string]bool{}
+		for _, command := range group.commands {
+			seen[command.Name()] = true
+		}
+		for _, want := range []string{"timeline", "lists", "search"} {
+			if !seen[want] {
+				t.Fatalf("%q is missing from the every day help group: %v", want, seen)
+			}
+		}
+		return
+	}
+	t.Fatal("root help has no every day command group")
+}
+
 func TestRootHelpHidesHiddenCommands(t *testing.T) {
 	tidyGeneratedCommands()
 	var buf bytes.Buffer

--- a/cmd/lists.go
+++ b/cmd/lists.go
@@ -20,7 +20,11 @@ var listsCmd = &cobra.Command{
 		if err := applyConfiguredTheme(listsTheme); err != nil {
 			return err
 		}
-		return runTimeline(cmd.Context(), listsImageMode, []timeline.ColumnSpec{{Kind: timeline.FeedList}})
+		refresh, err := refreshIntervalFor(cmd)
+		if err != nil {
+			return err
+		}
+		return runTimeline(cmd.Context(), listsImageMode, []timeline.ColumnSpec{{Kind: timeline.FeedList}}, refresh)
 	},
 }
 

--- a/cmd/lists.go
+++ b/cmd/lists.go
@@ -20,7 +20,7 @@ var listsCmd = &cobra.Command{
 		if err := applyConfiguredTheme(listsTheme); err != nil {
 			return err
 		}
-		return runTimeline(cmd.Context(), listsImageMode, timeline.FeedList, "", "")
+		return runTimeline(cmd.Context(), listsImageMode, timeline.FeedList, "", "", 1)
 	},
 }
 

--- a/cmd/lists.go
+++ b/cmd/lists.go
@@ -20,7 +20,7 @@ var listsCmd = &cobra.Command{
 		if err := applyConfiguredTheme(listsTheme); err != nil {
 			return err
 		}
-		return runTimeline(cmd.Context(), listsImageMode, timeline.FeedList, "", "", 1)
+		return runTimeline(cmd.Context(), listsImageMode, []timeline.ColumnSpec{{Kind: timeline.FeedList}})
 	},
 }
 

--- a/cmd/lists.go
+++ b/cmd/lists.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"github.com/melqtx/xeet/internal/timeline"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	listsImageMode string
+	listsTheme     string
+)
+
+var listsCmd = &cobra.Command{
+	Use:     "lists",
+	Short:   "pick a list and browse its posts",
+	Example: `  xeet lists  # pick a list and browse it`,
+	Args:    cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := applyConfiguredTheme(listsTheme); err != nil {
+			return err
+		}
+		return runTimeline(cmd.Context(), listsImageMode, timeline.FeedList, "", "")
+	},
+}
+
+func init() {
+	listsCmd.Flags().StringVar(&listsImageMode, "images", "auto", "image mode: auto, native, ansi, or off")
+	listsCmd.Flags().StringVar(&listsTheme, "theme", "", "color theme for this run (see 'xeet theme')")
+	rootCmd.AddCommand(listsCmd)
+}

--- a/cmd/lists_test.go
+++ b/cmd/lists_test.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestListsCommandRegisteredWithFlags(t *testing.T) {
+	command, _, err := rootCmd.Find([]string{"lists"})
+	if err != nil {
+		t.Fatalf("find lists command: %v", err)
+	}
+	if command != listsCmd {
+		t.Fatalf("lists resolves to %q instead of listsCmd", command.CommandPath())
+	}
+	for _, name := range []string{"images", "theme"} {
+		if listsCmd.Flags().Lookup(name) == nil {
+			t.Errorf("lists command is missing --%s", name)
+		}
+	}
+
+	rootList := rootCmd.Flags().Lookup("list")
+	timelineList := timelineCmd.Flags().Lookup("list")
+	if rootList == nil || timelineList == nil {
+		t.Fatalf("--list must be registered separately on root and timeline: root=%v timeline=%v", rootList, timelineList)
+	}
+	if rootList == timelineList {
+		t.Fatal("root and timeline unexpectedly share one --list flag")
+	}
+}
+
+func TestTimelineListFlagIsExclusiveWithOtherFeeds(t *testing.T) {
+	tests := []struct {
+		name    string
+		command *cobra.Command
+		other   string
+	}{
+		{name: "timeline following", command: timelineCmd, other: "following"},
+		{name: "timeline bookmarks", command: timelineCmd, other: "bookmarks"},
+		{name: "root following", command: rootCmd, other: "following"},
+		{name: "root bookmarks", command: rootCmd, other: "bookmarks"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setChangedFlag(t, tt.command, "list", "123")
+			setChangedFlag(t, tt.command, tt.other, "true")
+			err := tt.command.ValidateFlagGroups()
+			if err == nil || !strings.Contains(err.Error(), "none of the others can be") {
+				t.Fatalf("--list and --%s were not rejected as mutually exclusive: %v", tt.other, err)
+			}
+		})
+	}
+}
+
+func TestListIDMustBeNumeric(t *testing.T) {
+	for _, id := range []string{"123", "00123"} {
+		if !isNumericListID(id) {
+			t.Errorf("numeric list id %q was rejected", id)
+		}
+	}
+	for _, id := range []string{"", "abc", "12.3", "-123", "+123"} {
+		if isNumericListID(id) {
+			t.Errorf("non-numeric list id %q was accepted", id)
+		}
+	}
+}
+
+func setChangedFlag(t *testing.T, command *cobra.Command, name, value string) {
+	t.Helper()
+	flag := command.Flags().Lookup(name)
+	if flag == nil {
+		t.Fatalf("%s has no --%s flag", command.CommandPath(), name)
+	}
+	oldValue := flag.Value.String()
+	oldChanged := flag.Changed
+	if err := command.Flags().Set(name, value); err != nil {
+		t.Fatalf("set --%s: %v", name, err)
+	}
+	t.Cleanup(func() {
+		if err := command.Flags().Set(name, oldValue); err != nil {
+			t.Errorf("restore --%s: %v", name, err)
+		}
+		flag.Changed = oldChanged
+	})
+}

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -8,24 +8,43 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var logoutAll bool
+
 var logoutCmd = &cobra.Command{
 	Use:   "logout",
 	Short: "disconnect and erase the saved session",
-	Long: `Removes the x.com session tokens from your OS keyring and deletes xeet's
-config file. Your browser session is untouched; run 'xeet auth' to reconnect.`,
+	Long: `Removes the active x.com session from your OS keyring while preserving
+other accounts and global settings. Use --all to remove every account and the
+config file. Your browser sessions are untouched.`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		configMgr, err := config.NewConfigManager()
 		if err != nil {
 			return err
 		}
-		if err := configMgr.Erase(); err != nil {
+		if logoutAll {
+			if err := configMgr.EraseAll(); err != nil {
+				return fmt.Errorf("logout incomplete: %w", err)
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), "✓ Logged out all accounts. Sessions and config erased.")
+			return nil
+		}
+		cfg, err := configMgr.Load()
+		if err != nil {
+			return err
+		}
+		if cfg.UserID == "" {
+			return fmt.Errorf("no saved session; run 'xeet auth' first")
+		}
+		if err := configMgr.EraseAccount(cfg.UserID); err != nil {
 			return fmt.Errorf("logout incomplete: %w", err)
 		}
-		fmt.Println("✓ Logged out. Session erased from keyring and config removed.")
+		fmt.Fprintln(cmd.OutOrStdout(), "✓ Logged out. Active session erased; global settings preserved.")
 		return nil
 	},
 }
 
 func init() {
+	logoutCmd.Flags().BoolVar(&logoutAll, "all", false, "remove every saved account and the config file")
 	rootCmd.AddCommand(logoutCmd)
 }

--- a/cmd/post.go
+++ b/cmd/post.go
@@ -90,7 +90,11 @@ func runPost(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	cfg, err := loadAccountSelection(configMgr, postAccount)
+	selector, err := accountSelectorFrom(cmd, postAccount)
+	if err != nil {
+		return err
+	}
+	cfg, err := loadAccountSelection(configMgr, selector)
 	if err != nil {
 		return err
 	}

--- a/cmd/post.go
+++ b/cmd/post.go
@@ -122,7 +122,7 @@ func runPost(cmd *cobra.Command, args []string) error {
 	}
 	// Cache freshly discovered operation ids so later commands avoid discovery.
 	if client.ApplyRefreshedQueryIDs(cfg) {
-		_ = configMgr.Save(cfg)
+		_ = configMgr.SaveQueryIDs(cfg)
 	}
 	if id != "" {
 		fmt.Printf("posted: https://x.com/i/status/%s\n", id)

--- a/cmd/post.go
+++ b/cmd/post.go
@@ -24,7 +24,14 @@ var postCmd = &cobra.Command{
 	Short: "post from the command line, or from a pipe",
 	Long: `Post straight from the command line, with no interface in the way. The text
 can be an argument or piped in on stdin; attachments are up to four images or
-a single video.`,
+a single video.
+
+--account decides which saved account posts, resolved inside this one command
+so nothing else on the machine can move it in between. It only decides; it does
+not judge. A script that used to compare its expected handle against the active
+account was getting a wrong-account check for free, because a mistaken expected
+value disagreed with whatever was active. Passing that same value to --account
+turns it into the destination instead, so the check has to move to the caller.`,
 	Example: `  xeet post "hello world"
   echo "piped tweet" | xeet post
   xeet post "photo" --image ./photo.png

--- a/cmd/post.go
+++ b/cmd/post.go
@@ -14,8 +14,9 @@ import (
 )
 
 var (
-	replyTo    string
-	imagePaths []string
+	replyTo     string
+	imagePaths  []string
+	postAccount string
 )
 
 var postCmd = &cobra.Command{
@@ -29,13 +30,15 @@ a single video.`,
   xeet post "photo" --image ./photo.png
   xeet post --image one.png --image two.jpg   # no text, images only
   xeet post "clip" --image ./clip.mp4
-  xeet post "a reply" --reply 1234567890`,
+  xeet post "a reply" --reply 1234567890
+  xeet post "hi" --account @alice        # post as a saved account, not the active one`,
 	RunE: runPost,
 }
 
 func init() {
 	postCmd.Flags().StringVar(&replyTo, "reply", "", "tweet id to reply to")
 	postCmd.Flags().StringArrayVarP(&imagePaths, "image", "i", nil, "image or video path (up to 4 images, or 1 video)")
+	postCmd.Flags().StringVar(&postAccount, "account", "", "saved account to post as (handle or user id); defaults to the active one")
 	rootCmd.AddCommand(postCmd)
 }
 
@@ -80,7 +83,7 @@ func runPost(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	cfg, err := configMgr.Load()
+	cfg, err := loadAccountSelection(configMgr, postAccount)
 	if err != nil {
 		return err
 	}

--- a/cmd/post.go
+++ b/cmd/post.go
@@ -15,6 +15,7 @@ import (
 
 var (
 	replyTo     string
+	quoteTo     string
 	imagePaths  []string
 	postAccount string
 )
@@ -38,12 +39,14 @@ turns it into the destination instead, so the check has to move to the caller.`,
   xeet post --image one.png --image two.jpg   # no text, images only
   xeet post "clip" --image ./clip.mp4
   xeet post "a reply" --reply 1234567890
+  xeet post "a quote" --quote 1234567890
   xeet post "hi" --account @alice        # post as a saved account, not the active one`,
 	RunE: runPost,
 }
 
 func init() {
 	postCmd.Flags().StringVar(&replyTo, "reply", "", "tweet id to reply to")
+	postCmd.Flags().StringVar(&quoteTo, "quote", "", "tweet id to quote")
 	postCmd.Flags().StringArrayVarP(&imagePaths, "image", "i", nil, "image or video path (up to 4 images, or 1 video)")
 	postCmd.Flags().StringVar(&postAccount, "account", "", "saved account to post as (handle or user id); defaults to the active one")
 	rootCmd.AddCommand(postCmd)
@@ -106,7 +109,7 @@ func runPost(cmd *cobra.Command, args []string) error {
 	}
 
 	client := api.NewWebClient(cfg)
-	id, err := client.PostTweet(ctx, text, replyTo, uploads, func(event api.PostEvent) {
+	id, err := client.PostTweet(ctx, text, replyTo, quoteTo, uploads, func(event api.PostEvent) {
 		if v, _ := cmd.Flags().GetBool("verbose"); v {
 			switch event.Stage {
 			case api.PostStageUploading:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,6 +34,7 @@ var rootCmd = &cobra.Command{
   xeet --bookmarks             # your saved posts
   xeet --list 123              # a list by id
   xeet --columns 2             # two copies of the selected feed
+  xeet --columns @alice:foryou,@bob:following
   xeet --compose               # just the composer
   xeet post "hello, terminal"  # post without opening anything
   xeet theme                   # pick a color theme, with a preview`,
@@ -95,7 +96,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&rootFollowing, "following", false, "start on the Following feed instead of For You")
 	rootCmd.Flags().BoolVar(&rootBookmarks, "bookmarks", false, "start on your bookmarks feed")
 	rootCmd.Flags().StringVar(&rootListID, "list", "", "start on the given list id")
-	rootCmd.Flags().StringVar(&rootColumns, "columns", "1", "column count (1-4) or feeds: foryou,following,bookmarks,list:<id>,search:<query>")
+	rootCmd.Flags().StringVar(&rootColumns, "columns", "1", "column count (1-4) or feeds, optionally prefixed with @handle:")
 	rootCmd.Flags().StringVar(&rootTheme, "theme", "", "color theme for this run (see 'xeet theme')")
 	rootCmd.MarkFlagsMutuallyExclusive("barebones", "compose")
 	rootCmd.MarkFlagsMutuallyExclusive("compose", "following")
@@ -118,19 +119,22 @@ func runRoot(cmd *cobra.Command, args []string) error {
 	base := columnSpecForFeed(feed, "", rootListID)
 	singleFeedFlag := cmd.Flags().Changed("following") ||
 		cmd.Flags().Changed("bookmarks") || cmd.Flags().Changed("list")
+	configMgr, err := config.NewConfigManager()
+	if err != nil {
+		return err
+	}
+	accounts, err := configMgr.Accounts()
+	if err != nil {
+		return err
+	}
 	var specs []timeline.ColumnSpec
 	if cmd.Flags().Changed("columns") {
-		var err error
-		specs, err = resolveColumnSpecs(rootColumns, true, nil, base, singleFeedFlag)
+		specs, err = resolveColumnSpecs(rootColumns, true, nil, base, singleFeedFlag, accounts)
 		if err != nil {
 			return err
 		}
 	}
 
-	configMgr, err := config.NewConfigManager()
-	if err != nil {
-		return err
-	}
 	// A load failure here (an incomplete keyring pair, an unreadable config)
 	// carries its own recovery advice. Falling through to the timeline would
 	// bury it under a generic fetch error.
@@ -154,7 +158,7 @@ func runRoot(cmd *cobra.Command, args []string) error {
 		imageMode = "off"
 	}
 	if specs == nil {
-		specs, err = resolveColumnSpecs(rootColumns, false, cfg.Columns, base, singleFeedFlag)
+		specs, err = resolveColumnSpecs(rootColumns, false, cfg.Columns, base, singleFeedFlag, accounts)
 		if err != nil {
 			return err
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ var (
 	composeOnly   bool
 	rootFollowing bool
 	rootBookmarks bool
+	rootListID    string
 	rootTheme     string
 )
 
@@ -30,6 +31,7 @@ var rootCmd = &cobra.Command{
 	Example: `  xeet                         # your timeline, with inline images
   xeet --following             # the Following feed instead of For You
   xeet --bookmarks             # your saved posts
+  xeet --list 123              # a list by id
   xeet --compose               # just the composer
   xeet post "hello, terminal"  # post without opening anything
   xeet theme                   # pick a color theme, with a preview`,
@@ -90,11 +92,13 @@ func init() {
 	rootCmd.Flags().BoolVar(&composeOnly, "compose", false, "open only the post composer")
 	rootCmd.Flags().BoolVar(&rootFollowing, "following", false, "start on the Following feed instead of For You")
 	rootCmd.Flags().BoolVar(&rootBookmarks, "bookmarks", false, "start on your bookmarks feed")
+	rootCmd.Flags().StringVar(&rootListID, "list", "", "start on the given list id")
 	rootCmd.Flags().StringVar(&rootTheme, "theme", "", "color theme for this run (see 'xeet theme')")
 	rootCmd.MarkFlagsMutuallyExclusive("barebones", "compose")
 	rootCmd.MarkFlagsMutuallyExclusive("compose", "following")
-	rootCmd.MarkFlagsMutuallyExclusive("following", "bookmarks")
+	rootCmd.MarkFlagsMutuallyExclusive("following", "bookmarks", "list")
 	rootCmd.MarkFlagsMutuallyExclusive("compose", "bookmarks")
+	rootCmd.MarkFlagsMutuallyExclusive("compose", "list")
 }
 
 func runRoot(cmd *cobra.Command, args []string) error {
@@ -131,7 +135,10 @@ func runRoot(cmd *cobra.Command, args []string) error {
 	if rootBookmarks {
 		feed = timeline.FeedBookmarks
 	}
-	return runTimeline(cmd.Context(), imageMode, feed, "")
+	if rootListID != "" {
+		feed = timeline.FeedList
+	}
+	return runTimeline(cmd.Context(), imageMode, feed, "", rootListID)
 }
 
 // printFirstRun greets someone who has not connected an account yet. It is the

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -98,6 +98,7 @@ func init() {
 	rootCmd.Flags().StringVar(&rootListID, "list", "", "start on the given list id")
 	rootCmd.Flags().StringVar(&rootColumns, "columns", "1", "column count (1-4) or feeds, optionally prefixed with @handle:")
 	rootCmd.Flags().StringVar(&rootTheme, "theme", "", "color theme for this run (see 'xeet theme')")
+	rootCmd.Flags().String("refresh", "", "auto-refresh the focused column every interval (e.g. 60s, 5m); off by default")
 	rootCmd.MarkFlagsMutuallyExclusive("barebones", "compose")
 	rootCmd.MarkFlagsMutuallyExclusive("compose", "following")
 	rootCmd.MarkFlagsMutuallyExclusive("following", "bookmarks", "list")
@@ -163,7 +164,11 @@ func runRoot(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
-	return runTimeline(cmd.Context(), imageMode, specs)
+	refresh, err := refreshIntervalFor(cmd)
+	if err != nil {
+		return err
+	}
+	return runTimeline(cmd.Context(), imageMode, specs, refresh)
 }
 
 // printFirstRun greets someone who has not connected an account yet. It is the

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,7 +22,7 @@ var (
 	rootFollowing bool
 	rootBookmarks bool
 	rootListID    string
-	rootColumns   int
+	rootColumns   string
 	rootTheme     string
 )
 
@@ -95,7 +95,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&rootFollowing, "following", false, "start on the Following feed instead of For You")
 	rootCmd.Flags().BoolVar(&rootBookmarks, "bookmarks", false, "start on your bookmarks feed")
 	rootCmd.Flags().StringVar(&rootListID, "list", "", "start on the given list id")
-	rootCmd.Flags().IntVar(&rootColumns, "columns", 1, "number of side-by-side columns (1-4)")
+	rootCmd.Flags().StringVar(&rootColumns, "columns", "1", "column count (1-4) or feeds: foryou,following,bookmarks,list:<id>,search:<query>")
 	rootCmd.Flags().StringVar(&rootTheme, "theme", "", "color theme for this run (see 'xeet theme')")
 	rootCmd.MarkFlagsMutuallyExclusive("barebones", "compose")
 	rootCmd.MarkFlagsMutuallyExclusive("compose", "following")
@@ -105,9 +105,28 @@ func init() {
 }
 
 func runRoot(cmd *cobra.Command, args []string) error {
-	if err := validateColumnCount(rootColumns); err != nil {
-		return err
+	feed := timeline.FeedForYou
+	if rootFollowing {
+		feed = timeline.FeedFollowing
 	}
+	if rootBookmarks {
+		feed = timeline.FeedBookmarks
+	}
+	if rootListID != "" {
+		feed = timeline.FeedList
+	}
+	base := columnSpecForFeed(feed, "", rootListID)
+	singleFeedFlag := cmd.Flags().Changed("following") ||
+		cmd.Flags().Changed("bookmarks") || cmd.Flags().Changed("list")
+	var specs []timeline.ColumnSpec
+	if cmd.Flags().Changed("columns") {
+		var err error
+		specs, err = resolveColumnSpecs(rootColumns, true, nil, base, singleFeedFlag)
+		if err != nil {
+			return err
+		}
+	}
+
 	configMgr, err := config.NewConfigManager()
 	if err != nil {
 		return err
@@ -134,17 +153,13 @@ func runRoot(cmd *cobra.Command, args []string) error {
 	if barebones {
 		imageMode = "off"
 	}
-	feed := timeline.FeedForYou
-	if rootFollowing {
-		feed = timeline.FeedFollowing
+	if specs == nil {
+		specs, err = resolveColumnSpecs(rootColumns, false, cfg.Columns, base, singleFeedFlag)
+		if err != nil {
+			return err
+		}
 	}
-	if rootBookmarks {
-		feed = timeline.FeedBookmarks
-	}
-	if rootListID != "" {
-		feed = timeline.FeedList
-	}
-	return runTimeline(cmd.Context(), imageMode, feed, "", rootListID, rootColumns)
+	return runTimeline(cmd.Context(), imageMode, specs)
 }
 
 // printFirstRun greets someone who has not connected an account yet. It is the

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,7 @@ var (
 	rootFollowing bool
 	rootBookmarks bool
 	rootListID    string
+	rootColumns   int
 	rootTheme     string
 )
 
@@ -32,6 +33,7 @@ var rootCmd = &cobra.Command{
   xeet --following             # the Following feed instead of For You
   xeet --bookmarks             # your saved posts
   xeet --list 123              # a list by id
+  xeet --columns 2             # two copies of the selected feed
   xeet --compose               # just the composer
   xeet post "hello, terminal"  # post without opening anything
   xeet theme                   # pick a color theme, with a preview`,
@@ -93,6 +95,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&rootFollowing, "following", false, "start on the Following feed instead of For You")
 	rootCmd.Flags().BoolVar(&rootBookmarks, "bookmarks", false, "start on your bookmarks feed")
 	rootCmd.Flags().StringVar(&rootListID, "list", "", "start on the given list id")
+	rootCmd.Flags().IntVar(&rootColumns, "columns", 1, "number of side-by-side columns (1-4)")
 	rootCmd.Flags().StringVar(&rootTheme, "theme", "", "color theme for this run (see 'xeet theme')")
 	rootCmd.MarkFlagsMutuallyExclusive("barebones", "compose")
 	rootCmd.MarkFlagsMutuallyExclusive("compose", "following")
@@ -102,6 +105,9 @@ func init() {
 }
 
 func runRoot(cmd *cobra.Command, args []string) error {
+	if err := validateColumnCount(rootColumns); err != nil {
+		return err
+	}
 	configMgr, err := config.NewConfigManager()
 	if err != nil {
 		return err
@@ -138,7 +144,7 @@ func runRoot(cmd *cobra.Command, args []string) error {
 	if rootListID != "" {
 		feed = timeline.FeedList
 	}
-	return runTimeline(cmd.Context(), imageMode, feed, "", rootListID)
+	return runTimeline(cmd.Context(), imageMode, feed, "", rootListID, rootColumns)
 }
 
 // printFirstRun greets someone who has not connected an account yet. It is the

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -25,7 +25,7 @@ var searchCmd = &cobra.Command{
 		if len(args) == 1 {
 			query = args[0]
 		}
-		return runTimeline(cmd.Context(), searchImageMode, timeline.FeedSearch, query, "")
+		return runTimeline(cmd.Context(), searchImageMode, timeline.FeedSearch, query, "", 1)
 	},
 }
 

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -25,7 +25,7 @@ var searchCmd = &cobra.Command{
 		if len(args) == 1 {
 			query = args[0]
 		}
-		return runTimeline(cmd.Context(), searchImageMode, timeline.FeedSearch, query)
+		return runTimeline(cmd.Context(), searchImageMode, timeline.FeedSearch, query, "")
 	},
 }
 

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -25,7 +25,9 @@ var searchCmd = &cobra.Command{
 		if len(args) == 1 {
 			query = args[0]
 		}
-		return runTimeline(cmd.Context(), searchImageMode, timeline.FeedSearch, query, "", 1)
+		return runTimeline(cmd.Context(), searchImageMode, []timeline.ColumnSpec{{
+			Kind: timeline.FeedSearch, Query: query,
+		}})
 	},
 }
 

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -25,9 +25,13 @@ var searchCmd = &cobra.Command{
 		if len(args) == 1 {
 			query = args[0]
 		}
+		refresh, err := refreshIntervalFor(cmd)
+		if err != nil {
+			return err
+		}
 		return runTimeline(cmd.Context(), searchImageMode, []timeline.ColumnSpec{{
 			Kind: timeline.FeedSearch, Query: query,
-		}})
+		}}, refresh)
 	},
 }
 

--- a/cmd/setqid.go
+++ b/cmd/setqid.go
@@ -30,7 +30,7 @@ Then run:  xeet setqid <THIS-PART>`,
 			return err
 		}
 		cfg.CreateTweetQID = args[0]
-		if err := configMgr.Save(cfg); err != nil {
+		if err := configMgr.SaveQueryIDs(cfg); err != nil {
 			return err
 		}
 		fmt.Printf("saved CreateTweet query id: %s\n", args[0])

--- a/cmd/theme.go
+++ b/cmd/theme.go
@@ -152,5 +152,7 @@ func applyConfiguredTheme(flagValue string) error {
 	}
 	timeline.ApplyTheme(palette)
 	tui.ApplyTheme(palette)
+	// The timeline's in-TUI theme picker marks the current entry from this.
+	timeline.SetThemeName(name)
 	return nil
 }

--- a/cmd/theme.go
+++ b/cmd/theme.go
@@ -79,16 +79,8 @@ func runTheme(cmd *cobra.Command, args []string) error {
 	return saveTheme(configMgr, chosen, out)
 }
 
-// saveTheme rewrites the whole config, so it has to start from the whole
-// config: saving a half-read one would drop the cached query ids and the
-// session metadata `xeet doctor` reports.
 func saveTheme(configMgr *config.ConfigManager, name string, out io.Writer) error {
-	cfg, err := configMgr.Load()
-	if err != nil {
-		return err
-	}
-	cfg.Theme = name
-	if err := configMgr.Save(cfg); err != nil {
+	if err := configMgr.SaveTheme(name); err != nil {
 		return err
 	}
 	styles := ui.New(paletteNamed(name))

--- a/cmd/timeline.go
+++ b/cmd/timeline.go
@@ -255,6 +255,8 @@ func parseColumnSpecList(value string, accounts []config.AccountInfo) ([]timelin
 			spec.Kind = timeline.FeedFollowing
 		case item == "bookmarks":
 			spec.Kind = timeline.FeedBookmarks
+		case item == "notifications":
+			spec.Kind = timeline.FeedNotifications
 		case strings.HasPrefix(item, "list:"):
 			id := strings.TrimSpace(strings.TrimPrefix(item, "list:"))
 			if !isNumericListID(id) {
@@ -272,7 +274,7 @@ func parseColumnSpecList(value string, accounts []config.AccountInfo) ([]timelin
 			spec.Query = query
 			item = "search:" + query
 		default:
-			return nil, nil, fmt.Errorf("use foryou, following, bookmarks, list:<id>, or search:<query>")
+			return nil, nil, fmt.Errorf("use foryou, following, bookmarks, notifications, list:<id>, or search:<query>")
 		}
 		specs = append(specs, spec)
 		canonical = append(canonical, prefix+item)
@@ -309,7 +311,7 @@ func validateColumnSpecs(specs []timeline.ColumnSpec) error {
 	}
 	for _, spec := range specs {
 		switch spec.Kind {
-		case timeline.FeedForYou, timeline.FeedFollowing, timeline.FeedBookmarks:
+		case timeline.FeedForYou, timeline.FeedFollowing, timeline.FeedBookmarks, timeline.FeedNotifications:
 		case timeline.FeedSearch:
 			if len(specs) > 1 && spec.Query == "" {
 				return fmt.Errorf("invalid --columns search spec (use search:<query>)")

--- a/cmd/timeline.go
+++ b/cmd/timeline.go
@@ -47,7 +47,7 @@ var timelineCmd = &cobra.Command{
 }
 
 func init() {
-	timelineCmd.Flags().StringVar(&timelineImageMode, "images", "auto", "image mode: auto, native, ansi, or off")
+	timelineCmd.Flags().StringVar(&timelineImageMode, "images", "auto", "image mode: auto, native, ansi, or off (multi-column iTerm2/WezTerm falls back to ansi)")
 	timelineCmd.Flags().BoolVar(&timelineFollowing, "following", false, "start on the Following feed instead of For You")
 	timelineCmd.Flags().BoolVar(&timelineBookmarks, "bookmarks", false, "start on your bookmarks feed")
 	timelineCmd.Flags().StringVar(&timelineListID, "list", "", "start on the given list id")

--- a/cmd/timeline.go
+++ b/cmd/timeline.go
@@ -14,6 +14,7 @@ var (
 	timelineImageMode string
 	timelineFollowing bool
 	timelineBookmarks bool
+	timelineListID    string
 	timelineTheme     string
 )
 
@@ -23,6 +24,7 @@ var timelineCmd = &cobra.Command{
 	Example: `  xeet timeline                # same as plain 'xeet'
   xeet timeline --following    # the Following feed
   xeet timeline --bookmarks    # your saved posts
+  xeet timeline --list 123     # a list by id
   xeet timeline --images off   # text only, no previews`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := applyConfiguredTheme(timelineTheme); err != nil {
@@ -35,7 +37,10 @@ var timelineCmd = &cobra.Command{
 		if timelineBookmarks {
 			feed = timeline.FeedBookmarks
 		}
-		return runTimeline(cmd.Context(), timelineImageMode, feed, "")
+		if timelineListID != "" {
+			feed = timeline.FeedList
+		}
+		return runTimeline(cmd.Context(), timelineImageMode, feed, "", timelineListID)
 	},
 }
 
@@ -43,19 +48,23 @@ func init() {
 	timelineCmd.Flags().StringVar(&timelineImageMode, "images", "auto", "image mode: auto, native, ansi, or off")
 	timelineCmd.Flags().BoolVar(&timelineFollowing, "following", false, "start on the Following feed instead of For You")
 	timelineCmd.Flags().BoolVar(&timelineBookmarks, "bookmarks", false, "start on your bookmarks feed")
+	timelineCmd.Flags().StringVar(&timelineListID, "list", "", "start on the given list id")
 	timelineCmd.Flags().StringVar(&timelineTheme, "theme", "", "color theme for this run (see 'xeet theme')")
-	timelineCmd.MarkFlagsMutuallyExclusive("following", "bookmarks")
+	timelineCmd.MarkFlagsMutuallyExclusive("following", "bookmarks", "list")
 	rootCmd.AddCommand(timelineCmd)
 }
 
-func runTimeline(ctx context.Context, imageMode string, feed timeline.FeedKind, query string) error {
+func runTimeline(ctx context.Context, imageMode string, feed timeline.FeedKind, query, listID string) error {
 	switch imageMode {
 	case "auto", "native", "ansi", "off":
 	default:
 		return fmt.Errorf("invalid --images value %q (use auto, native, ansi, or off)", imageMode)
 	}
+	if feed == timeline.FeedList && listID != "" && !isNumericListID(listID) {
+		return fmt.Errorf("invalid --list value %q (use a numeric list id)", listID)
+	}
 	for {
-		action, err := timeline.Run(ctx, imageMode, feed, query)
+		action, err := timeline.Run(ctx, imageMode, feed, query, listID)
 		if err != nil {
 			return err
 		}
@@ -91,4 +100,13 @@ func runTimeline(ctx context.Context, imageMode string, feed timeline.FeedKind, 
 			return nil
 		}
 	}
+}
+
+func isNumericListID(id string) bool {
+	for i := range len(id) {
+		if id[i] < '0' || id[i] > '9' {
+			return false
+		}
+	}
+	return id != ""
 }

--- a/cmd/timeline.go
+++ b/cmd/timeline.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/melqtx/xeet/internal/timeline"
 	"github.com/melqtx/xeet/internal/tui"
@@ -54,7 +55,11 @@ var timelineCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return runTimeline(cmd.Context(), timelineImageMode, specs)
+		refresh, err := refreshIntervalFor(cmd)
+		if err != nil {
+			return err
+		}
+		return runTimeline(cmd.Context(), timelineImageMode, specs, refresh)
 	},
 }
 
@@ -65,11 +70,12 @@ func init() {
 	timelineCmd.Flags().StringVar(&timelineListID, "list", "", "start on the given list id")
 	timelineCmd.Flags().StringVar(&timelineColumns, "columns", "1", "column count (1-4) or feeds, optionally prefixed with @handle:")
 	timelineCmd.Flags().StringVar(&timelineTheme, "theme", "", "color theme for this run (see 'xeet theme')")
+	timelineCmd.Flags().String("refresh", "", "auto-refresh the focused column every interval (e.g. 60s, 5m); off by default")
 	timelineCmd.MarkFlagsMutuallyExclusive("following", "bookmarks", "list")
 	rootCmd.AddCommand(timelineCmd)
 }
 
-func runTimeline(ctx context.Context, imageMode string, specs []timeline.ColumnSpec) error {
+func runTimeline(ctx context.Context, imageMode string, specs []timeline.ColumnSpec, refreshInterval time.Duration) error {
 	switch imageMode {
 	case "auto", "native", "ansi", "off":
 	default:
@@ -79,7 +85,7 @@ func runTimeline(ctx context.Context, imageMode string, specs []timeline.ColumnS
 		return err
 	}
 	for {
-		action, err := timeline.Run(ctx, imageMode, specs)
+		action, err := timeline.Run(ctx, imageMode, specs, refreshInterval)
 		if err != nil {
 			return err
 		}
@@ -115,6 +121,24 @@ func runTimeline(ctx context.Context, imageMode string, specs []timeline.ColumnS
 			return nil
 		}
 	}
+}
+
+// refreshIntervalFor resolves the auto-refresh period: an explicit --refresh
+// wins, then the saved refresh_interval, and 0 keeps polling off. Commands
+// without a --refresh flag (lists, search) fall straight through to config.
+func refreshIntervalFor(cmd *cobra.Command) (time.Duration, error) {
+	if value, err := cmd.Flags().GetString("refresh"); err == nil && cmd.Flags().Changed("refresh") {
+		interval, err := time.ParseDuration(value)
+		if err != nil || interval < 0 {
+			return 0, fmt.Errorf("invalid --refresh value %q (use a duration like 60s or 5m)", value)
+		}
+		return interval, nil
+	}
+	mgr, err := config.NewConfigManager()
+	if err != nil {
+		return 0, err
+	}
+	return mgr.RefreshInterval()
 }
 
 func columnSpecsForTimelineCommand(

--- a/cmd/timeline.go
+++ b/cmd/timeline.go
@@ -3,9 +3,12 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/melqtx/xeet/internal/timeline"
 	"github.com/melqtx/xeet/internal/tui"
+	"github.com/melqtx/xeet/pkg/config"
 
 	"github.com/spf13/cobra"
 )
@@ -15,7 +18,7 @@ var (
 	timelineFollowing bool
 	timelineBookmarks bool
 	timelineListID    string
-	timelineColumns   int
+	timelineColumns   string
 	timelineTheme     string
 )
 
@@ -27,6 +30,7 @@ var timelineCmd = &cobra.Command{
   xeet timeline --bookmarks    # your saved posts
   xeet timeline --list 123     # a list by id
   xeet timeline --columns 2    # two copies of the selected feed
+  xeet timeline --columns foryou,bookmarks
   xeet timeline --images off   # text only, no previews`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := applyConfiguredTheme(timelineTheme); err != nil {
@@ -42,7 +46,14 @@ var timelineCmd = &cobra.Command{
 		if timelineListID != "" {
 			feed = timeline.FeedList
 		}
-		return runTimeline(cmd.Context(), timelineImageMode, feed, "", timelineListID, timelineColumns)
+		base := columnSpecForFeed(feed, "", timelineListID)
+		singleFeedFlag := cmd.Flags().Changed("following") ||
+			cmd.Flags().Changed("bookmarks") || cmd.Flags().Changed("list")
+		specs, err := columnSpecsForTimelineCommand(cmd, timelineColumns, base, singleFeedFlag)
+		if err != nil {
+			return err
+		}
+		return runTimeline(cmd.Context(), timelineImageMode, specs)
 	},
 }
 
@@ -51,26 +62,23 @@ func init() {
 	timelineCmd.Flags().BoolVar(&timelineFollowing, "following", false, "start on the Following feed instead of For You")
 	timelineCmd.Flags().BoolVar(&timelineBookmarks, "bookmarks", false, "start on your bookmarks feed")
 	timelineCmd.Flags().StringVar(&timelineListID, "list", "", "start on the given list id")
-	timelineCmd.Flags().IntVar(&timelineColumns, "columns", 1, "number of side-by-side columns (1-4)")
+	timelineCmd.Flags().StringVar(&timelineColumns, "columns", "1", "column count (1-4) or feeds: foryou,following,bookmarks,list:<id>,search:<query>")
 	timelineCmd.Flags().StringVar(&timelineTheme, "theme", "", "color theme for this run (see 'xeet theme')")
 	timelineCmd.MarkFlagsMutuallyExclusive("following", "bookmarks", "list")
 	rootCmd.AddCommand(timelineCmd)
 }
 
-func runTimeline(ctx context.Context, imageMode string, feed timeline.FeedKind, query, listID string, columns int) error {
+func runTimeline(ctx context.Context, imageMode string, specs []timeline.ColumnSpec) error {
 	switch imageMode {
 	case "auto", "native", "ansi", "off":
 	default:
 		return fmt.Errorf("invalid --images value %q (use auto, native, ansi, or off)", imageMode)
 	}
-	if feed == timeline.FeedList && listID != "" && !isNumericListID(listID) {
-		return fmt.Errorf("invalid --list value %q (use a numeric list id)", listID)
-	}
-	if err := validateColumnCount(columns); err != nil {
+	if err := validateColumnSpecs(specs); err != nil {
 		return err
 	}
 	for {
-		action, err := timeline.Run(ctx, imageMode, feed, query, listID, columns)
+		action, err := timeline.Run(ctx, imageMode, specs)
 		if err != nil {
 			return err
 		}
@@ -108,18 +116,166 @@ func runTimeline(ctx context.Context, imageMode string, feed timeline.FeedKind, 
 	}
 }
 
-func validateColumnCount(columns int) error {
-	if columns < 1 || columns > 4 {
-		return fmt.Errorf("invalid --columns value %d (use a number from 1 to 4)", columns)
+func columnSpecsForTimelineCommand(
+	cmd *cobra.Command,
+	value string,
+	base timeline.ColumnSpec,
+	singleFeedFlag bool,
+) ([]timeline.ColumnSpec, error) {
+	if cmd.Flags().Changed("columns") {
+		specs, ownsFeeds, err := parseColumnsFlag(value, base)
+		if err != nil {
+			return nil, err
+		}
+		if ownsFeeds && singleFeedFlag {
+			return nil, fmt.Errorf("--columns feed specs cannot be used with --following, --bookmarks, or --list")
+		}
+		return specs, nil
+	}
+	if singleFeedFlag {
+		return []timeline.ColumnSpec{base}, nil
+	}
+	mgr, err := config.NewConfigManager()
+	if err != nil {
+		return nil, err
+	}
+	saved, err := mgr.Columns()
+	if err != nil {
+		return nil, err
+	}
+	return resolveColumnSpecs(value, false, saved, base, false)
+}
+
+func resolveColumnSpecs(
+	value string,
+	flagSet bool,
+	saved []string,
+	base timeline.ColumnSpec,
+	singleFeedFlag bool,
+) ([]timeline.ColumnSpec, error) {
+	if flagSet {
+		specs, ownsFeeds, err := parseColumnsFlag(value, base)
+		if err != nil {
+			return nil, err
+		}
+		if ownsFeeds && singleFeedFlag {
+			return nil, fmt.Errorf("--columns feed specs cannot be used with --following, --bookmarks, or --list")
+		}
+		return specs, nil
+	}
+	if singleFeedFlag || len(saved) == 0 {
+		return []timeline.ColumnSpec{base}, nil
+	}
+	specs, _, err := parseColumnSpecList(strings.Join(saved, ","))
+	if err != nil {
+		return nil, fmt.Errorf("invalid columns config: %w", err)
+	}
+	return specs, nil
+}
+
+func parseColumnsFlag(value string, base timeline.ColumnSpec) ([]timeline.ColumnSpec, bool, error) {
+	value = strings.TrimSpace(value)
+	if isDigits(value) {
+		count, err := strconv.Atoi(value)
+		if err != nil || count < 1 || count > 4 {
+			return nil, false, fmt.Errorf("invalid --columns value %q (use a number from 1 to 4)", value)
+		}
+		specs := make([]timeline.ColumnSpec, count)
+		for i := range specs {
+			specs[i] = base
+		}
+		return specs, false, nil
+	}
+	specs, _, err := parseColumnSpecList(value)
+	if err != nil {
+		return nil, true, fmt.Errorf("invalid --columns value %q (%v)", value, err)
+	}
+	return specs, true, nil
+}
+
+func parseColumnSpecList(value string) ([]timeline.ColumnSpec, []string, error) {
+	raw := strings.Split(value, ",")
+	if len(raw) < 1 || len(raw) > 4 {
+		return nil, nil, fmt.Errorf("use between 1 and 4 column specs")
+	}
+	specs := make([]timeline.ColumnSpec, 0, len(raw))
+	canonical := make([]string, 0, len(raw))
+	for _, item := range raw {
+		item = strings.TrimSpace(item)
+		spec := timeline.ColumnSpec{}
+		switch {
+		case item == "foryou":
+			spec.Kind = timeline.FeedForYou
+		case item == "following":
+			spec.Kind = timeline.FeedFollowing
+		case item == "bookmarks":
+			spec.Kind = timeline.FeedBookmarks
+		case strings.HasPrefix(item, "list:"):
+			id := strings.TrimSpace(strings.TrimPrefix(item, "list:"))
+			if !isNumericListID(id) {
+				return nil, nil, fmt.Errorf("list specs need a numeric id")
+			}
+			spec.Kind = timeline.FeedList
+			spec.ListID = id
+			item = "list:" + id
+		case strings.HasPrefix(item, "search:"):
+			query := strings.TrimSpace(strings.TrimPrefix(item, "search:"))
+			if query == "" {
+				return nil, nil, fmt.Errorf("search specs need a query")
+			}
+			spec.Kind = timeline.FeedSearch
+			spec.Query = query
+			item = "search:" + query
+		default:
+			return nil, nil, fmt.Errorf("use foryou, following, bookmarks, list:<id>, or search:<query>")
+		}
+		specs = append(specs, spec)
+		canonical = append(canonical, item)
+	}
+	return specs, canonical, nil
+}
+
+func validateColumnSpecs(specs []timeline.ColumnSpec) error {
+	if len(specs) < 1 || len(specs) > 4 {
+		return fmt.Errorf("invalid --columns layout with %d columns (use 1 to 4)", len(specs))
+	}
+	for _, spec := range specs {
+		switch spec.Kind {
+		case timeline.FeedForYou, timeline.FeedFollowing, timeline.FeedBookmarks:
+		case timeline.FeedSearch:
+			if len(specs) > 1 && spec.Query == "" {
+				return fmt.Errorf("invalid --columns search spec (use search:<query>)")
+			}
+		case timeline.FeedList:
+			if spec.ListID != "" && !isNumericListID(spec.ListID) {
+				return fmt.Errorf("invalid --list value %q (use a numeric list id)", spec.ListID)
+			}
+			if len(specs) > 1 && spec.ListID == "" {
+				return fmt.Errorf("invalid --columns list spec (use list:<id>)")
+			}
+		default:
+			return fmt.Errorf("invalid --columns feed kind %d", spec.Kind)
+		}
 	}
 	return nil
 }
 
-func isNumericListID(id string) bool {
-	for i := range len(id) {
-		if id[i] < '0' || id[i] > '9' {
+func columnSpecForFeed(feed timeline.FeedKind, query, listID string) timeline.ColumnSpec {
+	return timeline.ColumnSpec{Kind: feed, Query: query, ListID: listID}
+}
+
+func isDigits(value string) bool {
+	if value == "" {
+		return false
+	}
+	for i := range len(value) {
+		if value[i] < '0' || value[i] > '9' {
 			return false
 		}
 	}
-	return id != ""
+	return true
+}
+
+func isNumericListID(id string) bool {
+	return isDigits(id)
 }

--- a/cmd/timeline.go
+++ b/cmd/timeline.go
@@ -31,6 +31,7 @@ var timelineCmd = &cobra.Command{
   xeet timeline --list 123     # a list by id
   xeet timeline --columns 2    # two copies of the selected feed
   xeet timeline --columns foryou,bookmarks
+  xeet timeline --columns @alice:foryou,@bob:following
   xeet timeline --images off   # text only, no previews`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := applyConfiguredTheme(timelineTheme); err != nil {
@@ -62,7 +63,7 @@ func init() {
 	timelineCmd.Flags().BoolVar(&timelineFollowing, "following", false, "start on the Following feed instead of For You")
 	timelineCmd.Flags().BoolVar(&timelineBookmarks, "bookmarks", false, "start on your bookmarks feed")
 	timelineCmd.Flags().StringVar(&timelineListID, "list", "", "start on the given list id")
-	timelineCmd.Flags().StringVar(&timelineColumns, "columns", "1", "column count (1-4) or feeds: foryou,following,bookmarks,list:<id>,search:<query>")
+	timelineCmd.Flags().StringVar(&timelineColumns, "columns", "1", "column count (1-4) or feeds, optionally prefixed with @handle:")
 	timelineCmd.Flags().StringVar(&timelineTheme, "theme", "", "color theme for this run (see 'xeet theme')")
 	timelineCmd.MarkFlagsMutuallyExclusive("following", "bookmarks", "list")
 	rootCmd.AddCommand(timelineCmd)
@@ -122,8 +123,16 @@ func columnSpecsForTimelineCommand(
 	base timeline.ColumnSpec,
 	singleFeedFlag bool,
 ) ([]timeline.ColumnSpec, error) {
+	mgr, err := config.NewConfigManager()
+	if err != nil {
+		return nil, err
+	}
+	accounts, err := mgr.Accounts()
+	if err != nil {
+		return nil, err
+	}
 	if cmd.Flags().Changed("columns") {
-		specs, ownsFeeds, err := parseColumnsFlag(value, base)
+		specs, ownsFeeds, err := parseColumnsFlag(value, base, accounts)
 		if err != nil {
 			return nil, err
 		}
@@ -135,15 +144,11 @@ func columnSpecsForTimelineCommand(
 	if singleFeedFlag {
 		return []timeline.ColumnSpec{base}, nil
 	}
-	mgr, err := config.NewConfigManager()
-	if err != nil {
-		return nil, err
-	}
 	saved, err := mgr.Columns()
 	if err != nil {
 		return nil, err
 	}
-	return resolveColumnSpecs(value, false, saved, base, false)
+	return resolveColumnSpecs(value, false, saved, base, false, accounts)
 }
 
 func resolveColumnSpecs(
@@ -152,9 +157,10 @@ func resolveColumnSpecs(
 	saved []string,
 	base timeline.ColumnSpec,
 	singleFeedFlag bool,
+	accounts []config.AccountInfo,
 ) ([]timeline.ColumnSpec, error) {
 	if flagSet {
-		specs, ownsFeeds, err := parseColumnsFlag(value, base)
+		specs, ownsFeeds, err := parseColumnsFlag(value, base, accounts)
 		if err != nil {
 			return nil, err
 		}
@@ -166,14 +172,14 @@ func resolveColumnSpecs(
 	if singleFeedFlag || len(saved) == 0 {
 		return []timeline.ColumnSpec{base}, nil
 	}
-	specs, _, err := parseColumnSpecList(strings.Join(saved, ","))
+	specs, _, err := parseColumnSpecList(strings.Join(saved, ","), accounts)
 	if err != nil {
 		return nil, fmt.Errorf("invalid columns config: %w", err)
 	}
 	return specs, nil
 }
 
-func parseColumnsFlag(value string, base timeline.ColumnSpec) ([]timeline.ColumnSpec, bool, error) {
+func parseColumnsFlag(value string, base timeline.ColumnSpec, accounts []config.AccountInfo) ([]timeline.ColumnSpec, bool, error) {
 	value = strings.TrimSpace(value)
 	if isDigits(value) {
 		count, err := strconv.Atoi(value)
@@ -186,14 +192,14 @@ func parseColumnsFlag(value string, base timeline.ColumnSpec) ([]timeline.Column
 		}
 		return specs, false, nil
 	}
-	specs, _, err := parseColumnSpecList(value)
+	specs, _, err := parseColumnSpecList(value, accounts)
 	if err != nil {
 		return nil, true, fmt.Errorf("invalid --columns value %q (%v)", value, err)
 	}
 	return specs, true, nil
 }
 
-func parseColumnSpecList(value string) ([]timeline.ColumnSpec, []string, error) {
+func parseColumnSpecList(value string, accounts []config.AccountInfo) ([]timeline.ColumnSpec, []string, error) {
 	raw := strings.Split(value, ",")
 	if len(raw) < 1 || len(raw) > 4 {
 		return nil, nil, fmt.Errorf("use between 1 and 4 column specs")
@@ -203,6 +209,21 @@ func parseColumnSpecList(value string) ([]timeline.ColumnSpec, []string, error) 
 	for _, item := range raw {
 		item = strings.TrimSpace(item)
 		spec := timeline.ColumnSpec{}
+		prefix := ""
+		if strings.HasPrefix(item, "@") {
+			separator := strings.IndexByte(item, ':')
+			if separator < 2 {
+				return nil, nil, fmt.Errorf("account-prefixed specs use @handle:<feed>")
+			}
+			handle := strings.TrimSpace(item[1:separator])
+			account, err := resolveColumnAccount(handle, accounts)
+			if err != nil {
+				return nil, nil, err
+			}
+			spec.AccountID = account.UserID
+			prefix = "@" + account.Handle + ":"
+			item = strings.TrimSpace(item[separator+1:])
+		}
 		switch {
 		case item == "foryou":
 			spec.Kind = timeline.FeedForYou
@@ -230,9 +251,32 @@ func parseColumnSpecList(value string) ([]timeline.ColumnSpec, []string, error) 
 			return nil, nil, fmt.Errorf("use foryou, following, bookmarks, list:<id>, or search:<query>")
 		}
 		specs = append(specs, spec)
-		canonical = append(canonical, item)
+		canonical = append(canonical, prefix+item)
 	}
 	return specs, canonical, nil
+}
+
+func resolveColumnAccount(handle string, accounts []config.AccountInfo) (config.AccountInfo, error) {
+	for _, account := range accounts {
+		if account.Handle != "" && strings.EqualFold(account.Handle, handle) {
+			return account, nil
+		}
+	}
+	known := make([]string, 0, len(accounts))
+	for _, account := range accounts {
+		if account.Handle != "" {
+			known = append(known, "@"+account.Handle)
+		} else {
+			known = append(known, account.UserID)
+		}
+	}
+	if len(known) == 0 {
+		known = append(known, "none")
+	}
+	return config.AccountInfo{}, fmt.Errorf(
+		"unknown column account @%s (known accounts: %s)",
+		handle, strings.Join(known, ", "),
+	)
 }
 
 func validateColumnSpecs(specs []timeline.ColumnSpec) error {

--- a/cmd/timeline.go
+++ b/cmd/timeline.go
@@ -15,6 +15,7 @@ var (
 	timelineFollowing bool
 	timelineBookmarks bool
 	timelineListID    string
+	timelineColumns   int
 	timelineTheme     string
 )
 
@@ -25,6 +26,7 @@ var timelineCmd = &cobra.Command{
   xeet timeline --following    # the Following feed
   xeet timeline --bookmarks    # your saved posts
   xeet timeline --list 123     # a list by id
+  xeet timeline --columns 2    # two copies of the selected feed
   xeet timeline --images off   # text only, no previews`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := applyConfiguredTheme(timelineTheme); err != nil {
@@ -40,7 +42,7 @@ var timelineCmd = &cobra.Command{
 		if timelineListID != "" {
 			feed = timeline.FeedList
 		}
-		return runTimeline(cmd.Context(), timelineImageMode, feed, "", timelineListID)
+		return runTimeline(cmd.Context(), timelineImageMode, feed, "", timelineListID, timelineColumns)
 	},
 }
 
@@ -49,12 +51,13 @@ func init() {
 	timelineCmd.Flags().BoolVar(&timelineFollowing, "following", false, "start on the Following feed instead of For You")
 	timelineCmd.Flags().BoolVar(&timelineBookmarks, "bookmarks", false, "start on your bookmarks feed")
 	timelineCmd.Flags().StringVar(&timelineListID, "list", "", "start on the given list id")
+	timelineCmd.Flags().IntVar(&timelineColumns, "columns", 1, "number of side-by-side columns (1-4)")
 	timelineCmd.Flags().StringVar(&timelineTheme, "theme", "", "color theme for this run (see 'xeet theme')")
 	timelineCmd.MarkFlagsMutuallyExclusive("following", "bookmarks", "list")
 	rootCmd.AddCommand(timelineCmd)
 }
 
-func runTimeline(ctx context.Context, imageMode string, feed timeline.FeedKind, query, listID string) error {
+func runTimeline(ctx context.Context, imageMode string, feed timeline.FeedKind, query, listID string, columns int) error {
 	switch imageMode {
 	case "auto", "native", "ansi", "off":
 	default:
@@ -63,8 +66,11 @@ func runTimeline(ctx context.Context, imageMode string, feed timeline.FeedKind, 
 	if feed == timeline.FeedList && listID != "" && !isNumericListID(listID) {
 		return fmt.Errorf("invalid --list value %q (use a numeric list id)", listID)
 	}
+	if err := validateColumnCount(columns); err != nil {
+		return err
+	}
 	for {
-		action, err := timeline.Run(ctx, imageMode, feed, query, listID)
+		action, err := timeline.Run(ctx, imageMode, feed, query, listID, columns)
 		if err != nil {
 			return err
 		}
@@ -100,6 +106,13 @@ func runTimeline(ctx context.Context, imageMode string, feed timeline.FeedKind, 
 			return nil
 		}
 	}
+}
+
+func validateColumnCount(columns int) error {
+	if columns < 1 || columns > 4 {
+		return fmt.Errorf("invalid --columns value %d (use a number from 1 to 4)", columns)
+	}
+	return nil
 }
 
 func isNumericListID(id string) bool {

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -41,8 +41,11 @@ func runWhoami(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("identify saved session: %w", err)
 	}
+	if err := manager.RecordViewer(account.ID, account.Handle); err != nil {
+		return fmt.Errorf("update saved account identity: %w", err)
+	}
 	if client.ApplyRefreshedQueryIDs(cfg) {
-		_ = manager.Save(cfg)
+		_ = manager.SaveQueryIDs(cfg)
 	}
 	printAccount(cmd.OutOrStdout(), account, sessionSource(cfg))
 	return nil

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -33,7 +33,11 @@ func runWhoami(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	cfg, err := loadAccountSelection(manager, whoamiAccount)
+	selector, err := accountSelectorFrom(cmd, whoamiAccount)
+	if err != nil {
+		return err
+	}
+	cfg, err := loadAccountSelection(manager, selector)
 	if err != nil {
 		return err
 	}

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -12,21 +12,28 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var whoamiAccount string
+
 var whoamiCmd = &cobra.Command{
 	Use:   "whoami",
 	Short: "show which account is connected",
-	Args:  cobra.NoArgs,
-	RunE:  runWhoami,
+	Example: `  xeet whoami
+  xeet whoami --account @alice   # check one saved account without switching`,
+	Args: cobra.NoArgs,
+	RunE: runWhoami,
 }
 
-func init() { rootCmd.AddCommand(whoamiCmd) }
+func init() {
+	whoamiCmd.Flags().StringVar(&whoamiAccount, "account", "", "saved account to identify (handle or user id); defaults to the active one")
+	rootCmd.AddCommand(whoamiCmd)
+}
 
 func runWhoami(cmd *cobra.Command, args []string) error {
 	manager, err := config.NewConfigManager()
 	if err != nil {
 		return err
 	}
-	cfg, err := manager.Load()
+	cfg, err := loadAccountSelection(manager, whoamiAccount)
 	if err != nil {
 		return err
 	}

--- a/internal/timeline/accounts.go
+++ b/internal/timeline/accounts.go
@@ -1,0 +1,96 @@
+package timeline
+
+import (
+	"fmt"
+
+	"github.com/melqtx/xeet/pkg/config"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type timelineAccountStore interface {
+	Accounts() ([]config.AccountInfo, error)
+	SetActive(string) error
+}
+
+var openTimelineAccountStore = func() (timelineAccountStore, error) {
+	return config.NewConfigManager()
+}
+
+type accountsLoadedMsg struct {
+	accounts []config.AccountInfo
+	err      error
+}
+
+type accountCycledMsg struct {
+	accounts []config.AccountInfo
+	active   config.AccountInfo
+	err      error
+}
+
+func loadAccountsCmd() tea.Cmd {
+	return func() tea.Msg {
+		store, err := openTimelineAccountStore()
+		if err != nil {
+			return accountsLoadedMsg{err: err}
+		}
+		accounts, err := store.Accounts()
+		return accountsLoadedMsg{accounts: accounts, err: err}
+	}
+}
+
+func cycleAccountCmd() tea.Cmd {
+	return func() tea.Msg {
+		store, err := openTimelineAccountStore()
+		if err != nil {
+			return accountCycledMsg{err: err}
+		}
+		accounts, err := store.Accounts()
+		if err != nil {
+			return accountCycledMsg{err: err}
+		}
+		if len(accounts) == 0 {
+			return accountCycledMsg{err: fmt.Errorf("no saved accounts; run 'xeet auth' first")}
+		}
+		active := -1
+		for i := range accounts {
+			if accounts[i].Active {
+				active = i
+				break
+			}
+		}
+		if active < 0 {
+			return accountCycledMsg{err: fmt.Errorf("no active saved account")}
+		}
+		if len(accounts) == 1 {
+			return accountCycledMsg{accounts: accounts, err: fmt.Errorf("only one account is saved")}
+		}
+		next := (active + 1) % len(accounts)
+		if err := store.SetActive(accounts[next].UserID); err != nil {
+			return accountCycledMsg{err: fmt.Errorf("switch account: %w", err)}
+		}
+		for i := range accounts {
+			accounts[i].Active = i == next
+		}
+		return accountCycledMsg{accounts: accounts, active: accounts[next]}
+	}
+}
+
+func accountInfoLabel(account config.AccountInfo) string {
+	if account.Handle != "" {
+		return "@" + account.Handle
+	}
+	return account.UserID
+}
+
+func (m Model) activeAccountLabel() string {
+	if len(m.accounts) <= 1 {
+		return ""
+	}
+	for _, account := range m.accounts {
+		if account.Active {
+			return accountInfoLabel(account)
+		}
+	}
+	return ""
+}

--- a/internal/timeline/accounts_test.go
+++ b/internal/timeline/accounts_test.go
@@ -1,6 +1,9 @@
 package timeline
 
 import (
+	"context"
+	"io"
+	"net/http"
 	"reflect"
 	"strings"
 	"testing"
@@ -10,6 +13,34 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 )
+
+type fakeRequestSecretStore struct {
+	data map[string]string
+}
+
+func (f *fakeRequestSecretStore) Get(key string) (string, error) {
+	value, ok := f.data[key]
+	if !ok {
+		return "", config.ErrSecretNotFound
+	}
+	return value, nil
+}
+
+func (f *fakeRequestSecretStore) Set(key, value string) error {
+	f.data[key] = value
+	return nil
+}
+
+func (f *fakeRequestSecretStore) Delete(key string) error {
+	delete(f.data, key)
+	return nil
+}
+
+type requestRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f requestRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
 
 type fakeTimelineAccountStore struct {
 	accounts []config.AccountInfo
@@ -33,6 +64,126 @@ func useFakeTimelineAccountStore(t *testing.T, store *fakeTimelineAccountStore) 
 	previous := openTimelineAccountStore
 	openTimelineAccountStore = func() (timelineAccountStore, error) { return store, nil }
 	t.Cleanup(func() { openTimelineAccountStore = previous })
+}
+
+func useRequestConfigManager(t *testing.T, manager requestConfigManager) {
+	t.Helper()
+	previous := openRequestConfigManager
+	openRequestConfigManager = func() (requestConfigManager, error) { return manager, nil }
+	t.Cleanup(func() { openRequestConfigManager = previous })
+}
+
+func TestColumnFetchUsesItsOwnAccountSession(t *testing.T) {
+	secrets := &fakeRequestSecretStore{data: map[string]string{}}
+	manager := config.NewConfigManagerAt(t.TempDir(), secrets)
+	if err := manager.Save(&config.Config{
+		UserID: "42", Handle: "alice", AuthToken: "alice-auth", CT0: "alice-csrf",
+		HomeTimelineQID: "home-qid",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.SaveAccount(&config.Config{
+		UserID: "84", Handle: "bob", AuthToken: "bob-auth", CT0: "bob-csrf",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.SetActive("42"); err != nil {
+		t.Fatal(err)
+	}
+	useRequestConfigManager(t, manager)
+
+	originalTransport := http.DefaultTransport
+	var cookies []string
+	var csrfTokens []string
+	http.DefaultTransport = requestRoundTripper(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Host != "x.com" {
+			t.Fatalf("request host = %q, want x.com", request.URL.Host)
+		}
+		cookies = append(cookies, request.Header.Get("Cookie"))
+		csrfTokens = append(csrfTokens, request.Header.Get("X-Csrf-Token"))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"data":{"entries":[]}}`)),
+			Request:    request,
+		}, nil
+	})
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	for index, accountID := range []string{"42", "84"} {
+		msg := fetchPageSeq(
+			context.Background(), FeedForYou, "", "", accountID, "", false, index, index,
+		)().(pageMsg)
+		if msg.err != nil {
+			t.Fatalf("account %s fetch: %v", accountID, msg.err)
+		}
+	}
+
+	wantCookies := []string{
+		"auth_token=alice-auth; ct0=alice-csrf",
+		"auth_token=bob-auth; ct0=bob-csrf",
+	}
+	if !reflect.DeepEqual(cookies, wantCookies) {
+		t.Fatalf("request Cookie headers = %q, want %q", cookies, wantCookies)
+	}
+	if !reflect.DeepEqual(csrfTokens, []string{"alice-csrf", "bob-csrf"}) {
+		t.Fatalf("request X-Csrf-Token headers = %q", csrfTokens)
+	}
+}
+
+func TestAccountSwitchMidFlightDropsStalePageViaSeqGuard(t *testing.T) {
+	m := New()
+	m.configureColumns([]ColumnSpec{{Kind: FeedForYou, AccountID: "42"}})
+	c := m.cur()
+	c.feedSeq = 7
+	stale := pageMsg{
+		page:  &api.TimelinePage{Posts: []api.TimelinePost{{ID: "old-account"}}},
+		seq:   c.feedSeq,
+		colID: c.id,
+	}
+
+	c.accountID = "84"
+	m.setFeed(c.feed)
+	next, _ := m.applyFeedPage(stale)
+	m = next.(Model)
+
+	if m.cur().accountID != "84" || m.cur().feedSeq != 8 {
+		t.Fatalf("column account switch did not bump the feed sequence: %+v", m.cur())
+	}
+	if len(m.cur().posts) != 0 {
+		t.Fatalf("old-account page landed after the switch: %+v", m.cur().posts)
+	}
+}
+
+func TestLikeFanOutStaysWithinTheActingAccount(t *testing.T) {
+	m := New()
+	m.configureColumns([]ColumnSpec{
+		{Kind: FeedForYou, AccountID: "42"},
+		{Kind: FeedForYou, AccountID: "84"},
+		{Kind: FeedFollowing, AccountID: "42"},
+	})
+	for i := range m.columns {
+		m.columns[i].posts = []api.TimelinePost{{ID: "shared"}}
+		m.columns[i].threadPosts = []api.ConversationPost{{
+			TimelinePost: api.TimelinePost{ID: "shared"},
+		}}
+	}
+
+	if cmd := m.toggleSelectedLike(); cmd == nil {
+		t.Fatal("account 42 like did not start")
+	}
+	if !m.liking[likeKey("42", "shared")] || m.liking[likeKey("84", "shared")] {
+		t.Fatalf("in-flight likes are not account-keyed: %v", m.liking)
+	}
+
+	for _, index := range []int{0, 2} {
+		if !m.columns[index].posts[0].Liked || !m.columns[index].threadPosts[0].Liked {
+			t.Fatalf("account 42 column %d did not receive the like", index)
+		}
+	}
+	if m.columns[1].posts[0].Liked || m.columns[1].threadPosts[0].Liked {
+		t.Fatal("account 42 like crossed into account 84 state")
+	}
 }
 
 func TestAccountCycleResetsEveryColumnAndDropsInFlightPages(t *testing.T) {

--- a/internal/timeline/accounts_test.go
+++ b/internal/timeline/accounts_test.go
@@ -112,7 +112,7 @@ func TestColumnFetchUsesItsOwnAccountSession(t *testing.T) {
 
 	for index, accountID := range []string{"42", "84"} {
 		msg := fetchPageSeq(
-			context.Background(), FeedForYou, "", "", accountID, "", false, index, index, false,
+			context.Background(), FeedForYou, "", "", "", accountID, "", false, index, index, false,
 		)().(pageMsg)
 		if msg.err != nil {
 			t.Fatalf("account %s fetch: %v", accountID, msg.err)

--- a/internal/timeline/accounts_test.go
+++ b/internal/timeline/accounts_test.go
@@ -112,7 +112,7 @@ func TestColumnFetchUsesItsOwnAccountSession(t *testing.T) {
 
 	for index, accountID := range []string{"42", "84"} {
 		msg := fetchPageSeq(
-			context.Background(), FeedForYou, "", "", accountID, "", false, index, index,
+			context.Background(), FeedForYou, "", "", accountID, "", false, index, index, false,
 		)().(pageMsg)
 		if msg.err != nil {
 			t.Fatalf("account %s fetch: %v", accountID, msg.err)

--- a/internal/timeline/accounts_test.go
+++ b/internal/timeline/accounts_test.go
@@ -1,0 +1,131 @@
+package timeline
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/melqtx/xeet/pkg/api"
+	"github.com/melqtx/xeet/pkg/config"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type fakeTimelineAccountStore struct {
+	accounts []config.AccountInfo
+	switched []string
+}
+
+func (f *fakeTimelineAccountStore) Accounts() ([]config.AccountInfo, error) {
+	return append([]config.AccountInfo(nil), f.accounts...), nil
+}
+
+func (f *fakeTimelineAccountStore) SetActive(userID string) error {
+	f.switched = append(f.switched, userID)
+	for i := range f.accounts {
+		f.accounts[i].Active = f.accounts[i].UserID == userID
+	}
+	return nil
+}
+
+func useFakeTimelineAccountStore(t *testing.T, store *fakeTimelineAccountStore) {
+	t.Helper()
+	previous := openTimelineAccountStore
+	openTimelineAccountStore = func() (timelineAccountStore, error) { return store, nil }
+	t.Cleanup(func() { openTimelineAccountStore = previous })
+}
+
+func TestAccountCycleResetsEveryColumnAndDropsInFlightPages(t *testing.T) {
+	store := &fakeTimelineAccountStore{accounts: []config.AccountInfo{
+		{UserID: "42", Handle: "alice", Active: true},
+		{UserID: "84", Handle: "bob"},
+	}}
+	useFakeTimelineAccountStore(t, store)
+
+	m := New()
+	m.configureColumns([]ColumnSpec{
+		{Kind: FeedForYou},
+		{Kind: FeedFollowing},
+	})
+	m.accounts = append([]config.AccountInfo(nil), store.accounts...)
+	oldMessages := make([]pageMsg, len(m.columns))
+	oldSequences := make([]int, len(m.columns))
+	for i := range m.columns {
+		c := &m.columns[i]
+		c.feedSeq = i + 3
+		c.loading = false
+		c.posts = []api.TimelinePost{{ID: "old"}}
+		c.cursor = "cursor"
+		oldSequences[i] = c.feedSeq
+		oldMessages[i] = pageMsg{
+			page:  &api.TimelinePage{Posts: []api.TimelinePost{{ID: "stale"}}},
+			seq:   c.feedSeq,
+			colID: c.id,
+		}
+	}
+
+	model, cycle := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'@'}})
+	if cycle == nil {
+		t.Fatal("@ did not start an account cycle")
+	}
+	cycled := cycle()
+	if _, ok := cycled.(accountCycledMsg); !ok {
+		t.Fatalf("@ returned %T, want accountCycledMsg", cycled)
+	}
+	model, reload := model.(Model).Update(cycled)
+	updated := model.(Model)
+	if reload == nil {
+		t.Fatal("account cycle did not schedule fresh pages")
+	}
+	if !reflect.DeepEqual(store.switched, []string{"84"}) {
+		t.Fatalf("active account writes = %v", store.switched)
+	}
+	for i := range updated.columns {
+		c := &updated.columns[i]
+		if c.feedSeq != oldSequences[i]+1 || len(c.posts) != 0 || c.cursor != "" || !c.loading {
+			t.Fatalf("column %d was not fully reset: %+v", i, c)
+		}
+	}
+
+	for _, stale := range oldMessages {
+		next, _ := updated.Update(stale)
+		updated = next.(Model)
+	}
+	for i := range updated.columns {
+		if len(updated.columns[i].posts) != 0 {
+			t.Fatalf("stale page landed in column %d: %+v", i, updated.columns[i].posts)
+		}
+	}
+	if got := updated.activeAccountLabel(); got != "@bob" {
+		t.Fatalf("active account label = %q, want @bob", got)
+	}
+}
+
+func TestActiveAccountHandleAppearsOnlyWhenSeveralAccountsAreSaved(t *testing.T) {
+	m := New()
+	m.cur().loading = false
+	m.accounts = []config.AccountInfo{
+		{UserID: "42", Handle: "alice", Active: true},
+		{UserID: "84", Handle: "bob"},
+	}
+	if header := m.header(m.contentWidth()); !strings.Contains(header, "@alice") {
+		t.Fatalf("multi-account header omitted the active handle:\n%s", header)
+	}
+
+	m.accounts = m.accounts[:1]
+	if header := m.header(m.contentWidth()); strings.Contains(header, "@alice") {
+		t.Fatalf("single-account header added redundant identity:\n%s", header)
+	}
+}
+
+func TestTimelineHelpKeepsAltTextOnAAndUsesAtForAccounts(t *testing.T) {
+	m := New()
+	m.width = 80
+	m.height = 30
+	view := m.viewHelp()
+	for _, want := range []string{"@           next account", "A           image alt text"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("help omitted %q:\n%s", want, view)
+		}
+	}
+}

--- a/internal/timeline/bookmark_test.go
+++ b/internal/timeline/bookmark_test.go
@@ -1,0 +1,117 @@
+package timeline
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/melqtx/xeet/pkg/api"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestBookmarkKeyTogglesSelectedPostOptimistically(t *testing.T) {
+	m := New()
+	m.cur().loading = false
+	m.cur().posts = posts(3)
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'B'}})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("B produced no bookmark request")
+	}
+	if !m.cur().posts[0].Bookmarked {
+		t.Fatal("selected post was not bookmarked optimistically")
+	}
+	if !m.bookmarking[likeKey(m.columnAccountID(m.cur()), "a")] {
+		t.Fatalf("in-flight bookmark not keyed: %v", m.bookmarking)
+	}
+}
+
+func TestBookmarkFailureRollsBackOptimisticState(t *testing.T) {
+	m := New()
+	m.cur().loading = false
+	m.cur().posts = posts(3)
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'B'}})
+	m = next.(Model)
+
+	m.applyBookmarkResult(bookmarkMsg{
+		id: "a", accountID: m.columnAccountID(m.cur()), bookmarked: true, err: errors.New("boom"),
+	})
+	if m.cur().posts[0].Bookmarked {
+		t.Fatal("failed bookmark was not rolled back")
+	}
+	if len(m.bookmarking) != 0 {
+		t.Fatalf("in-flight marker leaked: %v", m.bookmarking)
+	}
+	if !strings.Contains(m.toast, "couldn't update bookmark") {
+		t.Fatalf("toast = %q", m.toast)
+	}
+}
+
+func TestBookmarkSuccessKeepsStateAndToasts(t *testing.T) {
+	m := New()
+	m.cur().loading = false
+	m.cur().posts = posts(3)
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'B'}})
+	m = next.(Model)
+
+	m.applyBookmarkResult(bookmarkMsg{
+		id: "a", accountID: m.columnAccountID(m.cur()), bookmarked: true,
+	})
+	if !m.cur().posts[0].Bookmarked {
+		t.Fatal("successful bookmark lost the flag")
+	}
+	if len(m.bookmarking) != 0 {
+		t.Fatalf("in-flight marker leaked: %v", m.bookmarking)
+	}
+	if !strings.Contains(m.toast, "bookmarked") {
+		t.Fatalf("toast = %q", m.toast)
+	}
+}
+
+func TestBookmarkKeyFromThreadTogglesThreadPost(t *testing.T) {
+	m := New()
+	m.cur().loading = false
+	m.mode = modeThread
+	m.cur().threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "t1", Text: "post", Handle: "alice"}}}
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'B'}})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("B in thread produced no bookmark request")
+	}
+	if !m.cur().threadPosts[0].Bookmarked {
+		t.Fatal("thread post was not bookmarked optimistically")
+	}
+}
+
+func TestBookmarkFanOutStaysWithinTheActingAccount(t *testing.T) {
+	m := New()
+	m.configureColumns([]ColumnSpec{
+		{Kind: FeedForYou, AccountID: "42"},
+		{Kind: FeedForYou, AccountID: "84"},
+		{Kind: FeedFollowing, AccountID: "42"},
+	})
+	for i := range m.columns {
+		m.columns[i].posts = []api.TimelinePost{{ID: "shared"}}
+		m.columns[i].threadPosts = []api.ConversationPost{{
+			TimelinePost: api.TimelinePost{ID: "shared"},
+		}}
+	}
+
+	if cmd := m.toggleSelectedBookmark(); cmd == nil {
+		t.Fatal("account 42 bookmark did not start")
+	}
+	if !m.bookmarking[likeKey("42", "shared")] || m.bookmarking[likeKey("84", "shared")] {
+		t.Fatalf("in-flight bookmarks are not account-keyed: %v", m.bookmarking)
+	}
+	for _, index := range []int{0, 2} {
+		if !m.columns[index].posts[0].Bookmarked || !m.columns[index].threadPosts[0].Bookmarked {
+			t.Fatalf("account 42 column %d did not receive the bookmark", index)
+		}
+	}
+	if m.columns[1].posts[0].Bookmarked || m.columns[1].threadPosts[0].Bookmarked {
+		t.Fatal("account 42 bookmark crossed into account 84 state")
+	}
+}

--- a/internal/timeline/column.go
+++ b/internal/timeline/column.go
@@ -61,8 +61,10 @@ func newColumn(id int) column {
 	}
 }
 
-func (m *Model) configureColumns(count int, feed FeedKind, query, listID string) {
-	count = max(1, count)
+func (m *Model) configureColumns(specs []ColumnSpec) {
+	if len(specs) == 0 {
+		specs = []ColumnSpec{{Kind: FeedForYou}}
+	}
 	firstID := m.nextColID
 	if len(m.columns) > 0 {
 		firstID = m.columns[0].id
@@ -70,17 +72,17 @@ func (m *Model) configureColumns(count int, feed FeedKind, query, listID string)
 		m.nextColID++
 	}
 	m.columns = []column{newColumn(firstID)}
-	for len(m.columns) < count {
+	for len(m.columns) < len(specs) {
 		m.columns = append(m.columns, newColumn(m.nextColID))
 		m.nextColID++
 	}
-	for index := range m.columns {
+	for index, spec := range specs {
 		c := &m.columns[index]
-		c.feed = feed
-		c.searchQuery = query
-		c.listID = listID
-		if feed == FeedList {
-			c.listName = listID
+		c.feed = spec.Kind
+		c.searchQuery = spec.Query
+		c.listID = spec.ListID
+		if spec.Kind == FeedList {
+			c.listName = spec.ListID
 		}
 	}
 	m.focus = 0

--- a/internal/timeline/column.go
+++ b/internal/timeline/column.go
@@ -52,3 +52,36 @@ func (m *Model) columnByID(id int) *column {
 	}
 	return nil
 }
+
+func newColumn(id int) column {
+	return column{
+		id:       id,
+		loading:  true,
+		viewport: viewport.New(72, 18),
+	}
+}
+
+func (m *Model) configureColumns(count int, feed FeedKind, query, listID string) {
+	count = max(1, count)
+	firstID := m.nextColID
+	if len(m.columns) > 0 {
+		firstID = m.columns[0].id
+	} else {
+		m.nextColID++
+	}
+	m.columns = []column{newColumn(firstID)}
+	for len(m.columns) < count {
+		m.columns = append(m.columns, newColumn(m.nextColID))
+		m.nextColID++
+	}
+	for index := range m.columns {
+		c := &m.columns[index]
+		c.feed = feed
+		c.searchQuery = query
+		c.listID = listID
+		if feed == FeedList {
+			c.listName = listID
+		}
+	}
+	m.focus = 0
+}

--- a/internal/timeline/column.go
+++ b/internal/timeline/column.go
@@ -118,7 +118,7 @@ func (m *Model) addColumn(spec ColumnSpec) tea.Cmd {
 	m.enforceMultiColumnImageMode()
 	m.resize()
 	cmds := []tea.Cmd{m.spinner.Tick, fetchPageSeq(
-		m.requestContext(), c.feed, c.searchQuery, c.listID, c.accountID, "", false, c.feedSeq, c.id,
+		m.requestContext(), c.feed, c.searchQuery, c.listID, c.accountID, "", false, c.feedSeq, c.id, false,
 	)}
 	if c.feed == FeedList {
 		cmds = append(cmds, fetchListsCmd(m.requestContext(), c.accountID, false))

--- a/internal/timeline/column.go
+++ b/internal/timeline/column.go
@@ -82,9 +82,42 @@ func (m *Model) configureColumns(specs []ColumnSpec) {
 		c.searchQuery = spec.Query
 		c.listID = spec.ListID
 		if spec.Kind == FeedList {
+			// A spec carries only the id, so the header shows that until the
+			// lists request lands and names it.
 			c.listName = spec.ListID
 		}
 	}
 	m.focus = 0
 	m.enforceMultiColumnImageMode()
+}
+
+// namesPendingForListColumns reports whether any column is still showing a raw
+// list id where its name belongs.
+func (m *Model) namesPendingForListColumns() bool {
+	for i := range m.columns {
+		if c := &m.columns[i]; c.feed == FeedList && c.listName == c.listID {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Model) nameListColumns(lists []api.ListInfo) {
+	byID := make(map[string]string, len(lists))
+	for _, l := range lists {
+		byID[l.ID] = l.Name
+	}
+	for i := range m.columns {
+		c := &m.columns[i]
+		if c.feed != FeedList {
+			continue
+		}
+		// Only fill the placeholder: a name the picker already resolved is
+		// better than one from a list the account has since stopped following.
+		if c.listName == c.listID {
+			if name := byID[c.listID]; name != "" {
+				c.listName = name
+			}
+		}
+	}
 }

--- a/internal/timeline/column.go
+++ b/internal/timeline/column.go
@@ -12,6 +12,7 @@ import (
 type column struct {
 	id          int // stable identity for message routing; never reused
 	feed        FeedKind
+	accountID   string
 	searchQuery string
 	listID      string
 	listName    string
@@ -79,6 +80,7 @@ func (m *Model) configureColumns(specs []ColumnSpec) {
 	for index, spec := range specs {
 		c := &m.columns[index]
 		c.feed = spec.Kind
+		c.accountID = spec.AccountID
 		c.searchQuery = spec.Query
 		c.listID = spec.ListID
 		if spec.Kind == FeedList {
@@ -102,14 +104,14 @@ func (m *Model) namesPendingForListColumns() bool {
 	return false
 }
 
-func (m *Model) nameListColumns(lists []api.ListInfo) {
+func (m *Model) nameListColumns(accountID string, lists []api.ListInfo) {
 	byID := make(map[string]string, len(lists))
 	for _, l := range lists {
 		byID[l.ID] = l.Name
 	}
 	for i := range m.columns {
 		c := &m.columns[i]
-		if c.feed != FeedList {
+		if c.feed != FeedList || c.accountID != accountID {
 			continue
 		}
 		// Only fill the placeholder: a name the picker already resolved is

--- a/internal/timeline/column.go
+++ b/internal/timeline/column.go
@@ -21,19 +21,23 @@ type column struct {
 	searchQuery string
 	listID      string
 	listName    string
-	feedSeq     int
-	posts       []api.TimelinePost
-	cursor      string
-	selected    int
-	starts      []int
-	ends        []int
-	loading     bool
-	loadingMore bool
-	refreshing  bool
-	expanded    bool
-	err         error
-	viewport    viewport.Model
-	wezFrameKey string
+	// profileHandle is shown in the header; profileUserID is the resolved
+	// id UserTweets pages by. Kept separate so pagination never re-resolves.
+	profileHandle string
+	profileUserID string
+	feedSeq       int
+	posts         []api.TimelinePost
+	cursor        string
+	selected      int
+	starts        []int
+	ends          []int
+	loading       bool
+	loadingMore   bool
+	refreshing    bool
+	expanded      bool
+	err           error
+	viewport      viewport.Model
+	wezFrameKey   string
 
 	// thread cluster — the thread overlay is full-screen (decision #2) but its
 	// STATE belongs to the column that opened it, so returning from the overlay
@@ -88,6 +92,7 @@ func (m *Model) configureColumns(specs []ColumnSpec) {
 		c.accountID = spec.AccountID
 		c.searchQuery = spec.Query
 		c.listID = spec.ListID
+		c.profileHandle = spec.ProfileHandle
 		if spec.Kind == FeedList {
 			// A spec carries only the id, so the header shows that until the
 			// lists request lands and names it.
@@ -110,6 +115,7 @@ func (m *Model) addColumn(spec ColumnSpec) tea.Cmd {
 	c.accountID = spec.AccountID
 	c.searchQuery = spec.Query
 	c.listID = spec.ListID
+	c.profileHandle = spec.ProfileHandle
 	if spec.Kind == FeedList {
 		c.listName = spec.ListID
 	}
@@ -118,7 +124,7 @@ func (m *Model) addColumn(spec ColumnSpec) tea.Cmd {
 	m.enforceMultiColumnImageMode()
 	m.resize()
 	cmds := []tea.Cmd{m.spinner.Tick, fetchPageSeq(
-		m.requestContext(), c.feed, c.searchQuery, c.listID, c.accountID, "", false, c.feedSeq, c.id, false,
+		m.requestContext(), c.feed, c.searchQuery, c.listID, c.profileUserID, c.accountID, "", false, c.feedSeq, c.id, false,
 	)}
 	if c.feed == FeedList {
 		cmds = append(cmds, fetchListsCmd(m.requestContext(), c.accountID, false))

--- a/internal/timeline/column.go
+++ b/internal/timeline/column.go
@@ -1,0 +1,54 @@
+package timeline
+
+import (
+	"github.com/melqtx/xeet/pkg/api"
+
+	"github.com/charmbracelet/bubbles/viewport"
+)
+
+// column is one independently scrolling feed pane. With one column the TUI
+// behaves exactly as before; the struct exists so state cannot leak between
+// panes once there are several.
+type column struct {
+	id          int // stable identity for message routing; never reused
+	feed        FeedKind
+	searchQuery string
+	listID      string
+	listName    string
+	feedSeq     int
+	posts       []api.TimelinePost
+	cursor      string
+	selected    int
+	starts      []int
+	ends        []int
+	loading     bool
+	loadingMore bool
+	refreshing  bool
+	expanded    bool
+	err         error
+	viewport    viewport.Model
+	wezFrameKey string
+
+	// thread cluster — the thread overlay is full-screen (decision #2) but its
+	// STATE belongs to the column that opened it, so returning from the overlay
+	// restores that column exactly.
+	feedSelected  int
+	threadRootID  string
+	threadPosts   []api.ConversationPost
+	threadCursor  string
+	threadLoading bool
+	threadMore    bool
+	threadErr     error
+	threadSeq     int
+}
+
+func (m *Model) cur() *column { return &m.columns[m.focus] }
+
+func (m *Model) columnByID(id int) *column {
+	for i := range m.columns {
+		if m.columns[i].id == id {
+			return &m.columns[i]
+		}
+	}
+	return nil
+}

--- a/internal/timeline/column.go
+++ b/internal/timeline/column.go
@@ -4,7 +4,12 @@ import (
 	"github.com/melqtx/xeet/pkg/api"
 
 	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
 )
+
+// maxColumns matches the --columns flag's limit; more panes than that leave
+// each one too narrow to read.
+const maxColumns = 4
 
 // column is one independently scrolling feed pane. With one column the TUI
 // behaves exactly as before; the struct exists so state cannot leak between
@@ -91,6 +96,82 @@ func (m *Model) configureColumns(specs []ColumnSpec) {
 	}
 	m.focus = 0
 	m.enforceMultiColumnImageMode()
+}
+
+// addColumn appends a pane and focuses it. A page arriving for an id that no
+// longer exists is dropped by columnByID, so ids are never reused.
+func (m *Model) addColumn(spec ColumnSpec) tea.Cmd {
+	if len(m.columns) >= maxColumns {
+		return m.showToast("already at 4 columns")
+	}
+	c := newColumn(m.nextColID)
+	m.nextColID++
+	c.feed = spec.Kind
+	c.accountID = spec.AccountID
+	c.searchQuery = spec.Query
+	c.listID = spec.ListID
+	if spec.Kind == FeedList {
+		c.listName = spec.ListID
+	}
+	m.columns = append(m.columns, c)
+	m.focus = len(m.columns) - 1
+	m.enforceMultiColumnImageMode()
+	m.resize()
+	cmds := []tea.Cmd{m.spinner.Tick, fetchPageSeq(
+		m.requestContext(), c.feed, c.searchQuery, c.listID, c.accountID, "", false, c.feedSeq, c.id,
+	)}
+	if c.feed == FeedList {
+		cmds = append(cmds, fetchListsCmd(m.requestContext(), c.accountID, false))
+	}
+	return m.imageRepaint(tea.Batch(cmds...))
+}
+
+// removeColumn drops the focused pane. In-flight pages for it die against the
+// nil from columnByID; the preview cache only needs a budget re-check.
+func (m *Model) removeColumn() tea.Cmd {
+	if len(m.columns) <= 1 {
+		return m.showToast("keep at least one column")
+	}
+	m.columns = append(m.columns[:m.focus], m.columns[m.focus+1:]...)
+	m.focus = min(m.focus, len(m.columns)-1)
+	m.evictDistantPreviews()
+	m.resize()
+	return m.imageRepaint(m.requestPreviews())
+}
+
+// setColumnAccount repoints the focused pane at another saved account while
+// keeping its feed kind, query, and list. The seq bump in resetColumnFeed
+// retires any page the old account still has in flight.
+func (m *Model) setColumnAccount(accountID string) tea.Cmd {
+	c := m.cur()
+	if c.accountID == accountID {
+		return m.showToast("already " + m.accountLabelFor(accountID))
+	}
+	c.accountID = accountID
+	if c.feed == FeedList {
+		// The name came from the old account's lists; show the id until the
+		// new account's enumeration confirms what it can actually see.
+		c.listName = c.listID
+	}
+	refetch := m.resetColumnFeed(c, c.feed)
+	cmds := []tea.Cmd{m.spinner.Tick, refetch}
+	if c.feed == FeedList {
+		cmds = append(cmds, fetchListsCmd(m.requestContext(), accountID, false))
+	}
+	m.syncViewport()
+	return m.imageRepaint(tea.Batch(cmds...))
+}
+
+func (m Model) accountLabelFor(accountID string) string {
+	if accountID == "" {
+		return "the active account"
+	}
+	for _, account := range m.accounts {
+		if account.UserID == accountID {
+			return accountInfoLabel(account)
+		}
+	}
+	return accountID
 }
 
 // namesPendingForListColumns reports whether any column is still showing a raw

--- a/internal/timeline/column.go
+++ b/internal/timeline/column.go
@@ -84,4 +84,5 @@ func (m *Model) configureColumns(count int, feed FeedKind, query, listID string)
 		}
 	}
 	m.focus = 0
+	m.enforceMultiColumnImageMode()
 }

--- a/internal/timeline/column_edit_test.go
+++ b/internal/timeline/column_edit_test.go
@@ -1,0 +1,169 @@
+package timeline
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/melqtx/xeet/pkg/api"
+)
+
+func TestAddColumnAppendsFocusAndFetches(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.configureColumns(repeatedColumnSpecs(1, FeedForYou, "", ""))
+	m.columns[0].loading = false
+
+	cmd := m.addColumn(ColumnSpec{Kind: FeedBookmarks, AccountID: "42"})
+
+	if cmd == nil {
+		t.Fatal("addColumn returned no command; the new column would never fetch")
+	}
+	if len(m.columns) != 2 {
+		t.Fatalf("addColumn left %d columns, want 2", len(m.columns))
+	}
+	added := m.columns[1]
+	if added.feed != FeedBookmarks || added.accountID != "42" {
+		t.Fatalf("added column = {feed:%v account:%q}, want bookmarks on 42", added.feed, added.accountID)
+	}
+	if !added.loading {
+		t.Error("added column is not loading; it has no page yet")
+	}
+	if m.focus != 1 {
+		t.Fatalf("focus = %d, want the new column at 1", m.focus)
+	}
+	if added.id == m.columns[0].id {
+		t.Error("added column reused an existing id; page routing would collide")
+	}
+}
+
+func TestAddColumnRefusesFifth(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.configureColumns(repeatedColumnSpecs(maxColumns, FeedForYou, "", ""))
+
+	cmd := m.addColumn(ColumnSpec{Kind: FeedFollowing})
+
+	if len(m.columns) != maxColumns {
+		t.Fatalf("addColumn grew to %d columns past the cap", len(m.columns))
+	}
+	if cmd == nil || !strings.Contains(m.toast, "4 columns") {
+		t.Fatalf("refusal toast = %q, want a 4-column notice", m.toast)
+	}
+}
+
+func TestAddColumnDowngradesWezTermMode(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.configureColumns(repeatedColumnSpecs(1, FeedForYou, "", ""))
+	m.imageMode = imageModeWezTerm
+
+	m.addColumn(ColumnSpec{Kind: FeedForYou})
+
+	if m.imageMode != imageModeANSI {
+		t.Fatalf("imageMode = %q, want ansi fallback for multiple columns", m.imageMode)
+	}
+	if m.imageNote != multiColumnImageNote {
+		t.Fatalf("imageNote = %q, want the multi-column explanation", m.imageNote)
+	}
+}
+
+func TestRemoveColumnDropsStalePagesByID(t *testing.T) {
+	m := modelWithNamedColumns("left", "right")
+	removedID := m.columns[m.focus].id
+
+	m.focus = 0
+	m.removeColumn()
+
+	if len(m.columns) != 1 {
+		t.Fatalf("removeColumn left %d columns, want 1", len(m.columns))
+	}
+	before := len(m.columns[0].posts)
+	stale := pageMsg{colID: removedID, seq: 0, page: &api.TimelinePage{Posts: []api.TimelinePost{{ID: "ghost"}}}}
+	m = update(t, m, stale)
+	if len(m.columns[0].posts) != before {
+		t.Error("a page for the removed column changed the survivor's posts")
+	}
+}
+
+func TestRemoveColumnRefusesLastAndClampsFocus(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.configureColumns(repeatedColumnSpecs(1, FeedForYou, "", ""))
+
+	m.removeColumn()
+
+	if len(m.columns) != 1 {
+		t.Fatalf("removeColumn dropped the last column, %d left", len(m.columns))
+	}
+	if !strings.Contains(m.toast, "at least one") {
+		t.Fatalf("refusal toast = %q, want a keep-one notice", m.toast)
+	}
+
+	m = modelWithNamedColumns("one", "two", "three")
+	m.focus = 2
+	m.removeColumn()
+	if m.focus != 1 {
+		t.Fatalf("focus = %d after removing the last column, want clamped to 1", m.focus)
+	}
+}
+
+func TestSetColumnAccountKeepsFeedAndBumpsSeq(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.configureColumns([]ColumnSpec{{Kind: FeedSearch, Query: "golang"}})
+	c := m.cur()
+	c.loading = false
+	c.feedSeq = 3
+
+	cmd := m.setColumnAccount("42")
+
+	if cmd == nil {
+		t.Fatal("setColumnAccount returned no command; the new account would never fetch")
+	}
+	if c.accountID != "42" {
+		t.Fatalf("accountID = %q, want 42", c.accountID)
+	}
+	if c.feed != FeedSearch || c.searchQuery != "golang" {
+		t.Fatalf("feed state = {%v %q}, want the search on golang kept", c.feed, c.searchQuery)
+	}
+	if c.feedSeq != 4 {
+		t.Fatalf("feedSeq = %d, want a bump past in-flight pages", c.feedSeq)
+	}
+	if !c.loading {
+		t.Error("column is not loading after the account switch")
+	}
+
+	stale := pageMsg{colID: c.id, seq: 3, page: &api.TimelinePage{Posts: []api.TimelinePost{{ID: "old"}}}}
+	m = update(t, m, stale)
+	if len(m.cur().posts) != 0 {
+		t.Error("a page from the old account landed after the switch")
+	}
+}
+
+func TestSetColumnAccountResetsListNamePlaceholder(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.configureColumns([]ColumnSpec{{Kind: FeedList, ListID: "123"}})
+	c := m.cur()
+	c.listName = "Frens"
+	c.loading = false
+
+	m.setColumnAccount("84")
+
+	if c.listName != c.listID {
+		t.Fatalf("listName = %q, want the id placeholder until the new account names it", c.listName)
+	}
+	if c.listID != "123" {
+		t.Fatalf("listID = %q, want the same list kept", c.listID)
+	}
+}
+
+func TestSetColumnAccountSameAccountToasts(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.configureColumns([]ColumnSpec{{Kind: FeedForYou, AccountID: "42"}})
+	m.cur().loading = false
+	seq := m.cur().feedSeq
+
+	m.setColumnAccount("42")
+
+	if m.cur().feedSeq != seq {
+		t.Error("same-account switch bumped feedSeq; nothing should refetch")
+	}
+	if !strings.Contains(m.toast, "already") {
+		t.Fatalf("toast = %q, want an already-there notice", m.toast)
+	}
+}

--- a/internal/timeline/columns_test.go
+++ b/internal/timeline/columns_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/melqtx/xeet/pkg/api"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 )
 
 func TestColumnContentWidths(t *testing.T) {
@@ -31,7 +32,7 @@ func TestColumnContentWidths(t *testing.T) {
 
 	m := New()
 	m.width = 100
-	m.configureColumns(2, FeedForYou, "", "")
+	m.configureColumns(repeatedColumnSpecs(2, FeedForYou, "", ""))
 	if got := m.contentWidth(); got != 47 {
 		t.Fatalf("contentWidth()=%d, want delegated two-column width 47", got)
 	}
@@ -39,7 +40,7 @@ func TestColumnContentWidths(t *testing.T) {
 
 func TestConfiguredColumnsStartOnTheSameSelectedFeed(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.configureColumns(4, FeedList, "", "123")
+	m.configureColumns(repeatedColumnSpecs(4, FeedList, "", "123"))
 
 	for index := range m.columns {
 		c := m.columns[index]
@@ -54,7 +55,7 @@ func TestConfiguredColumnsStartOnTheSameSelectedFeed(t *testing.T) {
 
 func TestInitSchedulesAFirstPageForEveryColumn(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.configureColumns(3, FeedFollowing, "", "")
+	m.configureColumns(repeatedColumnSpecs(3, FeedFollowing, "", ""))
 
 	msg := m.Init()()
 	batch, ok := msg.(tea.BatchMsg)
@@ -63,6 +64,57 @@ func TestInitSchedulesAFirstPageForEveryColumn(t *testing.T) {
 	}
 	if len(batch) != 5 {
 		t.Fatalf("Init scheduled %d commands, want spinner + 3 fetches + clock", len(batch))
+	}
+}
+
+func TestConfiguredColumnSpecsKeepIndependentFeedParameters(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.configureColumns([]ColumnSpec{
+		{Kind: FeedForYou},
+		{Kind: FeedFollowing},
+		{Kind: FeedBookmarks},
+		{Kind: FeedSearch, Query: "golang"},
+	})
+
+	if m.columns[0].feed != FeedForYou ||
+		m.columns[1].feed != FeedFollowing ||
+		m.columns[2].feed != FeedBookmarks ||
+		m.columns[3].feed != FeedSearch ||
+		m.columns[3].searchQuery != "golang" {
+		t.Fatalf("configured columns lost their feed specs: %+v", m.columns)
+	}
+}
+
+func TestMultiColumnHeaderShowsOneLogoAndAVisibleFocusBar(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.configureColumns([]ColumnSpec{
+		{Kind: FeedForYou},
+		{Kind: FeedFollowing},
+		{Kind: FeedBookmarks},
+		{Kind: FeedSearch, Query: "golang"},
+	})
+	for index := range m.columns {
+		m.columns[index].loading = false
+	}
+	m = update(t, m, tea.WindowSizeMsg{Width: 160, Height: 24})
+
+	view := ansi.Strip(m.View())
+	if count := strings.Count(view, `/\_/\`); count != 1 {
+		t.Fatalf("multi-column view rendered %d cat logos, want one:\n%s", count, view)
+	}
+	for _, label := range []string{"for you", "following", "bookmarks", "search: golang"} {
+		if !strings.Contains(view, label) {
+			t.Fatalf("multi-column header omitted %q:\n%s", label, view)
+		}
+	}
+	if !strings.Contains(view, "▸ for you") || strings.Contains(view, "▸ following") {
+		t.Fatalf("focus marker did not identify the first column:\n%s", view)
+	}
+
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyTab})
+	view = ansi.Strip(m.View())
+	if !strings.Contains(view, "▸ following") || strings.Contains(view, "▸ for you") {
+		t.Fatalf("focus marker did not move with focus:\n%s", view)
 	}
 }
 
@@ -187,7 +239,7 @@ func TestThreadOverlayUsesFullTerminalWidthWithMultipleColumns(t *testing.T) {
 
 func modelWithNamedColumns(names ...string) Model {
 	m := NewWithImageMode("off")
-	m.configureColumns(len(names), FeedForYou, "", "")
+	m.configureColumns(repeatedColumnSpecs(len(names), FeedForYou, "", ""))
 	for index, name := range names {
 		m.columns[index].loading = false
 		m.columns[index].posts = []api.TimelinePost{{
@@ -198,6 +250,14 @@ func modelWithNamedColumns(names ...string) Model {
 		}}
 	}
 	return m
+}
+
+func repeatedColumnSpecs(count int, kind FeedKind, query, listID string) []ColumnSpec {
+	specs := make([]ColumnSpec, count)
+	for index := range specs {
+		specs[index] = ColumnSpec{Kind: kind, Query: query, ListID: listID}
+	}
+	return specs
 }
 
 func lineContainsAll(value string, parts ...string) bool {

--- a/internal/timeline/columns_test.go
+++ b/internal/timeline/columns_test.go
@@ -275,3 +275,43 @@ func lineContainsAll(value string, parts ...string) bool {
 	}
 	return false
 }
+
+func TestListColumnsFromSpecsShowNamesOnceTheListsArrive(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.configureColumns([]ColumnSpec{
+		{Kind: FeedForYou},
+		{Kind: FeedList, ListID: "175677451"},
+	})
+	if !m.namesPendingForListColumns() {
+		t.Fatal("a column built from a spec starts with only an id, so a name lookup is owed")
+	}
+	if got := m.columns[1].listName; got != "175677451" {
+		t.Fatalf("placeholder name = %q, want the id so the header is never blank", got)
+	}
+
+	next, _ := m.Update(listsMsg{lists: []api.ListInfo{
+		{ID: "999", Name: "other"},
+		{ID: "175677451", Name: "music"},
+	}})
+	m = next.(Model)
+
+	if got := m.columns[1].listName; got != "music" {
+		t.Fatalf("list column name = %q, want music", got)
+	}
+	if m.namesPendingForListColumns() {
+		t.Fatal("nothing should still be owed once the names arrived")
+	}
+}
+
+func TestPickerChosenNameSurvivesALaterListsResponse(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.configureColumns([]ColumnSpec{{Kind: FeedList, ListID: "175677451"}})
+	m.columns[0].listName = "music"
+
+	next, _ := m.Update(listsMsg{lists: []api.ListInfo{{ID: "175677451", Name: "renamed upstream"}}})
+	m = next.(Model)
+
+	if got := m.columns[0].listName; got != "music" {
+		t.Fatalf("name = %q; a resolved name must not be overwritten by a later enumeration", got)
+	}
+}

--- a/internal/timeline/columns_test.go
+++ b/internal/timeline/columns_test.go
@@ -102,7 +102,7 @@ func TestMultiColumnHeaderShowsOneLogoAndAVisibleFocusBar(t *testing.T) {
 	if count := strings.Count(view, `/\_/\`); count != 1 {
 		t.Fatalf("multi-column view rendered %d cat logos, want one:\n%s", count, view)
 	}
-	for _, label := range []string{"for you", "following", "bookmarks", "search: golang"} {
+	for _, label := range []string{"for you", "following", "bookmarks", "search · “golang”"} {
 		if !strings.Contains(view, label) {
 			t.Fatalf("multi-column header omitted %q:\n%s", label, view)
 		}

--- a/internal/timeline/columns_test.go
+++ b/internal/timeline/columns_test.go
@@ -1,0 +1,217 @@
+package timeline
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/melqtx/xeet/pkg/api"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestColumnContentWidths(t *testing.T) {
+	tests := []struct {
+		name       string
+		totalWidth int
+		columns    int
+		want       int
+	}{
+		{name: "80 by 1", totalWidth: 80, columns: 1, want: 76},
+		{name: "100 by 2", totalWidth: 100, columns: 2, want: 47},
+		{name: "160 by 3", totalWidth: 160, columns: 3, want: 50},
+		{name: "42 collapsed to 1", totalWidth: 42, columns: 1, want: 38},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := columnContentWidth(tt.totalWidth, tt.columns); got != tt.want {
+				t.Fatalf("columnContentWidth(%d, %d)=%d, want %d", tt.totalWidth, tt.columns, got, tt.want)
+			}
+		})
+	}
+
+	m := New()
+	m.width = 100
+	m.configureColumns(2, FeedForYou, "", "")
+	if got := m.contentWidth(); got != 47 {
+		t.Fatalf("contentWidth()=%d, want delegated two-column width 47", got)
+	}
+}
+
+func TestConfiguredColumnsStartOnTheSameSelectedFeed(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.configureColumns(4, FeedList, "", "123")
+
+	for index := range m.columns {
+		c := m.columns[index]
+		if c.feed != FeedList || c.listID != "123" || c.listName != "123" {
+			t.Fatalf("column %d did not inherit the selected feed: %+v", index, c)
+		}
+		if c.id != index {
+			t.Fatalf("column %d id=%d, want %d", index, c.id, index)
+		}
+	}
+}
+
+func TestInitSchedulesAFirstPageForEveryColumn(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.configureColumns(3, FeedFollowing, "", "")
+
+	msg := m.Init()()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("Init returned %T, want tea.BatchMsg", msg)
+	}
+	if len(batch) != 5 {
+		t.Fatalf("Init scheduled %d commands, want spinner + 3 fetches + clock", len(batch))
+	}
+}
+
+func TestTwoColumnsRenderSideBySideWithoutOverflowAt100Cols(t *testing.T) {
+	m := modelWithNamedColumns("Alice", "Bob")
+	m = update(t, m, tea.WindowSizeMsg{Width: 100, Height: 24})
+
+	view := m.View()
+	if !lineContainsAll(view, "Alice", "Bob") {
+		t.Fatalf("columns did not render side by side:\n%s", view)
+	}
+	if width := maxLineWidth(view); width > 98 {
+		t.Fatalf("view width=%d fills the two-cell safety reserve:\n%s", width, view)
+	}
+}
+
+func TestNarrowTerminalCollapsesToOneColumnAndNotesHiddenColumns(t *testing.T) {
+	m := modelWithNamedColumns("Alice", "Bob")
+	m = update(t, m, tea.WindowSizeMsg{Width: 42, Height: 15})
+
+	view := m.View()
+	if !strings.Contains(view, "Alice") || strings.Contains(view, "Bob") {
+		t.Fatalf("42-column view did not collapse to only the focused column:\n%s", view)
+	}
+	if !strings.Contains(view, "+1 more (widen terminal)") {
+		t.Fatalf("collapsed view omitted its hidden-column note:\n%s", view)
+	}
+	if width := maxLineWidth(view); width > 40 {
+		t.Fatalf("collapsed view width=%d fills the two-cell safety reserve:\n%s", width, view)
+	}
+}
+
+func TestFocusCycleMovesActionTargetBetweenColumns(t *testing.T) {
+	m := modelWithNamedColumns("Alice", "Bob")
+	m.columns[0].posts[0].ID = "first"
+	m.columns[1].posts[0].ID = "second"
+	m = update(t, m, tea.WindowSizeMsg{Width: 100, Height: 24})
+
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyTab})
+	if m.focus != 1 {
+		t.Fatalf("tab focused column %d, want 1", m.focus)
+	}
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
+	if m.columns[0].posts[0].Liked {
+		t.Fatal("liking in column 2 changed column 1's different post")
+	}
+	if !m.columns[1].posts[0].Liked {
+		t.Fatal("liking in column 2 did not update its selected post")
+	}
+
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyShiftTab})
+	if m.focus != 0 {
+		t.Fatalf("shift+tab focused column %d, want 0", m.focus)
+	}
+}
+
+func TestLikeFansOutToDuplicatePostAcrossColumns(t *testing.T) {
+	m := modelWithNamedColumns("Alice", "Bob")
+	m.columns[0].posts[0].ID = "shared"
+	m.columns[1].posts[0].ID = "shared"
+
+	m.applyLike("shared", true)
+
+	for index := range m.columns {
+		post := m.columns[index].posts[0]
+		if !post.Liked || post.LikeCount != 1 {
+			t.Fatalf("column %d duplicate was not updated: %+v", index, post)
+		}
+	}
+}
+
+func TestFocusedColumnStaysVisibleWhenWindowSlides(t *testing.T) {
+	m := modelWithNamedColumns("Alice", "Bob", "Carol", "Dave")
+	m = update(t, m, tea.WindowSizeMsg{Width: 100, Height: 24})
+	if view := m.View(); !strings.Contains(view, "Alice") || strings.Contains(view, "Dave") {
+		t.Fatalf("initial three-column window is wrong:\n%s", view)
+	}
+
+	for range 3 {
+		m = update(t, m, tea.KeyMsg{Type: tea.KeyTab})
+	}
+	view := m.View()
+	if m.focus != 3 || strings.Contains(view, "Alice") || !strings.Contains(view, "Dave") {
+		t.Fatalf("window did not slide to focused column 4:\n%s", view)
+	}
+}
+
+func TestTwoColumnViewIsFixedHeightAndDoesNotDuplicateRows(t *testing.T) {
+	m := modelWithNamedColumns("Alice", "Alice")
+	m = update(t, m, tea.WindowSizeMsg{Width: 100, Height: 24})
+
+	view := m.View()
+	if strings.Count(view, "Alice") != 2 {
+		t.Fatalf("Alice should appear once in each column:\n%s", view)
+	}
+	if strings.Count(view, "♡") != 2 {
+		t.Fatalf("each column should render one action line:\n%s", view)
+	}
+	if lines := strings.Count(view, "\n") + 1; lines != 24 {
+		t.Fatalf("two-column view has %d lines, want 24", lines)
+	}
+}
+
+func TestThreadOverlayUsesFullTerminalWidthWithMultipleColumns(t *testing.T) {
+	m := modelWithNamedColumns("Alice", "Bob")
+	m = update(t, m, tea.WindowSizeMsg{Width: 100, Height: 24})
+	m.mode = modeThread
+	m.cur().threadRootID = "root"
+	m.cur().threadPosts = []api.ConversationPost{{
+		TimelinePost: api.TimelinePost{ID: "root", AuthorName: "Root", Handle: "root", Text: "full-width thread"},
+	}}
+	m.cur().selected = 0
+	m.resize()
+
+	if got := m.cur().viewport.Width; got != 76 {
+		t.Fatalf("thread viewport width=%d, want full-screen width 76", got)
+	}
+	if view := m.View(); !strings.Contains(view, "full-width thread") {
+		t.Fatalf("thread overlay did not render its content:\n%s", view)
+	}
+}
+
+func modelWithNamedColumns(names ...string) Model {
+	m := NewWithImageMode("off")
+	m.configureColumns(len(names), FeedForYou, "", "")
+	for index, name := range names {
+		m.columns[index].loading = false
+		m.columns[index].posts = []api.TimelinePost{{
+			ID:         strings.ToLower(name),
+			AuthorName: name,
+			Handle:     strings.ToLower(name),
+			Text:       "a post in this column",
+		}}
+	}
+	return m
+}
+
+func lineContainsAll(value string, parts ...string) bool {
+	for _, line := range strings.Split(value, "\n") {
+		found := true
+		for _, part := range parts {
+			if !strings.Contains(line, part) {
+				found = false
+				break
+			}
+		}
+		if found {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/timeline/columns_test.go
+++ b/internal/timeline/columns_test.go
@@ -176,7 +176,7 @@ func TestLikeFansOutToDuplicatePostAcrossColumns(t *testing.T) {
 	m.columns[0].posts[0].ID = "shared"
 	m.columns[1].posts[0].ID = "shared"
 
-	m.applyLike("shared", true)
+	m.applyLike("", "shared", true)
 
 	for index := range m.columns {
 		post := m.columns[index].posts[0]

--- a/internal/timeline/columns_test.go
+++ b/internal/timeline/columns_test.go
@@ -62,8 +62,8 @@ func TestInitSchedulesAFirstPageForEveryColumn(t *testing.T) {
 	if !ok {
 		t.Fatalf("Init returned %T, want tea.BatchMsg", msg)
 	}
-	if len(batch) != 5 {
-		t.Fatalf("Init scheduled %d commands, want spinner + 3 fetches + clock", len(batch))
+	if len(batch) != 6 {
+		t.Fatalf("Init scheduled %d commands, want spinner + account metadata + 3 fetches + clock", len(batch))
 	}
 }
 

--- a/internal/timeline/columns_test.go
+++ b/internal/timeline/columns_test.go
@@ -186,6 +186,21 @@ func TestLikeFansOutToDuplicatePostAcrossColumns(t *testing.T) {
 	}
 }
 
+func TestRepostFansOutToDuplicatePostAcrossColumns(t *testing.T) {
+	m := modelWithNamedColumns("Alice", "Bob")
+	m.columns[0].posts[0].ID = "shared"
+	m.columns[1].posts[0].ID = "shared"
+
+	m.applyRepost("", "shared", true)
+
+	for index := range m.columns {
+		post := m.columns[index].posts[0]
+		if !post.Reposted || post.RepostCount != 1 {
+			t.Fatalf("column %d duplicate was not updated: %+v", index, post)
+		}
+	}
+}
+
 func TestFocusedColumnStaysVisibleWhenWindowSlides(t *testing.T) {
 	m := modelWithNamedColumns("Alice", "Bob", "Carol", "Dave")
 	m = update(t, m, tea.WindowSizeMsg{Width: 100, Height: 24})

--- a/internal/timeline/lists.go
+++ b/internal/timeline/lists.go
@@ -106,6 +106,8 @@ func (m Model) updateListPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case retweetMsg:
 		m.settleRepost(msg)
 		return m, nil
+	case profileMsg:
+		return m, m.applyProfileResult(msg)
 	case previewMsg:
 		m.storePreview(msg)
 		return m, nil

--- a/internal/timeline/lists.go
+++ b/internal/timeline/lists.go
@@ -103,6 +103,9 @@ func (m Model) updateListPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case likeMsg:
 		m.settleLike(msg)
 		return m, nil
+	case retweetMsg:
+		m.settleRepost(msg)
+		return m, nil
 	case previewMsg:
 		m.storePreview(msg)
 		return m, nil

--- a/internal/timeline/lists.go
+++ b/internal/timeline/lists.go
@@ -31,7 +31,7 @@ func fetchListsCmd(parent context.Context) tea.Cmd {
 		client := api.NewWebClient(cfg)
 		lists, err := client.FetchOwnedLists(ctx)
 		if client.ApplyRefreshedQueryIDs(cfg) {
-			_ = mgr.Save(cfg)
+			_ = mgr.SaveQueryIDs(cfg)
 		}
 		return listsMsg{lists: lists, err: err}
 	}

--- a/internal/timeline/lists.go
+++ b/internal/timeline/lists.go
@@ -106,6 +106,9 @@ func (m Model) updateListPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case retweetMsg:
 		m.settleRepost(msg)
 		return m, nil
+	case bookmarkMsg:
+		m.settleBookmark(msg)
+		return m, nil
 	case profileMsg:
 		return m, m.applyProfileResult(msg)
 	case previewMsg:

--- a/internal/timeline/lists.go
+++ b/internal/timeline/lists.go
@@ -1,0 +1,113 @@
+package timeline
+
+import (
+	"context"
+	"time"
+
+	"github.com/melqtx/xeet/pkg/api"
+	"github.com/melqtx/xeet/pkg/config"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type listsMsg struct {
+	lists []api.ListInfo
+	err   error
+}
+
+func fetchListsCmd(parent context.Context) tea.Cmd {
+	return func() tea.Msg {
+		mgr, err := config.NewConfigManager()
+		if err != nil {
+			return listsMsg{err: err}
+		}
+		cfg, err := mgr.Load()
+		if err != nil {
+			return listsMsg{err: err}
+		}
+		ctx, cancel := context.WithTimeout(parent, 40*time.Second)
+		defer cancel()
+		client := api.NewWebClient(cfg)
+		lists, err := client.FetchOwnedLists(ctx)
+		if client.ApplyRefreshedQueryIDs(cfg) {
+			_ = mgr.Save(cfg)
+		}
+		return listsMsg{lists: lists, err: err}
+	}
+}
+
+func (m *Model) beginListPicker() tea.Cmd {
+	m.listReturn = m.mode
+	m.listPicker = nil
+	m.listPickerSel = 0
+	m.listPickerErr = nil
+	m.listPickerLoading = true
+	m.mode = modeListPicker
+	return m.imageRepaint(tea.Batch(m.spinner.Tick, fetchListsCmd(m.requestContext())))
+}
+
+func (m Model) cancelListPicker() (tea.Model, tea.Cmd) {
+	m.mode = m.listReturn
+	m.listPickerLoading = false
+	m.syncViewport()
+	m.ensureSelectedVisible()
+	return m, m.imageRepaint(m.requestPreviews())
+}
+
+func (m Model) updateListPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case listsMsg:
+		m.listPickerLoading = false
+		m.listPickerErr = msg.err
+		if msg.err == nil {
+			m.listPicker = msg.lists
+			m.listPickerSel = min(m.listPickerSel, max(0, len(m.listPicker)-1))
+		}
+		return m, nil
+	case threadMsg:
+		if m.listReturn != modeThread {
+			return m, nil
+		}
+		return m.applyThreadPage(msg, false)
+	case pageMsg:
+		return m.applyFeedPage(msg)
+	case likeMsg:
+		m.settleLike(msg)
+		return m, nil
+	case previewMsg:
+		m.storePreview(msg)
+		return m, nil
+	case spinner.TickMsg:
+		if m.listPickerLoading || m.loading || m.loadingMore || m.refreshing || m.threadLoading || m.threadMore {
+			var cmd tea.Cmd
+			m.spinner, cmd = m.spinner.Update(msg)
+			return m, cmd
+		}
+	}
+
+	key, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+	switch key.String() {
+	case "esc":
+		return m.cancelListPicker()
+	case "j", "down":
+		m.listPickerSel = min(max(0, len(m.listPicker)-1), m.listPickerSel+1)
+	case "k", "up":
+		m.listPickerSel = max(0, m.listPickerSel-1)
+	case "enter":
+		if m.listPickerLoading || m.listPickerErr != nil ||
+			m.listPickerSel < 0 || m.listPickerSel >= len(m.listPicker) {
+			return m, nil
+		}
+		selected := m.listPicker[m.listPickerSel]
+		m.listID = selected.ID
+		m.listName = selected.Name
+		m.listPickerLoading = false
+		m.mode = modeFeed
+		return m, m.setFeed(FeedList)
+	}
+	return m, nil
+}

--- a/internal/timeline/lists.go
+++ b/internal/timeline/lists.go
@@ -45,13 +45,25 @@ func (m *Model) beginListPicker() tea.Cmd {
 	m.listPickerErr = nil
 	m.listPickerLoading = true
 	m.mode = modeListPicker
+	// In the add-column flow the account is chosen afterwards, so the lists
+	// come from the active account.
+	accountID := m.cur().accountID
+	if m.listFor == targetNewColumn {
+		accountID = ""
+	}
 	return m.imageRepaint(tea.Batch(
-		m.spinner.Tick, fetchListsCmd(m.requestContext(), m.cur().accountID, true),
+		m.spinner.Tick, fetchListsCmd(m.requestContext(), accountID, true),
 	))
 }
 
 func (m Model) cancelListPicker() (tea.Model, tea.Cmd) {
-	m.mode = m.listReturn
+	if m.listFor == targetNewColumn {
+		m.listFor = targetFocusedColumn
+		m.columnDraft = ColumnSpec{}
+		m.mode = modeFeed
+	} else {
+		m.mode = m.listReturn
+	}
 	m.listPickerLoading = false
 	m.syncViewport()
 	m.ensureSelectedVisible()
@@ -67,7 +79,11 @@ func (m Model) updateListPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 		}
-		if msg.accountID != m.cur().accountID {
+		expected := m.cur().accountID
+		if m.listFor == targetNewColumn {
+			expected = ""
+		}
+		if msg.accountID != expected {
 			return m, nil
 		}
 		m.listPickerLoading = false
@@ -115,6 +131,12 @@ func (m Model) updateListPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		selected := m.listPicker[m.listPickerSel]
+		if m.listFor == targetNewColumn {
+			m.columnDraft = ColumnSpec{Kind: FeedList, ListID: selected.ID}
+			m.listFor = targetFocusedColumn
+			m.listPickerLoading = false
+			return m, m.beginAccountPicker("new column · account", intentColumnAccount)
+		}
 		m.cur().listID = selected.ID
 		m.cur().listName = selected.Name
 		m.listPickerLoading = false

--- a/internal/timeline/lists.go
+++ b/internal/timeline/lists.go
@@ -5,26 +5,27 @@ import (
 	"time"
 
 	"github.com/melqtx/xeet/pkg/api"
-	"github.com/melqtx/xeet/pkg/config"
 
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
 type listsMsg struct {
-	lists []api.ListInfo
-	err   error
+	lists     []api.ListInfo
+	accountID string
+	picker    bool
+	err       error
 }
 
-func fetchListsCmd(parent context.Context) tea.Cmd {
+func fetchListsCmd(parent context.Context, accountID string, picker bool) tea.Cmd {
 	return func() tea.Msg {
-		mgr, err := config.NewConfigManager()
+		mgr, err := openRequestConfigManager()
 		if err != nil {
-			return listsMsg{err: err}
+			return listsMsg{accountID: accountID, picker: picker, err: err}
 		}
-		cfg, err := mgr.Load()
+		cfg, err := loadRequestConfig(mgr, accountID)
 		if err != nil {
-			return listsMsg{err: err}
+			return listsMsg{accountID: accountID, picker: picker, err: err}
 		}
 		ctx, cancel := context.WithTimeout(parent, 40*time.Second)
 		defer cancel()
@@ -33,7 +34,7 @@ func fetchListsCmd(parent context.Context) tea.Cmd {
 		if client.ApplyRefreshedQueryIDs(cfg) {
 			_ = mgr.SaveQueryIDs(cfg)
 		}
-		return listsMsg{lists: lists, err: err}
+		return listsMsg{lists: lists, accountID: accountID, picker: picker, err: err}
 	}
 }
 
@@ -44,7 +45,9 @@ func (m *Model) beginListPicker() tea.Cmd {
 	m.listPickerErr = nil
 	m.listPickerLoading = true
 	m.mode = modeListPicker
-	return m.imageRepaint(tea.Batch(m.spinner.Tick, fetchListsCmd(m.requestContext())))
+	return m.imageRepaint(tea.Batch(
+		m.spinner.Tick, fetchListsCmd(m.requestContext(), m.cur().accountID, true),
+	))
 }
 
 func (m Model) cancelListPicker() (tea.Model, tea.Cmd) {
@@ -58,6 +61,15 @@ func (m Model) cancelListPicker() (tea.Model, tea.Cmd) {
 func (m Model) updateListPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case listsMsg:
+		if !msg.picker {
+			if msg.err == nil {
+				m.nameListColumns(msg.accountID, msg.lists)
+			}
+			return m, nil
+		}
+		if msg.accountID != m.cur().accountID {
+			return m, nil
+		}
 		m.listPickerLoading = false
 		m.listPickerErr = msg.err
 		if msg.err == nil {

--- a/internal/timeline/lists.go
+++ b/internal/timeline/lists.go
@@ -79,7 +79,7 @@ func (m Model) updateListPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.storePreview(msg)
 		return m, nil
 	case spinner.TickMsg:
-		if m.listPickerLoading || m.loading || m.loadingMore || m.refreshing || m.threadLoading || m.threadMore {
+		if m.listPickerLoading || m.cur().loading || m.cur().loadingMore || m.cur().refreshing || m.cur().threadLoading || m.cur().threadMore {
 			var cmd tea.Cmd
 			m.spinner, cmd = m.spinner.Update(msg)
 			return m, cmd
@@ -103,8 +103,8 @@ func (m Model) updateListPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		selected := m.listPicker[m.listPickerSel]
-		m.listID = selected.ID
-		m.listName = selected.Name
+		m.cur().listID = selected.ID
+		m.cur().listName = selected.Name
 		m.listPickerLoading = false
 		m.mode = modeFeed
 		return m, m.setFeed(FeedList)

--- a/internal/timeline/lists_test.go
+++ b/internal/timeline/lists_test.go
@@ -14,8 +14,8 @@ import (
 
 func TestListPickerOpensOnCapitalLAndClosesOnEsc(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.loading = false
-	m.feed = FeedFollowing
+	m.cur().loading = false
+	m.cur().feed = FeedFollowing
 
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'L'}})
 	m = next.(Model)
@@ -23,24 +23,24 @@ func TestListPickerOpensOnCapitalLAndClosesOnEsc(t *testing.T) {
 	if cmd == nil || m.mode != modeListPicker || m.listReturn != modeFeed {
 		t.Fatalf("list picker did not open from feed: mode=%v return=%v cmd=%v", m.mode, m.listReturn, cmd)
 	}
-	if !m.listPickerLoading || m.feed != FeedFollowing {
-		t.Fatalf("opening picker changed the feed or skipped loading: feed=%v loading=%v", m.feed, m.listPickerLoading)
+	if !m.listPickerLoading || m.cur().feed != FeedFollowing {
+		t.Fatalf("opening picker changed the feed or skipped loading: feed=%v loading=%v", m.cur().feed, m.listPickerLoading)
 	}
 
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyEsc})
-	if m.mode != modeFeed || m.feed != FeedFollowing || m.listPickerLoading {
-		t.Fatalf("esc did not restore the feed: mode=%v feed=%v loading=%v", m.mode, m.feed, m.listPickerLoading)
+	if m.mode != modeFeed || m.cur().feed != FeedFollowing || m.listPickerLoading {
+		t.Fatalf("esc did not restore the feed: mode=%v feed=%v loading=%v", m.mode, m.cur().feed, m.listPickerLoading)
 	}
 }
 
 func TestListPickerSelectionSwitchesFeedAndResetsState(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.loading = false
-	m.feed = FeedBookmarks
-	m.feedSeq = 7
-	m.posts = []api.TimelinePost{{ID: "old", Text: "old"}}
-	m.cursor = "old-cursor"
-	m.selected = 1
+	m.cur().loading = false
+	m.cur().feed = FeedBookmarks
+	m.cur().feedSeq = 7
+	m.cur().posts = []api.TimelinePost{{ID: "old", Text: "old"}}
+	m.cur().cursor = "old-cursor"
+	m.cur().selected = 1
 
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'L'}})
 	m = update(t, m, listsMsg{lists: []api.ListInfo{
@@ -51,24 +51,24 @@ func TestListPickerSelectionSwitchesFeedAndResetsState(t *testing.T) {
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = next.(Model)
 
-	if cmd == nil || m.mode != modeFeed || m.feed != FeedList {
-		t.Fatalf("list selection did not become a feed: mode=%v feed=%v cmd=%v", m.mode, m.feed, cmd)
+	if cmd == nil || m.mode != modeFeed || m.cur().feed != FeedList {
+		t.Fatalf("list selection did not become a feed: mode=%v feed=%v cmd=%v", m.mode, m.cur().feed, cmd)
 	}
-	if m.listID != "200" || m.listName != "Second" || m.feedSeq != 8 {
-		t.Fatalf("selected list or stale-page sequence is wrong: id=%q name=%q seq=%d", m.listID, m.listName, m.feedSeq)
+	if m.cur().listID != "200" || m.cur().listName != "Second" || m.cur().feedSeq != 8 {
+		t.Fatalf("selected list or stale-page sequence is wrong: id=%q name=%q seq=%d", m.cur().listID, m.cur().listName, m.cur().feedSeq)
 	}
-	if len(m.posts) != 0 || m.cursor != "" || m.selected != 0 || !m.loading {
+	if len(m.cur().posts) != 0 || m.cur().cursor != "" || m.cur().selected != 0 || !m.cur().loading {
 		t.Fatalf("list feed did not reset for its first page: posts=%d cursor=%q selected=%d loading=%v",
-			len(m.posts), m.cursor, m.selected, m.loading)
+			len(m.cur().posts), m.cur().cursor, m.cur().selected, m.cur().loading)
 	}
 }
 
 func TestListFeedHeaderShowsListNameWithinWidth(t *testing.T) {
 	m := NewWithImageMode("off")
 	m.width = 42
-	m.loading = false
-	m.feed = FeedList
-	m.listName = strings.Repeat("very long list name ", 8)
+	m.cur().loading = false
+	m.cur().feed = FeedList
+	m.cur().listName = strings.Repeat("very long list name ", 8)
 
 	header := m.header(m.contentWidth())
 	if !strings.Contains(header, "List:") {
@@ -81,9 +81,9 @@ func TestListFeedHeaderShowsListNameWithinWidth(t *testing.T) {
 
 func TestStalePageFromPreviousFeedIsDroppedAfterListSwitch(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.loading = false
-	m.feed = FeedForYou
-	m.feedSeq = 3
+	m.cur().loading = false
+	m.cur().feed = FeedForYou
+	m.cur().feedSeq = 3
 
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'L'}})
 	m = update(t, m, listsMsg{lists: []api.ListInfo{{ID: "100", Name: "Cats"}}})
@@ -93,8 +93,8 @@ func TestStalePageFromPreviousFeedIsDroppedAfterListSwitch(t *testing.T) {
 		page: &api.TimelinePage{Posts: []api.TimelinePost{{ID: "stale", Text: "old feed"}}},
 	})
 
-	if m.feed != FeedList || m.feedSeq != 4 || len(m.posts) != 0 {
-		t.Fatalf("stale page leaked after list switch: feed=%v seq=%d posts=%v", m.feed, m.feedSeq, m.posts)
+	if m.cur().feed != FeedList || m.cur().feedSeq != 4 || len(m.cur().posts) != 0 {
+		t.Fatalf("stale page leaked after list switch: feed=%v seq=%d posts=%v", m.cur().feed, m.cur().feedSeq, m.cur().posts)
 	}
 }
 
@@ -102,7 +102,7 @@ func TestListPickerRendersLoadingAndErrorStates(t *testing.T) {
 	m := NewWithImageMode("off")
 	m.width = 60
 	m.height = 20
-	m.loading = false
+	m.cur().loading = false
 	m.beginListPicker()
 
 	if view := m.View(); !strings.Contains(view, "loading lists") {
@@ -123,25 +123,25 @@ func TestListPickerRendersLoadingAndErrorStates(t *testing.T) {
 
 func TestListPickerKeepsBackgroundFeedPagesFlowing(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.loading = false
+	m.cur().loading = false
 	m.beginListPicker()
 
 	m = update(t, m, pageMsg{
 		page: &api.TimelinePage{Posts: []api.TimelinePost{{ID: "fresh", Text: "fresh"}}},
 	})
 
-	if m.mode != modeListPicker || len(m.posts) != 1 || m.posts[0].ID != "fresh" {
-		t.Fatalf("background feed page did not flow through picker: mode=%v posts=%v", m.mode, m.posts)
+	if m.mode != modeListPicker || len(m.cur().posts) != 1 || m.cur().posts[0].ID != "fresh" {
+		t.Fatalf("background feed page did not flow through picker: mode=%v posts=%v", m.mode, m.cur().posts)
 	}
 }
 
 func TestListPickerKeepsBackgroundThreadPagesFlowing(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.loading = false
+	m.cur().loading = false
 	m.mode = modeThread
-	m.threadRootID = "root"
-	m.threadSeq = 4
-	m.threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}}}
+	m.cur().threadRootID = "root"
+	m.cur().threadSeq = 4
+	m.cur().threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}}}
 	m.beginListPicker()
 
 	m = update(t, m, threadMsg{
@@ -153,15 +153,15 @@ func TestListPickerKeepsBackgroundThreadPagesFlowing(t *testing.T) {
 		}}},
 	})
 
-	if m.mode != modeListPicker || len(m.threadPosts) != 2 {
-		t.Fatalf("background thread page did not flow through picker: mode=%v posts=%v", m.mode, m.threadPosts)
+	if m.mode != modeListPicker || len(m.cur().threadPosts) != 2 {
+		t.Fatalf("background thread page did not flow through picker: mode=%v posts=%v", m.mode, m.cur().threadPosts)
 	}
 }
 
 func TestListPickerKeepsLikePreviewAndSpinnerResultsFlowing(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.loading = false
-	m.posts = []api.TimelinePost{{ID: "post", Liked: true}}
+	m.cur().loading = false
+	m.cur().posts = []api.TimelinePost{{ID: "post", Liked: true}}
 	m.liking["post"] = true
 	m.beginListPicker()
 

--- a/internal/timeline/lists_test.go
+++ b/internal/timeline/lists_test.go
@@ -1,0 +1,182 @@
+package timeline
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/melqtx/xeet/pkg/api"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestListPickerOpensOnCapitalLAndClosesOnEsc(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.loading = false
+	m.feed = FeedFollowing
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'L'}})
+	m = next.(Model)
+
+	if cmd == nil || m.mode != modeListPicker || m.listReturn != modeFeed {
+		t.Fatalf("list picker did not open from feed: mode=%v return=%v cmd=%v", m.mode, m.listReturn, cmd)
+	}
+	if !m.listPickerLoading || m.feed != FeedFollowing {
+		t.Fatalf("opening picker changed the feed or skipped loading: feed=%v loading=%v", m.feed, m.listPickerLoading)
+	}
+
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyEsc})
+	if m.mode != modeFeed || m.feed != FeedFollowing || m.listPickerLoading {
+		t.Fatalf("esc did not restore the feed: mode=%v feed=%v loading=%v", m.mode, m.feed, m.listPickerLoading)
+	}
+}
+
+func TestListPickerSelectionSwitchesFeedAndResetsState(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.loading = false
+	m.feed = FeedBookmarks
+	m.feedSeq = 7
+	m.posts = []api.TimelinePost{{ID: "old", Text: "old"}}
+	m.cursor = "old-cursor"
+	m.selected = 1
+
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'L'}})
+	m = update(t, m, listsMsg{lists: []api.ListInfo{
+		{ID: "100", Name: "First"},
+		{ID: "200", Name: "Second", MemberCount: 12, IsPrivate: true},
+	}})
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+
+	if cmd == nil || m.mode != modeFeed || m.feed != FeedList {
+		t.Fatalf("list selection did not become a feed: mode=%v feed=%v cmd=%v", m.mode, m.feed, cmd)
+	}
+	if m.listID != "200" || m.listName != "Second" || m.feedSeq != 8 {
+		t.Fatalf("selected list or stale-page sequence is wrong: id=%q name=%q seq=%d", m.listID, m.listName, m.feedSeq)
+	}
+	if len(m.posts) != 0 || m.cursor != "" || m.selected != 0 || !m.loading {
+		t.Fatalf("list feed did not reset for its first page: posts=%d cursor=%q selected=%d loading=%v",
+			len(m.posts), m.cursor, m.selected, m.loading)
+	}
+}
+
+func TestListFeedHeaderShowsListNameWithinWidth(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.width = 42
+	m.loading = false
+	m.feed = FeedList
+	m.listName = strings.Repeat("very long list name ", 8)
+
+	header := m.header(m.contentWidth())
+	if !strings.Contains(header, "List:") {
+		t.Fatalf("list header does not identify the feed:\n%s", header)
+	}
+	if width := maxLineWidth(header); width > m.contentWidth() {
+		t.Fatalf("list header width=%d exceeds content width=%d:\n%s", width, m.contentWidth(), header)
+	}
+}
+
+func TestStalePageFromPreviousFeedIsDroppedAfterListSwitch(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.loading = false
+	m.feed = FeedForYou
+	m.feedSeq = 3
+
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'L'}})
+	m = update(t, m, listsMsg{lists: []api.ListInfo{{ID: "100", Name: "Cats"}}})
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	m = update(t, m, pageMsg{
+		seq:  3,
+		page: &api.TimelinePage{Posts: []api.TimelinePost{{ID: "stale", Text: "old feed"}}},
+	})
+
+	if m.feed != FeedList || m.feedSeq != 4 || len(m.posts) != 0 {
+		t.Fatalf("stale page leaked after list switch: feed=%v seq=%d posts=%v", m.feed, m.feedSeq, m.posts)
+	}
+}
+
+func TestListPickerRendersLoadingAndErrorStates(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.width = 60
+	m.height = 20
+	m.loading = false
+	m.beginListPicker()
+
+	if view := m.View(); !strings.Contains(view, "loading lists") {
+		t.Fatalf("loading state is not visible:\n%s", view)
+	}
+
+	m = update(t, m, listsMsg{err: errors.New("offline")})
+	view := m.View()
+	for _, want := range []string{"couldn't load lists", "offline", "esc cancel"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("error state is missing %q:\n%s", want, view)
+		}
+	}
+	if m.listPickerLoading {
+		t.Fatal("error left the picker loading")
+	}
+}
+
+func TestListPickerKeepsBackgroundFeedPagesFlowing(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.loading = false
+	m.beginListPicker()
+
+	m = update(t, m, pageMsg{
+		page: &api.TimelinePage{Posts: []api.TimelinePost{{ID: "fresh", Text: "fresh"}}},
+	})
+
+	if m.mode != modeListPicker || len(m.posts) != 1 || m.posts[0].ID != "fresh" {
+		t.Fatalf("background feed page did not flow through picker: mode=%v posts=%v", m.mode, m.posts)
+	}
+}
+
+func TestListPickerKeepsBackgroundThreadPagesFlowing(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.loading = false
+	m.mode = modeThread
+	m.threadRootID = "root"
+	m.threadSeq = 4
+	m.threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}}}
+	m.beginListPicker()
+
+	m = update(t, m, threadMsg{
+		rootID: "root",
+		seq:    4,
+		page: &api.ConversationPage{Posts: []api.ConversationPost{{
+			TimelinePost: api.TimelinePost{ID: "reply", InReplyToID: "root", Text: "reply"},
+			Depth:        1,
+		}}},
+	})
+
+	if m.mode != modeListPicker || len(m.threadPosts) != 2 {
+		t.Fatalf("background thread page did not flow through picker: mode=%v posts=%v", m.mode, m.threadPosts)
+	}
+}
+
+func TestListPickerKeepsLikePreviewAndSpinnerResultsFlowing(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.loading = false
+	m.posts = []api.TimelinePost{{ID: "post", Liked: true}}
+	m.liking["post"] = true
+	m.beginListPicker()
+
+	m = update(t, m, likeMsg{id: "post", liked: true})
+	m = update(t, m, previewMsg{postID: "post", content: "preview"})
+	next, cmd := m.Update(spinner.TickMsg{Time: time.Now()})
+	m = next.(Model)
+
+	if m.liking["post"] {
+		t.Fatal("like result did not settle while picker was open")
+	}
+	if got := m.previews["post"].content; got != "preview" {
+		t.Fatalf("preview result did not store while picker was open: %q", got)
+	}
+	if cmd == nil || m.mode != modeListPicker {
+		t.Fatalf("spinner did not keep ticking in picker: mode=%v cmd=%v", m.mode, cmd)
+	}
+}

--- a/internal/timeline/lists_test.go
+++ b/internal/timeline/lists_test.go
@@ -43,7 +43,7 @@ func TestListPickerSelectionSwitchesFeedAndResetsState(t *testing.T) {
 	m.cur().selected = 1
 
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'L'}})
-	m = update(t, m, listsMsg{lists: []api.ListInfo{
+	m = update(t, m, listsMsg{picker: true, lists: []api.ListInfo{
 		{ID: "100", Name: "First"},
 		{ID: "200", Name: "Second", MemberCount: 12, IsPrivate: true},
 	}})
@@ -86,7 +86,7 @@ func TestStalePageFromPreviousFeedIsDroppedAfterListSwitch(t *testing.T) {
 	m.cur().feedSeq = 3
 
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'L'}})
-	m = update(t, m, listsMsg{lists: []api.ListInfo{{ID: "100", Name: "Cats"}}})
+	m = update(t, m, listsMsg{picker: true, lists: []api.ListInfo{{ID: "100", Name: "Cats"}}})
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyEnter})
 	m = update(t, m, pageMsg{
 		seq:  3,
@@ -109,7 +109,7 @@ func TestListPickerRendersLoadingAndErrorStates(t *testing.T) {
 		t.Fatalf("loading state is not visible:\n%s", view)
 	}
 
-	m = update(t, m, listsMsg{err: errors.New("offline")})
+	m = update(t, m, listsMsg{picker: true, err: errors.New("offline")})
 	view := m.View()
 	for _, want := range []string{"couldn't load lists", "offline", "esc cancel"} {
 		if !strings.Contains(view, want) {
@@ -162,7 +162,7 @@ func TestListPickerKeepsLikePreviewAndSpinnerResultsFlowing(t *testing.T) {
 	m := NewWithImageMode("off")
 	m.cur().loading = false
 	m.cur().posts = []api.TimelinePost{{ID: "post", Liked: true}}
-	m.liking["post"] = true
+	m.liking[likeKey("", "post")] = true
 	m.beginListPicker()
 
 	m = update(t, m, likeMsg{id: "post", liked: true})
@@ -170,7 +170,7 @@ func TestListPickerKeepsLikePreviewAndSpinnerResultsFlowing(t *testing.T) {
 	next, cmd := m.Update(spinner.TickMsg{Time: time.Now()})
 	m = next.(Model)
 
-	if m.liking["post"] {
+	if m.liking[likeKey("", "post")] {
 		t.Fatal("like result did not settle while picker was open")
 	}
 	if got := m.previews["post"].content; got != "preview" {

--- a/internal/timeline/lists_test.go
+++ b/internal/timeline/lists_test.go
@@ -71,7 +71,7 @@ func TestListFeedHeaderShowsListNameWithinWidth(t *testing.T) {
 	m.cur().listName = strings.Repeat("very long list name ", 8)
 
 	header := m.header(m.contentWidth())
-	if !strings.Contains(header, "List:") {
+	if !strings.Contains(header, "list · ") {
 		t.Fatalf("list header does not identify the feed:\n%s", header)
 	}
 	if width := maxLineWidth(header); width > m.contentWidth() {

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -79,44 +79,22 @@ type Model struct {
 	width, height int
 	imageMode     imageMode
 	imageNote     string
-	feed          FeedKind
-	searchQuery   string
-	listID        string
-	listName      string
-	feedSeq       int
-	posts         []api.TimelinePost
-	cursor        string
-	selected      int
-	starts        []int
-	ends          []int
-	loading       bool
-	loadingMore   bool
-	refreshing    bool
 	help          bool
 	altText       bool
 	altTextScroll int
-	expanded      bool
 	zoom          bool
 	action        Action
 	clipboardOK   bool
 	toast         string
 	toastSeq      int
-	err           error
 	liking        map[string]bool
 	previews      map[string]previewState
 	spinner       spinner.Model
-	viewport      viewport.Model
-	wezFrameKey   string
+	columns       []column
+	focus         int
+	nextColID     int
 
 	mode              mode
-	feedSelected      int
-	threadRootID      string
-	threadPosts       []api.ConversationPost
-	threadCursor      string
-	threadLoading     bool
-	threadMore        bool
-	threadErr         error
-	threadSeq         int
 	replyReturn       mode
 	replyEditor       textarea.Model
 	replyPost         api.TimelinePost
@@ -133,10 +111,11 @@ type Model struct {
 }
 
 type pageMsg struct {
-	page *api.TimelinePage
-	err  error
-	more bool
-	seq  int
+	page  *api.TimelinePage
+	err   error
+	more  bool
+	seq   int
+	colID int
 }
 
 type actionMsg struct {
@@ -158,6 +137,7 @@ type replyResultMsg struct {
 type threadMsg struct {
 	rootID string
 	seq    int
+	colID  int
 	page   *api.ConversationPage
 	err    error
 	more   bool
@@ -197,6 +177,7 @@ type previewState struct {
 
 type previewMsg struct {
 	postID     string
+	colID      int
 	content    string
 	nativePath string
 	nativeData string
@@ -227,9 +208,10 @@ func NewWithImageMode(requested string) Model {
 	mode, note := resolveImageMode(requested)
 	return Model{
 		ctx:   context.Background(),
-		width: 80, height: 24, imageMode: mode, imageNote: note, loading: true,
+		width: 80, height: 24, imageMode: mode, imageNote: note,
 		liking: map[string]bool{}, previews: map[string]previewState{},
-		spinner: s, viewport: vp, replyEditor: editor, searchInput: search,
+		spinner: s, columns: []column{{id: 0, loading: true, viewport: vp}},
+		nextColID: 1, replyEditor: editor, searchInput: search,
 	}
 }
 
@@ -243,29 +225,30 @@ func (m Model) requestContext() context.Context {
 }
 
 func (m Model) Init() tea.Cmd {
-	if m.feed == FeedSearch && m.searchQuery == "" {
+	c := m.cur()
+	if c.feed == FeedSearch && c.searchQuery == "" {
 		return tea.Batch(m.searchInput.Focus(), clockTick())
 	}
 	if m.mode == modeListPicker {
 		return tea.Batch(m.spinner.Tick, fetchListsCmd(m.requestContext()), clockTick())
 	}
-	return tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.feed, m.searchQuery, m.listID, "", false, m.feedSeq), clockTick())
+	return tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), c.feed, c.searchQuery, c.listID, "", false, c.feedSeq, c.id), clockTick())
 }
 
 func Run(ctx context.Context, images string, feed FeedKind, query, listID string) (Action, error) {
 	m := NewWithImageMode(images)
 	m.ctx = ctx
-	m.feed = feed
-	m.searchQuery = query
-	m.listID = listID
+	m.cur().feed = feed
+	m.cur().searchQuery = query
+	m.cur().listID = listID
 	if feed == FeedSearch && query == "" {
-		m.loading = false
+		m.cur().loading = false
 		m.beginSearch()
 	}
 	if feed == FeedList {
-		m.listName = listID
+		m.cur().listName = listID
 		if listID == "" {
-			m.loading = false
+			m.cur().loading = false
 			m.beginListPicker()
 		}
 	}
@@ -298,15 +281,15 @@ func Run(ctx context.Context, images string, feed FeedKind, query, listID string
 	return Action{}, err
 }
 
-func fetchPageSeq(parent context.Context, feed FeedKind, query, listID, cursor string, more bool, seq int) tea.Cmd {
+func fetchPageSeq(parent context.Context, feed FeedKind, query, listID, cursor string, more bool, seq, colID int) tea.Cmd {
 	return func() tea.Msg {
 		mgr, err := config.NewConfigManager()
 		if err != nil {
-			return pageMsg{err: err, more: more, seq: seq}
+			return pageMsg{err: err, more: more, seq: seq, colID: colID}
 		}
 		cfg, err := mgr.Load()
 		if err != nil {
-			return pageMsg{err: err, more: more, seq: seq}
+			return pageMsg{err: err, more: more, seq: seq, colID: colID}
 		}
 		ctx, cancel := context.WithTimeout(parent, 40*time.Second)
 		defer cancel()
@@ -332,7 +315,7 @@ func fetchPageSeq(parent context.Context, feed FeedKind, query, listID, cursor s
 		if client.ApplyRefreshedQueryIDs(cfg) {
 			_ = mgr.Save(cfg)
 		}
-		return pageMsg{page: page, err: err, more: more, seq: seq}
+		return pageMsg{page: page, err: err, more: more, seq: seq, colID: colID}
 	}
 }
 
@@ -378,8 +361,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// rows whose text did not change. Clearing forces a full repaint, but
 		// doing it on every keystroke made iTerm2 flicker constantly, so it
 		// only happens when the frame's layout actually moved.
-		if key := m.imageFrameKey(); key != m.wezFrameKey {
-			m.wezFrameKey = key
+		if key := m.imageFrameKey(); key != m.cur().wezFrameKey {
+			m.cur().wezFrameKey = key
 			return m, func() tea.Msg { return tea.ClearScreen() }
 		}
 		return m, nil
@@ -457,7 +440,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case spinner.TickMsg:
-		if m.loading || m.loadingMore || m.refreshing || m.zoomLoading() {
+		if m.cur().loading || m.cur().loadingMore || m.cur().refreshing || m.zoomLoading() {
 			var cmd tea.Cmd
 			m.spinner, cmd = m.spinner.Update(msg)
 			return m, cmd
@@ -483,8 +466,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case "q", "ctrl+c":
 		return m, tea.Quit
 	case "esc":
-		if m.expanded {
-			m.expanded = false
+		if m.cur().expanded {
+			m.cur().expanded = false
 			m.syncViewport()
 			m.ensureSelectedVisible()
 			return m, m.imageRepaint()
@@ -494,22 +477,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.help = true
 		return m, m.imageRepaint()
 	case "j", "down":
-		m.moveSelection(m.selected + 1)
+		m.moveSelection(m.cur().selected + 1)
 		return m, m.imageRepaint(m.requestPreviews(), m.maybeLoadMore())
 	case "k", "up":
-		m.moveSelection(m.selected - 1)
+		m.moveSelection(m.cur().selected - 1)
 		return m, m.imageRepaint(m.requestPreviews())
 	case "ctrl+d":
-		m.moveSelection(m.selected + 5)
+		m.moveSelection(m.cur().selected + 5)
 		return m, m.imageRepaint(m.requestPreviews(), m.maybeLoadMore())
 	case "ctrl+u":
-		m.moveSelection(m.selected - 5)
+		m.moveSelection(m.cur().selected - 5)
 		return m, m.imageRepaint(m.requestPreviews())
 	case "g", "home":
 		m.moveSelection(0)
 		return m, m.imageRepaint(m.requestPreviews())
 	case "G", "end":
-		m.moveSelection(len(m.posts) - 1)
+		m.moveSelection(len(m.cur().posts) - 1)
 		return m, m.imageRepaint(m.requestPreviews(), m.maybeLoadMore())
 	case "ctrl+l":
 		m.syncViewport()
@@ -517,7 +500,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case "f":
 		return m, m.switchFeed()
 	case "b":
-		if m.feed == FeedBookmarks {
+		if m.cur().feed == FeedBookmarks {
 			return m, m.setFeed(FeedForYou)
 		}
 		return m, m.setFeed(FeedBookmarks)
@@ -526,19 +509,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case "L":
 		return m, m.beginListPicker()
 	case "R", "ctrl+r":
-		if len(m.posts) == 0 {
-			m.loading = true
+		c := m.cur()
+		if len(c.posts) == 0 {
+			c.loading = true
 		} else {
-			m.refreshing = true
+			c.refreshing = true
 		}
-		m.err = nil
-		return m, m.imageRepaint(tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.feed, m.searchQuery, m.listID, "", false, m.feedSeq)))
+		c.err = nil
+		return m, m.imageRepaint(tea.Batch(m.spinner.Tick, fetchPageSeq(
+			m.requestContext(), c.feed, c.searchQuery, c.listID, "", false, c.feedSeq, c.id,
+		)))
 	case "r":
 		if post, ok := m.currentPost(); ok {
 			return m.beginReply(post)
 		}
 	case "a":
-		if errors.Is(m.err, api.ErrSessionExpired) {
+		if errors.Is(m.cur().err, api.ErrSessionExpired) {
 			m.action = Action{Kind: ActionAuthenticate}
 			return m, tea.Quit
 		}
@@ -547,22 +533,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 	case "enter":
 		if post, ok := m.currentPost(); ok {
-			m.feedSelected = m.selected
+			m.cur().feedSelected = m.cur().selected
 			m.mode = modeThread
-			m.threadRootID = post.ID
-			m.threadPosts = []api.ConversationPost{{TimelinePost: post}}
-			m.threadCursor = ""
-			m.threadLoading = true
-			m.threadErr = nil
-			m.selected = 0
-			m.expanded = false
-			m.viewport.YOffset = 0
+			m.cur().threadRootID = post.ID
+			m.cur().threadPosts = []api.ConversationPost{{TimelinePost: post}}
+			m.cur().threadCursor = ""
+			m.cur().threadLoading = true
+			m.cur().threadErr = nil
+			m.cur().selected = 0
+			m.cur().expanded = false
+			m.cur().viewport.YOffset = 0
 			m.syncViewport()
 			return m, m.imageRepaint(tea.Batch(m.spinner.Tick, m.requestThread("", false), m.requestPreviews()))
 		}
 	case " ", "e":
-		if len(m.posts) > 0 {
-			m.expanded = !m.expanded
+		if len(m.cur().posts) > 0 {
+			m.cur().expanded = !m.cur().expanded
 			m.syncViewport()
 			m.ensureSelectedVisible()
 			return m, m.imageRepaint()
@@ -609,16 +595,27 @@ func (m *Model) applyLikeResult(msg likeMsg) tea.Cmd {
 	return cmd
 }
 
-func (m *Model) storePreview(msg previewMsg) {
+func (m *Model) storePreview(msg previewMsg) *column {
+	c := m.columnByID(msg.colID)
+	if c == nil {
+		return nil
+	}
 	m.previews[msg.postID] = previewState{
 		content: msg.content, nativePath: msg.nativePath, nativeData: msg.nativeData, imageID: msg.imageID,
 		columns: msg.columns, rows: msg.rows, err: msg.err,
 	}
+	return c
 }
 
 func (m *Model) applyPreview(msg previewMsg) tea.Cmd {
-	m.storePreview(msg)
+	c := m.storePreview(msg)
+	if c == nil {
+		return nil
+	}
 	m.evictDistantPreviews()
+	if c != m.cur() {
+		return nil
+	}
 	m.syncViewport()
 	m.ensureSelectedVisible()
 	return m.imageRepaint()
@@ -687,13 +684,13 @@ func (m *Model) moveAltText(delta int) {
 }
 
 func (m *Model) moveSelection(target int) {
-	if len(m.posts) == 0 {
+	if len(m.cur().posts) == 0 {
 		return
 	}
-	target = max(0, min(len(m.posts)-1, target))
-	if target != m.selected {
-		m.selected = target
-		m.expanded = false
+	target = max(0, min(len(m.cur().posts)-1, target))
+	if target != m.cur().selected {
+		m.cur().selected = target
+		m.cur().expanded = false
 	}
 	m.toast = ""
 	m.syncViewport()
@@ -702,70 +699,78 @@ func (m *Model) moveSelection(target int) {
 
 // setFeed resets feed state and kicks off a fresh first page for kind.
 func (m *Model) setFeed(kind FeedKind) tea.Cmd {
-	m.feed = kind
-	m.feedSeq++
-	m.posts = nil
-	m.cursor = ""
-	m.selected = 0
-	m.expanded = false
-	m.loading = true
-	m.loadingMore = false
-	m.refreshing = false
-	m.err = nil
-	m.viewport.YOffset = 0
+	c := m.cur()
+	c.feed = kind
+	c.feedSeq++
+	c.posts = nil
+	c.cursor = ""
+	c.selected = 0
+	c.expanded = false
+	c.loading = true
+	c.loadingMore = false
+	c.refreshing = false
+	c.err = nil
+	c.viewport.YOffset = 0
 	m.syncViewport()
-	return m.imageRepaint(tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.feed, m.searchQuery, m.listID, "", false, m.feedSeq)))
+	return m.imageRepaint(tea.Batch(m.spinner.Tick, fetchPageSeq(
+		m.requestContext(), c.feed, c.searchQuery, c.listID, "", false, c.feedSeq, c.id,
+	)))
 }
 
 // switchFeed keeps the f-key semantics: toggle For You <-> Following.
 // From any other feed kind it returns to For You.
 func (m *Model) switchFeed() tea.Cmd {
-	if m.feed == FeedForYou {
+	if m.cur().feed == FeedForYou {
 		return m.setFeed(FeedFollowing)
 	}
 	return m.setFeed(FeedForYou)
 }
 
 func (m *Model) maybeLoadMore() tea.Cmd {
-	if len(m.posts) > 0 && m.selected >= len(m.posts)-5 && m.cursor != "" && !m.loadingMore {
-		m.loadingMore = true
-		return tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.feed, m.searchQuery, m.listID, m.cursor, true, m.feedSeq))
+	c := m.cur()
+	if len(c.posts) > 0 && c.selected >= len(c.posts)-5 && c.cursor != "" && !c.loadingMore {
+		c.loadingMore = true
+		return tea.Batch(m.spinner.Tick, fetchPageSeq(
+			m.requestContext(), c.feed, c.searchQuery, c.listID, c.cursor, true, c.feedSeq, c.id,
+		))
 	}
 	return nil
 }
 
 func (m Model) applyFeedPage(msg pageMsg) (tea.Model, tea.Cmd) {
-	if msg.seq != m.feedSeq {
+	c := m.columnByID(msg.colID)
+	if c == nil || msg.seq != c.feedSeq {
 		// A page from before the last feed switch; the wrong feed's posts
 		// must not leak into the current one.
 		return m, nil
 	}
-	m.loading = false
-	m.loadingMore = false
-	m.refreshing = false
+	c.loading = false
+	c.loadingMore = false
+	c.refreshing = false
 	if msg.err != nil {
-		m.err = msg.err
+		c.err = msg.err
 		return m, nil
 	}
-	m.err = nil
-	threadContext := m.mode == modeThread ||
+	c.err = nil
+	focused := c == m.cur()
+	threadContext := focused && (m.mode == modeThread ||
 		(m.mode == modeReply && m.replyReturn == modeThread) ||
 		(m.mode == modeSearch && m.searchReturn == modeThread) ||
-		(m.mode == modeListPicker && m.listReturn == modeThread)
-	feedIndex := m.selected
+		(m.mode == modeListPicker && m.listReturn == modeThread))
+	feedIndex := c.selected
 	if threadContext {
-		feedIndex = m.feedSelected
+		feedIndex = c.feedSelected
 	}
 	selectedID := ""
-	if feedIndex >= 0 && feedIndex < len(m.posts) {
-		selectedID = m.posts[feedIndex].ID
+	if feedIndex >= 0 && feedIndex < len(c.posts) {
+		selectedID = c.posts[feedIndex].ID
 	}
-	seen := make(map[string]bool, len(m.posts))
-	for _, post := range m.posts {
+	seen := make(map[string]bool, len(c.posts))
+	for _, post := range c.posts {
 		seen[post.ID] = true
 	}
 	var toast tea.Cmd
-	if !msg.more && len(m.posts) > 0 {
+	if !msg.more && len(c.posts) > 0 {
 		var fresh []api.TimelinePost
 		for _, post := range msg.page.Posts {
 			if !seen[post.ID] {
@@ -773,7 +778,7 @@ func (m Model) applyFeedPage(msg pageMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 		if len(fresh) > 0 {
-			m.posts = append(fresh, m.posts...)
+			c.posts = append(fresh, c.posts...)
 			feedIndex += len(fresh)
 			label := "posts"
 			if len(fresh) == 1 {
@@ -786,23 +791,23 @@ func (m Model) applyFeedPage(msg pageMsg) (tea.Model, tea.Cmd) {
 	} else {
 		for _, post := range msg.page.Posts {
 			if !seen[post.ID] {
-				m.posts = append(m.posts, post)
+				c.posts = append(c.posts, post)
 				seen[post.ID] = true
 			}
 		}
-		m.cursor = msg.page.Cursor
-		feedIndex = indexOfPost(m.posts, selectedID)
+		c.cursor = msg.page.Cursor
+		feedIndex = indexOfPost(c.posts, selectedID)
 		if feedIndex < 0 {
 			feedIndex = 0
 		}
 		m.toast = ""
 	}
 	if threadContext {
-		m.feedSelected = feedIndex
+		c.feedSelected = feedIndex
 	} else {
-		m.selected = feedIndex
+		c.selected = feedIndex
 	}
-	if m.mode == modeReply {
+	if !focused || m.mode == modeReply {
 		return m, toast
 	}
 	m.syncViewport()
@@ -836,13 +841,13 @@ func (m Model) imageRepaint(cmds ...tea.Cmd) tea.Cmd {
 func (m Model) imageFrameKey() string {
 	hash := fnv.New64a()
 	fmt.Fprintf(hash, "%d|%d|%d|%d|%v|%v|%v|%v|%v|",
-		m.viewport.YOffset, m.viewport.Width, m.viewport.Height,
-		m.mode, m.help, m.altText, m.zoom, m.expanded, m.loading)
-	for _, start := range m.starts {
+		m.cur().viewport.YOffset, m.cur().viewport.Width, m.cur().viewport.Height,
+		m.mode, m.help, m.altText, m.zoom, m.cur().expanded, m.cur().loading)
+	for _, start := range m.cur().starts {
 		fmt.Fprintf(hash, "%d,", start)
 	}
-	if len(m.ends) > 0 {
-		fmt.Fprintf(hash, "|%d", m.ends[len(m.ends)-1])
+	if len(m.cur().ends) > 0 {
+		fmt.Fprintf(hash, "|%d", m.cur().ends[len(m.cur().ends)-1])
 	}
 	return fmt.Sprintf("%x", hash.Sum64())
 }
@@ -853,8 +858,8 @@ func (m *Model) resize() {
 	if viewportHeight < 1 {
 		viewportHeight = 1
 	}
-	m.viewport.Width = w
-	m.viewport.Height = viewportHeight
+	m.cur().viewport.Width = w
+	m.cur().viewport.Height = viewportHeight
 	m.replyEditor.SetWidth(max(20, w-6))
 	m.replyEditor.SetHeight(min(7, max(3, m.height-16)))
 	m.searchInput.Width = max(10, w-16)
@@ -871,56 +876,56 @@ func (m *Model) syncViewport() {
 	} else {
 		content, starts, ends = m.renderFeedContent()
 	}
-	m.starts = starts
-	m.ends = ends
-	m.viewport.SetContent(content)
+	m.cur().starts = starts
+	m.cur().ends = ends
+	m.cur().viewport.SetContent(content)
 }
 
 func (m *Model) ensureSelectedVisible() {
-	if m.selected < 0 || m.selected >= len(m.starts) {
+	if m.cur().selected < 0 || m.cur().selected >= len(m.cur().starts) {
 		return
 	}
 	// Keep a small margin above and below the selection so movement never
 	// pins it to the viewport edge (vim's scrolloff).
 	const margin = 2
-	start := m.starts[m.selected]
-	end := m.ends[m.selected]
-	top := m.viewport.YOffset
+	start := m.cur().starts[m.cur().selected]
+	end := m.cur().ends[m.cur().selected]
+	top := m.cur().viewport.YOffset
 	if start-margin < top {
 		top = max(0, start-margin)
-	} else if end+margin >= top+m.viewport.Height {
-		top = end + margin - m.viewport.Height + 1
+	} else if end+margin >= top+m.cur().viewport.Height {
+		top = end + margin - m.cur().viewport.Height + 1
 	}
 	// A post taller than the viewport anchors to its own first line.
 	if start < top {
 		top = start
 	}
-	maxTop := max(0, m.ends[len(m.ends)-1]+1-m.viewport.Height)
-	m.viewport.YOffset = max(0, min(top, maxTop))
+	maxTop := max(0, m.cur().ends[len(m.cur().ends)-1]+1-m.cur().viewport.Height)
+	m.cur().viewport.YOffset = max(0, min(top, maxTop))
 }
 
 func (m Model) activePosts() []api.TimelinePost {
 	if m.mode == modeThread {
-		posts := make([]api.TimelinePost, len(m.threadPosts))
-		for i := range m.threadPosts {
-			posts[i] = m.threadPosts[i].TimelinePost
+		posts := make([]api.TimelinePost, len(m.cur().threadPosts))
+		for i := range m.cur().threadPosts {
+			posts[i] = m.cur().threadPosts[i].TimelinePost
 		}
 		return posts
 	}
-	return m.posts
+	return m.cur().posts
 }
 
 func (m Model) currentPost() (api.TimelinePost, bool) {
 	if m.mode == modeThread {
-		if m.selected < 0 || m.selected >= len(m.threadPosts) {
+		if m.cur().selected < 0 || m.cur().selected >= len(m.cur().threadPosts) {
 			return api.TimelinePost{}, false
 		}
-		return m.threadPosts[m.selected].TimelinePost, true
+		return m.cur().threadPosts[m.cur().selected].TimelinePost, true
 	}
-	if m.selected < 0 || m.selected >= len(m.posts) {
+	if m.cur().selected < 0 || m.cur().selected >= len(m.cur().posts) {
 		return api.TimelinePost{}, false
 	}
-	return m.posts[m.selected], true
+	return m.cur().posts[m.cur().selected], true
 }
 
 func (m *Model) applyLike(id string, liked bool) {
@@ -935,11 +940,14 @@ func (m *Model) applyLike(id string, liked bool) {
 			post.LikeCount--
 		}
 	}
-	for i := range m.posts {
-		apply(&m.posts[i])
-	}
-	for i := range m.threadPosts {
-		apply(&m.threadPosts[i].TimelinePost)
+	for columnIndex := range m.columns {
+		c := &m.columns[columnIndex]
+		for i := range c.posts {
+			apply(&c.posts[i])
+		}
+		for i := range c.threadPosts {
+			apply(&c.threadPosts[i].TimelinePost)
+		}
 	}
 }
 

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -1219,6 +1219,17 @@ func relativeTime(value time.Time) string {
 	return value.Format("Jan 2")
 }
 
+// cleanText keeps a post's line breaks -- they carry meaning in lists and
+// verse -- but collapses runs of spaces inside each line and drops blank
+// lines, which would only eat the four-row preview budget.
 func cleanText(value string) string {
-	return strings.Join(strings.Fields(value), " ")
+	value = strings.ReplaceAll(value, "\r\n", "\n")
+	lines := strings.Split(value, "\n")
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if line = strings.Join(strings.Fields(line), " "); line != "" {
+			kept = append(kept, line)
+		}
+	}
+	return strings.Join(kept, "\n")
 }

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -60,6 +60,12 @@ const (
 	FeedList
 )
 
+type ColumnSpec struct {
+	Kind   FeedKind
+	Query  string
+	ListID string
+}
+
 type mode int
 
 const (
@@ -244,19 +250,17 @@ func (m Model) Init() tea.Cmd {
 	return tea.Batch(cmds...)
 }
 
-func Run(ctx context.Context, images string, feed FeedKind, query, listID string, columnCount int) (Action, error) {
+func Run(ctx context.Context, images string, specs []ColumnSpec) (Action, error) {
 	m := NewWithImageMode(images)
 	m.ctx = ctx
-	m.configureColumns(columnCount, feed, query, listID)
-	if feed == FeedSearch && query == "" {
+	m.configureColumns(specs)
+	if len(specs) == 1 && specs[0].Kind == FeedSearch && specs[0].Query == "" {
 		m.cur().loading = false
 		m.beginSearch()
 	}
-	if feed == FeedList {
-		if listID == "" {
-			m.cur().loading = false
-			m.beginListPicker()
-		}
+	if len(specs) == 1 && specs[0].Kind == FeedList && specs[0].ListID == "" {
+		m.cur().loading = false
+		m.beginListPicker()
 	}
 	// Auto-detected native mode is a claim, not a capability: multiplexers
 	// like cmux inherit ghostty's TERM without reliably rendering graphics.

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -61,9 +61,10 @@ const (
 )
 
 type ColumnSpec struct {
-	Kind   FeedKind
-	Query  string
-	ListID string
+	Kind      FeedKind
+	AccountID string
+	Query     string
+	ListID    string
 }
 
 type mode int
@@ -107,6 +108,7 @@ type Model struct {
 	replyReturn       mode
 	replyEditor       textarea.Model
 	replyPost         api.TimelinePost
+	replyAccountID    string
 	replyPosting      bool
 	replyErr          error
 	replyNotice       string
@@ -133,9 +135,10 @@ type actionMsg struct {
 }
 
 type likeMsg struct {
-	id    string
-	liked bool
-	err   error
+	id        string
+	accountID string
+	liked     bool
+	err       error
 }
 
 type replyResultMsg struct {
@@ -238,19 +241,32 @@ func (m Model) Init() tea.Cmd {
 		return tea.Batch(m.searchInput.Focus(), loadAccountsCmd(), clockTick())
 	}
 	if m.mode == modeListPicker {
-		return tea.Batch(m.spinner.Tick, fetchListsCmd(m.requestContext()), loadAccountsCmd(), clockTick())
+		return tea.Batch(
+			m.spinner.Tick,
+			fetchListsCmd(m.requestContext(), c.accountID, true),
+			loadAccountsCmd(),
+			clockTick(),
+		)
 	}
 	cmds := []tea.Cmd{m.spinner.Tick, loadAccountsCmd()}
 	for i := range m.columns {
 		c := &m.columns[i]
 		cmds = append(cmds, fetchPageSeq(
-			m.requestContext(), c.feed, c.searchQuery, c.listID, "", false, c.feedSeq, c.id,
+			m.requestContext(), c.feed, c.searchQuery, c.listID, c.accountID, "", false, c.feedSeq, c.id,
 		))
 	}
-	// Columns built from --columns or a saved layout carry only a list id, and
-	// one enumeration names all of them.
+	// List names are account-scoped, so one global enumeration could label a
+	// different account's column with metadata it cannot access.
 	if m.namesPendingForListColumns() {
-		cmds = append(cmds, fetchListsCmd(m.requestContext()))
+		requested := make(map[string]bool)
+		for i := range m.columns {
+			c := &m.columns[i]
+			if c.feed != FeedList || c.listName != c.listID || requested[c.accountID] {
+				continue
+			}
+			requested[c.accountID] = true
+			cmds = append(cmds, fetchListsCmd(m.requestContext(), c.accountID, false))
+		}
 	}
 	cmds = append(cmds, clockTick())
 	return tea.Batch(cmds...)
@@ -297,13 +313,30 @@ func Run(ctx context.Context, images string, specs []ColumnSpec) (Action, error)
 	return Action{}, err
 }
 
-func fetchPageSeq(parent context.Context, feed FeedKind, query, listID, cursor string, more bool, seq, colID int) tea.Cmd {
+type requestConfigManager interface {
+	Load() (*config.Config, error)
+	LoadAccount(string) (*config.Config, error)
+	SaveQueryIDs(*config.Config) error
+}
+
+var openRequestConfigManager = func() (requestConfigManager, error) {
+	return config.NewConfigManager()
+}
+
+func loadRequestConfig(mgr requestConfigManager, accountID string) (*config.Config, error) {
+	if accountID == "" {
+		return mgr.Load()
+	}
+	return mgr.LoadAccount(accountID)
+}
+
+func fetchPageSeq(parent context.Context, feed FeedKind, query, listID, accountID, cursor string, more bool, seq, colID int) tea.Cmd {
 	return func() tea.Msg {
-		mgr, err := config.NewConfigManager()
+		mgr, err := openRequestConfigManager()
 		if err != nil {
 			return pageMsg{err: err, more: more, seq: seq, colID: colID}
 		}
-		cfg, err := mgr.Load()
+		cfg, err := loadRequestConfig(mgr, accountID)
 		if err != nil {
 			return pageMsg{err: err, more: more, seq: seq, colID: colID}
 		}
@@ -335,15 +368,15 @@ func fetchPageSeq(parent context.Context, feed FeedKind, query, listID, cursor s
 	}
 }
 
-func setLike(parent context.Context, tweetID string, liked bool) tea.Cmd {
+func setLike(parent context.Context, selectedAccountID, actingAccountID, tweetID string, liked bool) tea.Cmd {
 	return func() tea.Msg {
-		mgr, err := config.NewConfigManager()
+		mgr, err := openRequestConfigManager()
 		if err != nil {
-			return likeMsg{id: tweetID, liked: liked, err: err}
+			return likeMsg{id: tweetID, accountID: actingAccountID, liked: liked, err: err}
 		}
-		cfg, err := mgr.Load()
+		cfg, err := loadRequestConfig(mgr, selectedAccountID)
 		if err != nil {
-			return likeMsg{id: tweetID, liked: liked, err: err}
+			return likeMsg{id: tweetID, accountID: actingAccountID, liked: liked, err: err}
 		}
 		ctx, cancel := context.WithTimeout(parent, 30*time.Second)
 		defer cancel()
@@ -352,7 +385,7 @@ func setLike(parent context.Context, tweetID string, liked bool) tea.Cmd {
 		if client.ApplyRefreshedQueryIDs(cfg) {
 			_ = mgr.SaveQueryIDs(cfg)
 		}
-		return likeMsg{id: tweetID, liked: liked, err: err}
+		return likeMsg{id: tweetID, accountID: actingAccountID, liked: liked, err: err}
 	}
 }
 
@@ -491,8 +524,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case listsMsg:
 		// Outside the picker this only ever arrives from Init's backfill, and a
 		// failure just leaves the ids on screen — the feeds themselves loaded.
-		if msg.err == nil {
-			m.nameListColumns(msg.lists)
+		if !msg.picker && msg.err == nil {
+			m.nameListColumns(msg.accountID, msg.lists)
 		}
 		return m, nil
 	}
@@ -564,7 +597,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		c.err = nil
 		return m, m.imageRepaint(tea.Batch(m.spinner.Tick, fetchPageSeq(
-			m.requestContext(), c.feed, c.searchQuery, c.listID, "", false, c.feedSeq, c.id,
+			m.requestContext(), c.feed, c.searchQuery, c.listID, c.accountID, "", false, c.feedSeq, c.id,
 		)))
 	case "r":
 		if post, ok := m.currentPost(); ok {
@@ -621,9 +654,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // settleLike clears the in-flight marker and rolls an optimistic like back if
 // the request failed.
 func (m *Model) settleLike(msg likeMsg) {
-	delete(m.liking, msg.id)
+	delete(m.liking, likeKey(msg.accountID, msg.id))
 	if msg.err != nil {
-		m.applyLike(msg.id, !msg.liked)
+		m.applyLike(msg.accountID, msg.id, !msg.liked)
 	}
 }
 
@@ -716,15 +749,21 @@ func (m *Model) zoomSelected() tea.Cmd {
 
 func (m *Model) toggleSelectedLike() tea.Cmd {
 	post, ok := m.currentPost()
-	if !ok || m.liking[post.ID] {
+	if !ok {
+		return nil
+	}
+	c := m.cur()
+	accountID := m.columnAccountID(c)
+	key := likeKey(accountID, post.ID)
+	if m.liking[key] {
 		return nil
 	}
 	liked := !post.Liked
-	m.liking[post.ID] = true
-	m.applyLike(post.ID, liked)
+	m.liking[key] = true
+	m.applyLike(accountID, post.ID, liked)
 	m.syncViewport()
 	m.ensureSelectedVisible()
-	return setLike(m.requestContext(), post.ID, liked)
+	return setLike(m.requestContext(), c.accountID, accountID, post.ID, liked)
 }
 
 func (m *Model) copySelectedLink() tea.Cmd {
@@ -801,7 +840,7 @@ func (m *Model) resetColumnFeed(c *column, kind FeedKind) tea.Cmd {
 	c.viewport.YOffset = 0
 	c.viewport.SetContent("")
 	return fetchPageSeq(
-		m.requestContext(), c.feed, c.searchQuery, c.listID, "", false, c.feedSeq, c.id,
+		m.requestContext(), c.feed, c.searchQuery, c.listID, c.accountID, "", false, c.feedSeq, c.id,
 	)
 }
 
@@ -830,7 +869,7 @@ func (m *Model) maybeLoadMore() tea.Cmd {
 	if len(c.posts) > 0 && c.selected >= len(c.posts)-5 && c.cursor != "" && !c.loadingMore {
 		c.loadingMore = true
 		return tea.Batch(m.spinner.Tick, fetchPageSeq(
-			m.requestContext(), c.feed, c.searchQuery, c.listID, c.cursor, true, c.feedSeq, c.id,
+			m.requestContext(), c.feed, c.searchQuery, c.listID, c.accountID, c.cursor, true, c.feedSeq, c.id,
 		))
 	}
 	return nil
@@ -1058,7 +1097,23 @@ func (m Model) currentPost() (api.TimelinePost, bool) {
 	return m.cur().posts[m.cur().selected], true
 }
 
-func (m *Model) applyLike(id string, liked bool) {
+func likeKey(accountID, postID string) string {
+	return accountID + ":" + postID
+}
+
+func (m Model) columnAccountID(c *column) string {
+	if c.accountID != "" {
+		return c.accountID
+	}
+	for _, account := range m.accounts {
+		if account.Active {
+			return account.UserID
+		}
+	}
+	return ""
+}
+
+func (m *Model) applyLike(accountID, id string, liked bool) {
 	apply := func(post *api.TimelinePost) {
 		if post.ID != id || post.Liked == liked {
 			return
@@ -1072,6 +1127,9 @@ func (m *Model) applyLike(id string, liked bool) {
 	}
 	for columnIndex := range m.columns {
 		c := &m.columns[columnIndex]
+		if m.columnAccountID(c) != accountID {
+			continue
+		}
 		for i := range c.posts {
 			apply(&c.posts[i])
 		}

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -101,6 +101,7 @@ type Model struct {
 	columns   []column
 	focus     int
 	nextColID int
+	accounts  []config.AccountInfo
 
 	mode              mode
 	replyReturn       mode
@@ -234,12 +235,12 @@ func (m Model) requestContext() context.Context {
 func (m Model) Init() tea.Cmd {
 	c := m.cur()
 	if c.feed == FeedSearch && c.searchQuery == "" {
-		return tea.Batch(m.searchInput.Focus(), clockTick())
+		return tea.Batch(m.searchInput.Focus(), loadAccountsCmd(), clockTick())
 	}
 	if m.mode == modeListPicker {
-		return tea.Batch(m.spinner.Tick, fetchListsCmd(m.requestContext()), clockTick())
+		return tea.Batch(m.spinner.Tick, fetchListsCmd(m.requestContext()), loadAccountsCmd(), clockTick())
 	}
-	cmds := []tea.Cmd{m.spinner.Tick}
+	cmds := []tea.Cmd{m.spinner.Tick, loadAccountsCmd()}
 	for i := range m.columns {
 		c := &m.columns[i]
 		cmds = append(cmds, fetchPageSeq(
@@ -387,6 +388,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.toast = ""
 		}
 		return m, nil
+	}
+	if loaded, ok := msg.(accountsLoadedMsg); ok {
+		if loaded.err == nil {
+			m.accounts = loaded.accounts
+		}
+		return m, nil
+	}
+	if cycled, ok := msg.(accountCycledMsg); ok {
+		if cycled.err != nil {
+			return m, m.showToast(cycled.err.Error())
+		}
+		m.accounts = cycled.accounts
+		m.mode = modeFeed
+		reload := m.resetEveryColumnFeed()
+		toast := m.showToast("switched to " + accountInfoLabel(cycled.active))
+		return m, m.imageRepaint(reload, toast)
 	}
 
 	if m.help {
@@ -536,6 +553,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.beginSearch()
 	case "L":
 		return m, m.beginListPicker()
+	case "@":
+		return m, cycleAccountCmd()
 	case "R", "ctrl+r":
 		c := m.cur()
 		if len(c.posts) == 0 {
@@ -761,21 +780,40 @@ func (m Model) columnsLoading() bool {
 // setFeed resets feed state and kicks off a fresh first page for kind.
 func (m *Model) setFeed(kind FeedKind) tea.Cmd {
 	c := m.cur()
+	fetch := m.resetColumnFeed(c, kind)
+	m.syncViewport()
+	return m.imageRepaint(tea.Batch(m.spinner.Tick, fetch))
+}
+
+func (m *Model) resetColumnFeed(c *column, kind FeedKind) tea.Cmd {
 	c.feed = kind
 	c.feedSeq++
 	c.posts = nil
 	c.cursor = ""
 	c.selected = 0
+	c.starts = nil
+	c.ends = nil
 	c.expanded = false
 	c.loading = true
 	c.loadingMore = false
 	c.refreshing = false
 	c.err = nil
 	c.viewport.YOffset = 0
-	m.syncViewport()
-	return m.imageRepaint(tea.Batch(m.spinner.Tick, fetchPageSeq(
+	c.viewport.SetContent("")
+	return fetchPageSeq(
 		m.requestContext(), c.feed, c.searchQuery, c.listID, "", false, c.feedSeq, c.id,
-	)))
+	)
+}
+
+func (m *Model) resetEveryColumnFeed() tea.Cmd {
+	cmds := make([]tea.Cmd, 0, len(m.columns)+1)
+	cmds = append(cmds, m.spinner.Tick)
+	for i := range m.columns {
+		c := &m.columns[i]
+		cmds = append(cmds, m.resetColumnFeed(c, c.feed))
+	}
+	m.resize()
+	return tea.Batch(cmds...)
 }
 
 // switchFeed keeps the f-key semantics: toggle For You <-> Following.

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -58,6 +58,7 @@ const (
 	FeedBookmarks
 	FeedSearch
 	FeedList
+	FeedNotifications
 )
 
 type ColumnSpec struct {
@@ -370,6 +371,8 @@ func fetchPageSeq(parent context.Context, feed FeedKind, query, listID, accountI
 			fetch = client.FetchFollowingTimeline
 		case FeedBookmarks:
 			fetch = client.FetchBookmarks
+		case FeedNotifications:
+			fetch = client.FetchNotificationsTimeline
 		case FeedSearch:
 			q := query
 			fetch = func(ctx context.Context, cursor string, count int) (*api.TimelinePage, error) {

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -246,17 +246,28 @@ func (m Model) Init() tea.Cmd {
 	if m.feed == FeedSearch && m.searchQuery == "" {
 		return tea.Batch(m.searchInput.Focus(), clockTick())
 	}
+	if m.mode == modeListPicker {
+		return tea.Batch(m.spinner.Tick, fetchListsCmd(m.requestContext()), clockTick())
+	}
 	return tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.feed, m.searchQuery, m.listID, "", false, m.feedSeq), clockTick())
 }
 
-func Run(ctx context.Context, images string, feed FeedKind, query string) (Action, error) {
+func Run(ctx context.Context, images string, feed FeedKind, query, listID string) (Action, error) {
 	m := NewWithImageMode(images)
 	m.ctx = ctx
 	m.feed = feed
 	m.searchQuery = query
+	m.listID = listID
 	if feed == FeedSearch && query == "" {
 		m.loading = false
 		m.beginSearch()
+	}
+	if feed == FeedList {
+		m.listName = listID
+		if listID == "" {
+			m.loading = false
+			m.beginListPicker()
+		}
 	}
 	// Auto-detected native mode is a claim, not a capability: multiplexers
 	// like cmux inherit ghostty's TERM without reliably rendering graphics.

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -104,6 +104,9 @@ type Model struct {
 	focus     int
 	nextColID int
 	accounts  []config.AccountInfo
+	// pollInterval is the auto-refresh period for the focused column.
+	// Zero keeps the timeline manual-only (R), which is the default.
+	pollInterval time.Duration
 
 	mode              mode
 	replyReturn       mode
@@ -130,6 +133,7 @@ type pageMsg struct {
 	page  *api.TimelinePage
 	err   error
 	more  bool
+	auto  bool
 	seq   int
 	colID int
 }
@@ -172,6 +176,15 @@ type clockTickMsg time.Time
 
 func clockTick() tea.Cmd {
 	return tea.Tick(30*time.Second, func(t time.Time) tea.Msg { return clockTickMsg(t) })
+}
+
+type pollTickMsg struct{}
+
+func (m Model) pollTick() tea.Cmd {
+	if m.pollInterval <= 0 {
+		return nil
+	}
+	return tea.Tick(m.pollInterval, func(time.Time) tea.Msg { return pollTickMsg{} })
 }
 
 func (m *Model) showToast(text string) tea.Cmd {
@@ -244,7 +257,7 @@ func (m Model) requestContext() context.Context {
 func (m Model) Init() tea.Cmd {
 	c := m.cur()
 	if c.feed == FeedSearch && c.searchQuery == "" {
-		return tea.Batch(m.searchInput.Focus(), loadAccountsCmd(), clockTick())
+		return tea.Batch(m.searchInput.Focus(), loadAccountsCmd(), clockTick(), m.pollTick())
 	}
 	if m.mode == modeListPicker {
 		return tea.Batch(
@@ -252,13 +265,14 @@ func (m Model) Init() tea.Cmd {
 			fetchListsCmd(m.requestContext(), c.accountID, true),
 			loadAccountsCmd(),
 			clockTick(),
+			m.pollTick(),
 		)
 	}
 	cmds := []tea.Cmd{m.spinner.Tick, loadAccountsCmd()}
 	for i := range m.columns {
 		c := &m.columns[i]
 		cmds = append(cmds, fetchPageSeq(
-			m.requestContext(), c.feed, c.searchQuery, c.listID, c.accountID, "", false, c.feedSeq, c.id,
+			m.requestContext(), c.feed, c.searchQuery, c.listID, c.accountID, "", false, c.feedSeq, c.id, false,
 		))
 	}
 	// List names are account-scoped, so one global enumeration could label a
@@ -274,13 +288,14 @@ func (m Model) Init() tea.Cmd {
 			cmds = append(cmds, fetchListsCmd(m.requestContext(), c.accountID, false))
 		}
 	}
-	cmds = append(cmds, clockTick())
+	cmds = append(cmds, clockTick(), m.pollTick())
 	return tea.Batch(cmds...)
 }
 
-func Run(ctx context.Context, images string, specs []ColumnSpec) (Action, error) {
+func Run(ctx context.Context, images string, specs []ColumnSpec, pollInterval time.Duration) (Action, error) {
 	m := NewWithImageMode(images)
 	m.ctx = ctx
+	m.pollInterval = pollInterval
 	m.configureColumns(specs)
 	if len(specs) == 1 && specs[0].Kind == FeedSearch && specs[0].Query == "" {
 		m.cur().loading = false
@@ -336,15 +351,15 @@ func loadRequestConfig(mgr requestConfigManager, accountID string) (*config.Conf
 	return mgr.LoadAccount(accountID)
 }
 
-func fetchPageSeq(parent context.Context, feed FeedKind, query, listID, accountID, cursor string, more bool, seq, colID int) tea.Cmd {
+func fetchPageSeq(parent context.Context, feed FeedKind, query, listID, accountID, cursor string, more bool, seq, colID int, auto bool) tea.Cmd {
 	return func() tea.Msg {
 		mgr, err := openRequestConfigManager()
 		if err != nil {
-			return pageMsg{err: err, more: more, seq: seq, colID: colID}
+			return pageMsg{err: err, more: more, auto: auto, seq: seq, colID: colID}
 		}
 		cfg, err := loadRequestConfig(mgr, accountID)
 		if err != nil {
-			return pageMsg{err: err, more: more, seq: seq, colID: colID}
+			return pageMsg{err: err, more: more, auto: auto, seq: seq, colID: colID}
 		}
 		ctx, cancel := context.WithTimeout(parent, 40*time.Second)
 		defer cancel()
@@ -370,7 +385,7 @@ func fetchPageSeq(parent context.Context, feed FeedKind, query, listID, accountI
 		if client.ApplyRefreshedQueryIDs(cfg) {
 			_ = mgr.SaveQueryIDs(cfg)
 		}
-		return pageMsg{page: page, err: err, more: more, seq: seq, colID: colID}
+		return pageMsg{page: page, err: err, more: more, auto: auto, seq: seq, colID: colID}
 	}
 }
 
@@ -406,6 +421,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.syncViewport()
 		}
 		return m, clockTick()
+	}
+	if _, ok := msg.(pollTickMsg); ok {
+		// The tick always reschedules, even when this round skips the fetch.
+		return m, tea.Batch(m.autoRefresh(), m.pollTick())
 	}
 	if _, ok := msg.(wezRepaintMsg); ok {
 		if m.imageMode != imageModeWezTerm {
@@ -615,16 +634,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.beginChoicePicker("theme", m.themeItems(), intentTheme)
 		return m, m.imageRepaint()
 	case "R", "ctrl+r":
-		c := m.cur()
-		if len(c.posts) == 0 {
-			c.loading = true
-		} else {
-			c.refreshing = true
-		}
-		c.err = nil
-		return m, m.imageRepaint(tea.Batch(m.spinner.Tick, fetchPageSeq(
-			m.requestContext(), c.feed, c.searchQuery, c.listID, c.accountID, "", false, c.feedSeq, c.id,
-		)))
+		return m, m.refreshCurrentColumn(false)
 	case "r":
 		if post, ok := m.currentPost(); ok {
 			return m.beginReply(post)
@@ -871,7 +881,7 @@ func (m *Model) resetColumnFeed(c *column, kind FeedKind) tea.Cmd {
 	c.viewport.YOffset = 0
 	c.viewport.SetContent("")
 	return fetchPageSeq(
-		m.requestContext(), c.feed, c.searchQuery, c.listID, c.accountID, "", false, c.feedSeq, c.id,
+		m.requestContext(), c.feed, c.searchQuery, c.listID, c.accountID, "", false, c.feedSeq, c.id, false,
 	)
 }
 
@@ -895,12 +905,41 @@ func (m *Model) switchFeed() tea.Cmd {
 	return m.setFeed(FeedForYou)
 }
 
+// refreshCurrentColumn re-fetches the focused column's first page. auto marks
+// poll-driven refreshes so applyFeedPage can stay quiet when nothing changed.
+func (m *Model) refreshCurrentColumn(auto bool) tea.Cmd {
+	c := m.cur()
+	if len(c.posts) == 0 {
+		c.loading = true
+	} else {
+		c.refreshing = true
+	}
+	c.err = nil
+	return m.imageRepaint(tea.Batch(m.spinner.Tick, fetchPageSeq(
+		m.requestContext(), c.feed, c.searchQuery, c.listID, c.accountID, "", false, c.feedSeq, c.id, auto,
+	)))
+}
+
+// autoRefresh polls the focused column only, and only while the feed view is
+// usable. A column holding an error is left alone: with an expired session
+// every tick would re-fail against X, so recovery stays a manual R.
+func (m *Model) autoRefresh() tea.Cmd {
+	if m.mode != modeFeed || m.help {
+		return nil
+	}
+	c := m.cur()
+	if c.loading || c.loadingMore || c.refreshing || c.err != nil {
+		return nil
+	}
+	return m.refreshCurrentColumn(true)
+}
+
 func (m *Model) maybeLoadMore() tea.Cmd {
 	c := m.cur()
 	if len(c.posts) > 0 && c.selected >= len(c.posts)-5 && c.cursor != "" && !c.loadingMore {
 		c.loadingMore = true
 		return tea.Batch(m.spinner.Tick, fetchPageSeq(
-			m.requestContext(), c.feed, c.searchQuery, c.listID, c.accountID, c.cursor, true, c.feedSeq, c.id,
+			m.requestContext(), c.feed, c.searchQuery, c.listID, c.accountID, c.cursor, true, c.feedSeq, c.id, false,
 		))
 	}
 	return nil
@@ -954,7 +993,9 @@ func (m Model) applyFeedPage(msg pageMsg) (tea.Model, tea.Cmd) {
 				label = "post"
 			}
 			toast = m.showToast(fmt.Sprintf("%d new %s · g jumps to top", len(fresh), label))
-		} else {
+		} else if !msg.auto {
+			// Polls fire every interval, so only a manual R earns the
+			// "all caught up" confirmation; auto refreshes stay silent.
 			toast = m.showToast("all caught up")
 		}
 	} else {

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -27,6 +27,7 @@ var (
 	muted    lipgloss.Color
 	red      lipgloss.Color
 	yellow   lipgloss.Color
+	green    lipgloss.Color
 	bright   lipgloss.Color
 	dim      lipgloss.Color
 )
@@ -36,7 +37,7 @@ func init() { ApplyTheme(theme.Default()) }
 // ApplyTheme recolors the timeline. Call it before Run; layout is unaffected.
 func ApplyTheme(p theme.Palette) {
 	blue, lavender, pink, muted = p.Blue, p.Lavender, p.Pink, p.Muted
-	red, yellow, bright, dim = p.Red, p.Yellow, p.Bright, p.Dim
+	red, yellow, green, bright, dim = p.Red, p.Yellow, p.Green, p.Bright, p.Dim
 }
 
 type ActionKind int
@@ -96,6 +97,7 @@ type Model struct {
 	toast         string
 	toastSeq      int
 	liking        map[string]bool
+	reposting     map[string]bool
 	// previews is shared by post ID rather than duplicated per column because
 	// every feed column has the same width. Unequal panes would need a
 	// per-column cache to avoid alternating width-based refetches.
@@ -148,6 +150,13 @@ type likeMsg struct {
 	id        string
 	accountID string
 	liked     bool
+	err       error
+}
+
+type retweetMsg struct {
+	id        string
+	accountID string
+	reposted  bool
 	err       error
 }
 
@@ -240,7 +249,7 @@ func NewWithImageMode(requested string) Model {
 	return Model{
 		ctx:   context.Background(),
 		width: 80, height: 24, imageMode: mode, imageNote: note,
-		liking: map[string]bool{}, previews: map[string]previewState{},
+		liking: map[string]bool{}, reposting: map[string]bool{}, previews: map[string]previewState{},
 		spinner: s, columns: []column{newColumn(0)},
 		nextColID: 1, replyEditor: editor, searchInput: search,
 	}
@@ -413,6 +422,27 @@ func setLike(parent context.Context, selectedAccountID, actingAccountID, tweetID
 	}
 }
 
+func setRetweet(parent context.Context, selectedAccountID, actingAccountID, tweetID string, reposted bool) tea.Cmd {
+	return func() tea.Msg {
+		mgr, err := openRequestConfigManager()
+		if err != nil {
+			return retweetMsg{id: tweetID, accountID: actingAccountID, reposted: reposted, err: err}
+		}
+		cfg, err := loadRequestConfig(mgr, selectedAccountID)
+		if err != nil {
+			return retweetMsg{id: tweetID, accountID: actingAccountID, reposted: reposted, err: err}
+		}
+		ctx, cancel := context.WithTimeout(parent, 30*time.Second)
+		defer cancel()
+		client := api.NewWebClient(cfg)
+		err = client.SetTweetReposted(ctx, tweetID, reposted)
+		if client.ApplyRefreshedQueryIDs(cfg) {
+			_ = mgr.SaveQueryIDs(cfg)
+		}
+		return retweetMsg{id: tweetID, accountID: actingAccountID, reposted: reposted, err: err}
+	}
+}
+
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if size, ok := msg.(tea.WindowSizeMsg); ok {
 		m.width, m.height = size.Width, size.Height
@@ -557,6 +587,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.applyPreview(msg)
 	case likeMsg:
 		return m, m.applyLikeResult(msg)
+	case retweetMsg:
+		return m, m.applyRepostResult(msg)
 	case listsMsg:
 		// Outside the picker this only ever arrives from Init's backfill, and a
 		// failure just leaves the ids on screen — the feeds themselves loaded.
@@ -680,6 +712,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.zoomSelected()
 	case "l":
 		return m, m.toggleSelectedLike()
+	case "t":
+		return m, m.toggleSelectedRepost()
 	case "y":
 		return m, m.copySelectedLink()
 	}
@@ -707,6 +741,30 @@ func (m *Model) applyLikeResult(msg likeMsg) tea.Cmd {
 		toast = "couldn't update like"
 	case msg.liked:
 		toast = "liked ♥"
+	}
+	cmd := m.showToast(toast)
+	m.syncViewport()
+	m.ensureSelectedVisible()
+	return cmd
+}
+
+// settleRepost clears the in-flight marker and rolls an optimistic repost back
+// if the request failed.
+func (m *Model) settleRepost(msg retweetMsg) {
+	delete(m.reposting, likeKey(msg.accountID, msg.id))
+	if msg.err != nil {
+		m.applyRepost(msg.accountID, msg.id, !msg.reposted)
+	}
+}
+
+func (m *Model) applyRepostResult(msg retweetMsg) tea.Cmd {
+	m.settleRepost(msg)
+	toast := "repost removed"
+	switch {
+	case msg.err != nil:
+		toast = "couldn't update repost"
+	case msg.reposted:
+		toast = "reposted ⟳"
 	}
 	cmd := m.showToast(toast)
 	m.syncViewport()
@@ -808,6 +866,25 @@ func (m *Model) toggleSelectedLike() tea.Cmd {
 	m.syncViewport()
 	m.ensureSelectedVisible()
 	return setLike(m.requestContext(), c.accountID, accountID, post.ID, liked)
+}
+
+func (m *Model) toggleSelectedRepost() tea.Cmd {
+	post, ok := m.currentPost()
+	if !ok {
+		return nil
+	}
+	c := m.cur()
+	accountID := m.columnAccountID(c)
+	key := likeKey(accountID, post.ID)
+	if m.reposting[key] {
+		return nil
+	}
+	reposted := !post.Reposted
+	m.reposting[key] = true
+	m.applyRepost(accountID, post.ID, reposted)
+	m.syncViewport()
+	m.ensureSelectedVisible()
+	return setRetweet(m.requestContext(), c.accountID, accountID, post.ID, reposted)
 }
 
 func (m *Model) copySelectedLink() tea.Cmd {
@@ -1198,6 +1275,32 @@ func (m *Model) applyLike(accountID, id string, liked bool) {
 			post.LikeCount++
 		} else if post.LikeCount > 0 {
 			post.LikeCount--
+		}
+	}
+	for columnIndex := range m.columns {
+		c := &m.columns[columnIndex]
+		if m.columnAccountID(c) != accountID {
+			continue
+		}
+		for i := range c.posts {
+			apply(&c.posts[i])
+		}
+		for i := range c.threadPosts {
+			apply(&c.threadPosts[i].TimelinePost)
+		}
+	}
+}
+
+func (m *Model) applyRepost(accountID, id string, reposted bool) {
+	apply := func(post *api.TimelinePost) {
+		if post.ID != id || post.Reposted == reposted {
+			return
+		}
+		post.Reposted = reposted
+		if reposted {
+			post.RepostCount++
+		} else if post.RepostCount > 0 {
+			post.RepostCount--
 		}
 	}
 	for columnIndex := range m.columns {

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -101,6 +101,7 @@ type Model struct {
 	toastSeq      int
 	liking        map[string]bool
 	reposting     map[string]bool
+	bookmarking   map[string]bool
 	// previews is shared by post ID rather than duplicated per column because
 	// every feed column has the same width. Unequal panes would need a
 	// per-column cache to avoid alternating width-based refetches.
@@ -161,6 +162,13 @@ type retweetMsg struct {
 	accountID string
 	reposted  bool
 	err       error
+}
+
+type bookmarkMsg struct {
+	id         string
+	accountID  string
+	bookmarked bool
+	err        error
 }
 
 type replyResultMsg struct {
@@ -252,7 +260,7 @@ func NewWithImageMode(requested string) Model {
 	return Model{
 		ctx:   context.Background(),
 		width: 80, height: 24, imageMode: mode, imageNote: note,
-		liking: map[string]bool{}, reposting: map[string]bool{}, previews: map[string]previewState{},
+		liking: map[string]bool{}, reposting: map[string]bool{}, bookmarking: map[string]bool{}, previews: map[string]previewState{},
 		spinner: s, columns: []column{newColumn(0)},
 		nextColID: 1, replyEditor: editor, searchInput: search,
 	}
@@ -451,6 +459,27 @@ func setRetweet(parent context.Context, selectedAccountID, actingAccountID, twee
 	}
 }
 
+func setBookmark(parent context.Context, selectedAccountID, actingAccountID, tweetID string, bookmarked bool) tea.Cmd {
+	return func() tea.Msg {
+		mgr, err := openRequestConfigManager()
+		if err != nil {
+			return bookmarkMsg{id: tweetID, accountID: actingAccountID, bookmarked: bookmarked, err: err}
+		}
+		cfg, err := loadRequestConfig(mgr, selectedAccountID)
+		if err != nil {
+			return bookmarkMsg{id: tweetID, accountID: actingAccountID, bookmarked: bookmarked, err: err}
+		}
+		ctx, cancel := context.WithTimeout(parent, 30*time.Second)
+		defer cancel()
+		client := api.NewWebClient(cfg)
+		err = client.SetTweetBookmarked(ctx, tweetID, bookmarked)
+		if client.ApplyRefreshedQueryIDs(cfg) {
+			_ = mgr.SaveQueryIDs(cfg)
+		}
+		return bookmarkMsg{id: tweetID, accountID: actingAccountID, bookmarked: bookmarked, err: err}
+	}
+}
+
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if size, ok := msg.(tea.WindowSizeMsg); ok {
 		m.width, m.height = size.Width, size.Height
@@ -597,6 +626,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.applyLikeResult(msg)
 	case retweetMsg:
 		return m, m.applyRepostResult(msg)
+	case bookmarkMsg:
+		return m, m.applyBookmarkResult(msg)
 	case profileMsg:
 		return m, m.applyProfileResult(msg)
 	case listsMsg:
@@ -732,6 +763,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.toggleSelectedLike()
 	case "t":
 		return m, m.toggleSelectedRepost()
+	case "B":
+		return m, m.toggleSelectedBookmark()
 	case "y":
 		return m, m.copySelectedLink()
 	}
@@ -783,6 +816,30 @@ func (m *Model) applyRepostResult(msg retweetMsg) tea.Cmd {
 		toast = "couldn't update repost"
 	case msg.reposted:
 		toast = "reposted ⟳"
+	}
+	cmd := m.showToast(toast)
+	m.syncViewport()
+	m.ensureSelectedVisible()
+	return cmd
+}
+
+// settleBookmark clears the in-flight marker and rolls an optimistic bookmark
+// back if the request failed.
+func (m *Model) settleBookmark(msg bookmarkMsg) {
+	delete(m.bookmarking, likeKey(msg.accountID, msg.id))
+	if msg.err != nil {
+		m.applyBookmark(msg.accountID, msg.id, !msg.bookmarked)
+	}
+}
+
+func (m *Model) applyBookmarkResult(msg bookmarkMsg) tea.Cmd {
+	m.settleBookmark(msg)
+	toast := "bookmark removed"
+	switch {
+	case msg.err != nil:
+		toast = "couldn't update bookmark"
+	case msg.bookmarked:
+		toast = "bookmarked 🔖"
 	}
 	cmd := m.showToast(toast)
 	m.syncViewport()
@@ -903,6 +960,25 @@ func (m *Model) toggleSelectedRepost() tea.Cmd {
 	m.syncViewport()
 	m.ensureSelectedVisible()
 	return setRetweet(m.requestContext(), c.accountID, accountID, post.ID, reposted)
+}
+
+func (m *Model) toggleSelectedBookmark() tea.Cmd {
+	post, ok := m.currentPost()
+	if !ok {
+		return nil
+	}
+	c := m.cur()
+	accountID := m.columnAccountID(c)
+	key := likeKey(accountID, post.ID)
+	if m.bookmarking[key] {
+		return nil
+	}
+	bookmarked := !post.Bookmarked
+	m.bookmarking[key] = true
+	m.applyBookmark(accountID, post.ID, bookmarked)
+	m.syncViewport()
+	m.ensureSelectedVisible()
+	return setBookmark(m.requestContext(), c.accountID, accountID, post.ID, bookmarked)
 }
 
 func (m *Model) copySelectedLink() tea.Cmd {
@@ -1330,6 +1406,29 @@ func (m *Model) applyRepost(accountID, id string, reposted bool) {
 		} else if post.RepostCount > 0 {
 			post.RepostCount--
 		}
+	}
+	for columnIndex := range m.columns {
+		c := &m.columns[columnIndex]
+		if m.columnAccountID(c) != accountID {
+			continue
+		}
+		for i := range c.posts {
+			apply(&c.posts[i])
+		}
+		for i := range c.threadPosts {
+			apply(&c.threadPosts[i].TimelinePost)
+		}
+	}
+}
+
+// applyBookmark mirrors applyRepost minus the counter: X keeps bookmark
+// counts private, so only the flag flips.
+func (m *Model) applyBookmark(accountID, id string, bookmarked bool) {
+	apply := func(post *api.TimelinePost) {
+		if post.ID != id || post.Bookmarked == bookmarked {
+			return
+		}
+		post.Bookmarked = bookmarked
 	}
 	for columnIndex := range m.columns {
 		c := &m.columns[columnIndex]

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -16,7 +16,6 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textarea"
 	"github.com/charmbracelet/bubbles/textinput"
-	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
@@ -194,7 +193,6 @@ func New() Model {
 func NewWithImageMode(requested string) Model {
 	s := spinner.New()
 	s.Spinner = spinner.Dot
-	vp := viewport.New(72, 18)
 	editor := textarea.New()
 	editor.Prompt = ""
 	editor.Placeholder = "write your reply…"
@@ -210,7 +208,7 @@ func NewWithImageMode(requested string) Model {
 		ctx:   context.Background(),
 		width: 80, height: 24, imageMode: mode, imageNote: note,
 		liking: map[string]bool{}, previews: map[string]previewState{},
-		spinner: s, columns: []column{{id: 0, loading: true, viewport: vp}},
+		spinner: s, columns: []column{newColumn(0)},
 		nextColID: 1, replyEditor: editor, searchInput: search,
 	}
 }
@@ -232,21 +230,26 @@ func (m Model) Init() tea.Cmd {
 	if m.mode == modeListPicker {
 		return tea.Batch(m.spinner.Tick, fetchListsCmd(m.requestContext()), clockTick())
 	}
-	return tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), c.feed, c.searchQuery, c.listID, "", false, c.feedSeq, c.id), clockTick())
+	cmds := []tea.Cmd{m.spinner.Tick}
+	for i := range m.columns {
+		c := &m.columns[i]
+		cmds = append(cmds, fetchPageSeq(
+			m.requestContext(), c.feed, c.searchQuery, c.listID, "", false, c.feedSeq, c.id,
+		))
+	}
+	cmds = append(cmds, clockTick())
+	return tea.Batch(cmds...)
 }
 
-func Run(ctx context.Context, images string, feed FeedKind, query, listID string) (Action, error) {
+func Run(ctx context.Context, images string, feed FeedKind, query, listID string, columnCount int) (Action, error) {
 	m := NewWithImageMode(images)
 	m.ctx = ctx
-	m.cur().feed = feed
-	m.cur().searchQuery = query
-	m.cur().listID = listID
+	m.configureColumns(columnCount, feed, query, listID)
 	if feed == FeedSearch && query == "" {
 		m.cur().loading = false
 		m.beginSearch()
 	}
 	if feed == FeedList {
-		m.cur().listName = listID
 		if listID == "" {
 			m.cur().loading = false
 			m.beginListPicker()
@@ -440,7 +443,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case spinner.TickMsg:
-		if m.cur().loading || m.cur().loadingMore || m.cur().refreshing || m.zoomLoading() {
+		if m.columnsLoading() || m.zoomLoading() {
 			var cmd tea.Cmd
 			m.spinner, cmd = m.spinner.Update(msg)
 			return m, cmd
@@ -463,6 +466,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	switch key.String() {
+	case "tab", "]":
+		m.cycleFocus(1)
+		return m, m.imageRepaint()
+	case "shift+tab", "[":
+		m.cycleFocus(-1)
+		return m, m.imageRepaint()
 	case "q", "ctrl+c":
 		return m, tea.Quit
 	case "esc":
@@ -697,6 +706,24 @@ func (m *Model) moveSelection(target int) {
 	m.ensureSelectedVisible()
 }
 
+func (m *Model) cycleFocus(delta int) {
+	if len(m.columns) <= 1 {
+		return
+	}
+	m.focus = (m.focus + delta + len(m.columns)) % len(m.columns)
+	m.resize()
+}
+
+func (m Model) columnsLoading() bool {
+	for i := range m.columns {
+		c := &m.columns[i]
+		if c.loading || c.loadingMore || c.refreshing {
+			return true
+		}
+	}
+	return false
+}
+
 // setFeed resets feed state and kicks off a fresh first page for kind.
 func (m *Model) setFeed(kind FeedKind) tea.Cmd {
 	c := m.cur()
@@ -807,6 +834,15 @@ func (m Model) applyFeedPage(msg pageMsg) (tea.Model, tea.Cmd) {
 	} else {
 		c.selected = feedIndex
 	}
+	if !focused {
+		first, count := m.visibleColumnRange()
+		for index := first; index < first+count; index++ {
+			if &m.columns[index] == c {
+				m.syncFeedColumn(c, columnContentWidth(m.width, count), false)
+				break
+			}
+		}
+	}
 	if !focused || m.mode == modeReply {
 		return m, toast
 	}
@@ -853,32 +889,51 @@ func (m Model) imageFrameKey() string {
 }
 
 func (m *Model) resize() {
-	w := m.contentWidth()
 	viewportHeight := m.height - 4
 	if viewportHeight < 1 {
 		viewportHeight = 1
 	}
-	m.cur().viewport.Width = w
-	m.cur().viewport.Height = viewportHeight
-	m.replyEditor.SetWidth(max(20, w-6))
+	if m.mode == modeThread {
+		m.cur().viewport.Width = columnContentWidth(m.width, 1)
+		m.cur().viewport.Height = viewportHeight
+		m.syncViewport()
+	} else {
+		first, count := m.visibleColumnRange()
+		width := columnContentWidth(m.width, count)
+		for index := first; index < first+count; index++ {
+			c := &m.columns[index]
+			c.viewport.Width = width
+			c.viewport.Height = viewportHeight
+			m.syncFeedColumn(c, width, index == m.focus)
+		}
+	}
+	overlayWidth := columnContentWidth(m.width, 1)
+	m.replyEditor.SetWidth(max(20, overlayWidth-6))
 	m.replyEditor.SetHeight(min(7, max(3, m.height-16)))
-	m.searchInput.Width = max(10, w-16)
+	m.searchInput.Width = max(10, overlayWidth-16)
 	m.searchInput.SetCursor(m.searchInput.Position())
-	m.syncViewport()
 	m.ensureSelectedVisible()
 }
 
 func (m *Model) syncViewport() {
-	var content string
-	var starts, ends []int
 	if m.mode == modeThread {
-		content, starts, ends = m.renderThreadContent()
-	} else {
-		content, starts, ends = m.renderFeedContent()
+		m.cur().viewport.Width = columnContentWidth(m.width, 1)
+		content, starts, ends := m.renderThreadContent()
+		m.cur().starts = starts
+		m.cur().ends = ends
+		m.cur().viewport.SetContent(content)
+		return
 	}
-	m.cur().starts = starts
-	m.cur().ends = ends
-	m.cur().viewport.SetContent(content)
+	width := m.visibleColumnWidth()
+	m.cur().viewport.Width = width
+	m.syncFeedColumn(m.cur(), width, true)
+}
+
+func (m *Model) syncFeedColumn(c *column, width int, focused bool) {
+	content, starts, ends := m.renderFeedColumnContent(c, width, focused)
+	c.starts = starts
+	c.ends = ends
+	c.viewport.SetContent(content)
 }
 
 func (m *Model) ensureSelectedVisible() {

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -328,7 +328,7 @@ func fetchPageSeq(parent context.Context, feed FeedKind, query, listID, cursor s
 		}
 		page, err := fetch(ctx, cursor, 30)
 		if client.ApplyRefreshedQueryIDs(cfg) {
-			_ = mgr.Save(cfg)
+			_ = mgr.SaveQueryIDs(cfg)
 		}
 		return pageMsg{page: page, err: err, more: more, seq: seq, colID: colID}
 	}
@@ -349,7 +349,7 @@ func setLike(parent context.Context, tweetID string, liked bool) tea.Cmd {
 		client := api.NewWebClient(cfg)
 		err = client.SetTweetLiked(ctx, tweetID, liked)
 		if client.ApplyRefreshedQueryIDs(cfg) {
-			_ = mgr.Save(cfg)
+			_ = mgr.SaveQueryIDs(cfg)
 		}
 		return likeMsg{id: tweetID, liked: liked, err: err}
 	}

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -75,6 +75,7 @@ const (
 	modeFeed mode = iota
 	modeThread
 	modeReply
+	modeQuote
 	modeSearch
 	modeListPicker
 	modeChoicePicker
@@ -557,7 +558,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 	switch m.mode {
-	case modeReply:
+	case modeReply, modeQuote:
 		return m.updateReply(msg)
 	case modeSearch:
 		return m.updateSearch(msg)
@@ -673,6 +674,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case "r":
 		if post, ok := m.currentPost(); ok {
 			return m.beginReply(post)
+		}
+	case "Q":
+		if post, ok := m.currentPost(); ok {
+			return m.beginQuote(post)
 		}
 	case "a":
 		if errors.Is(m.cur().err, api.ErrSessionExpired) {
@@ -1042,7 +1047,7 @@ func (m Model) applyFeedPage(msg pageMsg) (tea.Model, tea.Cmd) {
 	c.err = nil
 	focused := c == m.cur()
 	threadContext := focused && (m.mode == modeThread ||
-		(m.mode == modeReply && m.replyReturn == modeThread) ||
+		((m.mode == modeReply || m.mode == modeQuote) && m.replyReturn == modeThread) ||
 		(m.mode == modeSearch && m.searchReturn == modeThread) ||
 		(m.mode == modeListPicker && m.listReturn == modeThread))
 	feedIndex := c.selected
@@ -1106,7 +1111,7 @@ func (m Model) applyFeedPage(msg pageMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 	}
-	if !focused || m.mode == modeReply {
+	if !focused || m.mode == modeReply || m.mode == modeQuote {
 		if !focused && m.mode == modeFeed {
 			return m, m.imageRepaint(m.requestPreviews(), toast)
 		}

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -60,13 +60,15 @@ const (
 	FeedSearch
 	FeedList
 	FeedNotifications
+	FeedProfile
 )
 
 type ColumnSpec struct {
-	Kind      FeedKind
-	AccountID string
-	Query     string
-	ListID    string
+	Kind          FeedKind
+	AccountID     string
+	Query         string
+	ListID        string
+	ProfileHandle string
 }
 
 type mode int
@@ -283,7 +285,7 @@ func (m Model) Init() tea.Cmd {
 	for i := range m.columns {
 		c := &m.columns[i]
 		cmds = append(cmds, fetchPageSeq(
-			m.requestContext(), c.feed, c.searchQuery, c.listID, c.accountID, "", false, c.feedSeq, c.id, false,
+			m.requestContext(), c.feed, c.searchQuery, c.listID, c.profileUserID, c.accountID, "", false, c.feedSeq, c.id, false,
 		))
 	}
 	// List names are account-scoped, so one global enumeration could label a
@@ -362,7 +364,7 @@ func loadRequestConfig(mgr requestConfigManager, accountID string) (*config.Conf
 	return mgr.LoadAccount(accountID)
 }
 
-func fetchPageSeq(parent context.Context, feed FeedKind, query, listID, accountID, cursor string, more bool, seq, colID int, auto bool) tea.Cmd {
+func fetchPageSeq(parent context.Context, feed FeedKind, query, listID, profileUserID, accountID, cursor string, more bool, seq, colID int, auto bool) tea.Cmd {
 	return func() tea.Msg {
 		mgr, err := openRequestConfigManager()
 		if err != nil {
@@ -392,6 +394,11 @@ func fetchPageSeq(parent context.Context, feed FeedKind, query, listID, accountI
 			id := listID
 			fetch = func(ctx context.Context, cursor string, count int) (*api.TimelinePage, error) {
 				return client.FetchListTimeline(ctx, id, cursor, count)
+			}
+		case FeedProfile:
+			uid := profileUserID
+			fetch = func(ctx context.Context, cursor string, count int) (*api.TimelinePage, error) {
+				return client.FetchUserTweets(ctx, uid, cursor, count)
 			}
 		}
 		page, err := fetch(ctx, cursor, 30)
@@ -590,6 +597,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.applyLikeResult(msg)
 	case retweetMsg:
 		return m, m.applyRepostResult(msg)
+	case profileMsg:
+		return m, m.applyProfileResult(msg)
 	case listsMsg:
 		// Outside the picker this only ever arrives from Init's backfill, and a
 		// failure just leaves the ids on screen — the feeds themselves loaded.
@@ -678,6 +687,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case "Q":
 		if post, ok := m.currentPost(); ok {
 			return m.beginQuote(post)
+		}
+	case "u":
+		if post, ok := m.currentPost(); ok {
+			return m.beginProfile(post)
 		}
 	case "a":
 		if errors.Is(m.cur().err, api.ErrSessionExpired) {
@@ -966,7 +979,7 @@ func (m *Model) resetColumnFeed(c *column, kind FeedKind) tea.Cmd {
 	c.viewport.YOffset = 0
 	c.viewport.SetContent("")
 	return fetchPageSeq(
-		m.requestContext(), c.feed, c.searchQuery, c.listID, c.accountID, "", false, c.feedSeq, c.id, false,
+		m.requestContext(), c.feed, c.searchQuery, c.listID, c.profileUserID, c.accountID, "", false, c.feedSeq, c.id, false,
 	)
 }
 
@@ -994,6 +1007,16 @@ func (m *Model) switchFeed() tea.Cmd {
 // poll-driven refreshes so applyFeedPage can stay quiet when nothing changed.
 func (m *Model) refreshCurrentColumn(auto bool) tea.Cmd {
 	c := m.cur()
+	// A profile column whose resolution failed has nothing to fetch yet;
+	// retry the handle→id hop instead of replaying the empty id.
+	if c.feed == FeedProfile && c.profileUserID == "" {
+		c.loading = true
+		c.refreshing = false
+		c.err = nil
+		return m.imageRepaint(tea.Batch(m.spinner.Tick, resolveProfile(
+			m.requestContext(), c.id, c.accountID, c.profileHandle,
+		)))
+	}
 	if len(c.posts) == 0 {
 		c.loading = true
 	} else {
@@ -1001,7 +1024,7 @@ func (m *Model) refreshCurrentColumn(auto bool) tea.Cmd {
 	}
 	c.err = nil
 	return m.imageRepaint(tea.Batch(m.spinner.Tick, fetchPageSeq(
-		m.requestContext(), c.feed, c.searchQuery, c.listID, c.accountID, "", false, c.feedSeq, c.id, auto,
+		m.requestContext(), c.feed, c.searchQuery, c.listID, c.profileUserID, c.accountID, "", false, c.feedSeq, c.id, auto,
 	)))
 }
 
@@ -1024,7 +1047,7 @@ func (m *Model) maybeLoadMore() tea.Cmd {
 	if len(c.posts) > 0 && c.selected >= len(c.posts)-5 && c.cursor != "" && !c.loadingMore {
 		c.loadingMore = true
 		return tea.Batch(m.spinner.Tick, fetchPageSeq(
-			m.requestContext(), c.feed, c.searchQuery, c.listID, c.accountID, c.cursor, true, c.feedSeq, c.id, false,
+			m.requestContext(), c.feed, c.searchQuery, c.listID, c.profileUserID, c.accountID, c.cursor, true, c.feedSeq, c.id, false,
 		))
 	}
 	return nil

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -246,6 +246,11 @@ func (m Model) Init() tea.Cmd {
 			m.requestContext(), c.feed, c.searchQuery, c.listID, "", false, c.feedSeq, c.id,
 		))
 	}
+	// Columns built from --columns or a saved layout carry only a list id, and
+	// one enumeration names all of them.
+	if m.namesPendingForListColumns() {
+		cmds = append(cmds, fetchListsCmd(m.requestContext()))
+	}
 	cmds = append(cmds, clockTick())
 	return tea.Batch(cmds...)
 }
@@ -466,6 +471,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.applyPreview(msg)
 	case likeMsg:
 		return m, m.applyLikeResult(msg)
+	case listsMsg:
+		// Outside the picker this only ever arrives from Init's backfill, and a
+		// failure just leaves the ids on screen — the feeds themselves loaded.
+		if msg.err == nil {
+			m.nameListColumns(msg.lists)
+		}
+		return m, nil
 	}
 
 	key, ok := msg.(tea.KeyMsg)

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -87,11 +87,14 @@ type Model struct {
 	toast         string
 	toastSeq      int
 	liking        map[string]bool
-	previews      map[string]previewState
-	spinner       spinner.Model
-	columns       []column
-	focus         int
-	nextColID     int
+	// previews is shared by post ID rather than duplicated per column because
+	// every feed column has the same width. Unequal panes would need a
+	// per-column cache to avoid alternating width-based refetches.
+	previews  map[string]previewState
+	spinner   spinner.Model
+	columns   []column
+	focus     int
+	nextColID int
 
 	mode              mode
 	replyReturn       mode
@@ -622,11 +625,26 @@ func (m *Model) applyPreview(msg previewMsg) tea.Cmd {
 		return nil
 	}
 	m.evictDistantPreviews()
-	if c != m.cur() {
+	if m.mode == modeThread {
+		if c != m.cur() {
+			return nil
+		}
+		m.syncViewport()
+		m.ensureSelectedVisible()
+		return m.imageRepaint()
+	}
+	first, count := m.visibleColumnRange()
+	visible := false
+	for index := first; index < first+count; index++ {
+		if &m.columns[index] == c {
+			visible = true
+			break
+		}
+	}
+	if !visible {
 		return nil
 	}
-	m.syncViewport()
-	m.ensureSelectedVisible()
+	m.resize()
 	return m.imageRepaint()
 }
 
@@ -844,6 +862,9 @@ func (m Model) applyFeedPage(msg pageMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 	if !focused || m.mode == modeReply {
+		if !focused && m.mode == modeFeed {
+			return m, m.imageRepaint(m.requestPreviews(), toast)
+		}
 		return m, toast
 	}
 	m.syncViewport()

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -58,6 +58,7 @@ const (
 	FeedFollowing
 	FeedBookmarks
 	FeedSearch
+	FeedList
 )
 
 type mode int
@@ -67,6 +68,7 @@ const (
 	modeThread
 	modeReply
 	modeSearch
+	modeListPicker
 )
 
 type Model struct {
@@ -79,6 +81,8 @@ type Model struct {
 	imageNote     string
 	feed          FeedKind
 	searchQuery   string
+	listID        string
+	listName      string
 	feedSeq       int
 	posts         []api.TimelinePost
 	cursor        string
@@ -104,23 +108,28 @@ type Model struct {
 	viewport      viewport.Model
 	wezFrameKey   string
 
-	mode          mode
-	feedSelected  int
-	threadRootID  string
-	threadPosts   []api.ConversationPost
-	threadCursor  string
-	threadLoading bool
-	threadMore    bool
-	threadErr     error
-	threadSeq     int
-	replyReturn   mode
-	replyEditor   textarea.Model
-	replyPost     api.TimelinePost
-	replyPosting  bool
-	replyErr      error
-	replyNotice   string
-	searchInput   textinput.Model
-	searchReturn  mode
+	mode              mode
+	feedSelected      int
+	threadRootID      string
+	threadPosts       []api.ConversationPost
+	threadCursor      string
+	threadLoading     bool
+	threadMore        bool
+	threadErr         error
+	threadSeq         int
+	replyReturn       mode
+	replyEditor       textarea.Model
+	replyPost         api.TimelinePost
+	replyPosting      bool
+	replyErr          error
+	replyNotice       string
+	searchInput       textinput.Model
+	searchReturn      mode
+	listPicker        []api.ListInfo
+	listPickerSel     int
+	listPickerErr     error
+	listPickerLoading bool
+	listReturn        mode
 }
 
 type pageMsg struct {
@@ -237,7 +246,7 @@ func (m Model) Init() tea.Cmd {
 	if m.feed == FeedSearch && m.searchQuery == "" {
 		return tea.Batch(m.searchInput.Focus(), clockTick())
 	}
-	return tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.feed, m.searchQuery, "", false, m.feedSeq), clockTick())
+	return tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.feed, m.searchQuery, m.listID, "", false, m.feedSeq), clockTick())
 }
 
 func Run(ctx context.Context, images string, feed FeedKind, query string) (Action, error) {
@@ -278,7 +287,7 @@ func Run(ctx context.Context, images string, feed FeedKind, query string) (Actio
 	return Action{}, err
 }
 
-func fetchPageSeq(parent context.Context, feed FeedKind, query, cursor string, more bool, seq int) tea.Cmd {
+func fetchPageSeq(parent context.Context, feed FeedKind, query, listID, cursor string, more bool, seq int) tea.Cmd {
 	return func() tea.Msg {
 		mgr, err := config.NewConfigManager()
 		if err != nil {
@@ -301,6 +310,11 @@ func fetchPageSeq(parent context.Context, feed FeedKind, query, cursor string, m
 			q := query
 			fetch = func(ctx context.Context, cursor string, count int) (*api.TimelinePage, error) {
 				return client.FetchSearchTimeline(ctx, q, cursor, count)
+			}
+		case FeedList:
+			id := listID
+			fetch = func(ctx context.Context, cursor string, count int) (*api.TimelinePage, error) {
+				return client.FetchListTimeline(ctx, id, cursor, count)
 			}
 		}
 		page, err := fetch(ctx, cursor, 30)
@@ -424,6 +438,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.updateReply(msg)
 	case modeSearch:
 		return m.updateSearch(msg)
+	case modeListPicker:
+		return m.updateListPicker(msg)
 	case modeThread:
 		return m.updateThread(msg)
 	}
@@ -496,6 +512,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.setFeed(FeedBookmarks)
 	case "/":
 		return m, m.beginSearch()
+	case "L":
+		return m, m.beginListPicker()
 	case "R", "ctrl+r":
 		if len(m.posts) == 0 {
 			m.loading = true
@@ -503,7 +521,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.refreshing = true
 		}
 		m.err = nil
-		return m, m.imageRepaint(tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.feed, m.searchQuery, "", false, m.feedSeq)))
+		return m, m.imageRepaint(tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.feed, m.searchQuery, m.listID, "", false, m.feedSeq)))
 	case "r":
 		if post, ok := m.currentPost(); ok {
 			return m.beginReply(post)
@@ -685,7 +703,7 @@ func (m *Model) setFeed(kind FeedKind) tea.Cmd {
 	m.err = nil
 	m.viewport.YOffset = 0
 	m.syncViewport()
-	return m.imageRepaint(tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.feed, m.searchQuery, "", false, m.feedSeq)))
+	return m.imageRepaint(tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.feed, m.searchQuery, m.listID, "", false, m.feedSeq)))
 }
 
 // switchFeed keeps the f-key semantics: toggle For You <-> Following.
@@ -700,7 +718,7 @@ func (m *Model) switchFeed() tea.Cmd {
 func (m *Model) maybeLoadMore() tea.Cmd {
 	if len(m.posts) > 0 && m.selected >= len(m.posts)-5 && m.cursor != "" && !m.loadingMore {
 		m.loadingMore = true
-		return tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.feed, m.searchQuery, m.cursor, true, m.feedSeq))
+		return tea.Batch(m.spinner.Tick, fetchPageSeq(m.requestContext(), m.feed, m.searchQuery, m.listID, m.cursor, true, m.feedSeq))
 	}
 	return nil
 }
@@ -721,7 +739,8 @@ func (m Model) applyFeedPage(msg pageMsg) (tea.Model, tea.Cmd) {
 	m.err = nil
 	threadContext := m.mode == modeThread ||
 		(m.mode == modeReply && m.replyReturn == modeThread) ||
-		(m.mode == modeSearch && m.searchReturn == modeThread)
+		(m.mode == modeSearch && m.searchReturn == modeThread) ||
+		(m.mode == modeListPicker && m.listReturn == modeThread)
 	feedIndex := m.selected
 	if threadContext {
 		feedIndex = m.feedSelected

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -75,6 +75,7 @@ const (
 	modeReply
 	modeSearch
 	modeListPicker
+	modeChoicePicker
 )
 
 type Model struct {
@@ -119,6 +120,10 @@ type Model struct {
 	listPickerErr     error
 	listPickerLoading bool
 	listReturn        mode
+	picker            choicePicker
+	columnDraft       ColumnSpec
+	searchFor         pickerTarget
+	listFor           pickerTarget
 }
 
 type pageMsg struct {
@@ -190,6 +195,7 @@ type previewState struct {
 type previewMsg struct {
 	postID     string
 	colID      int
+	mode       imageMode
 	content    string
 	nativePath string
 	nativeData string
@@ -425,6 +431,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if loaded, ok := msg.(accountsLoadedMsg); ok {
 		if loaded.err == nil {
 			m.accounts = loaded.accounts
+			// An account picker already on screen follows the refresh.
+			if m.mode == modeChoicePicker &&
+				(m.picker.intent == intentColumnAccount || m.picker.intent == intentColumnAccountRetarget) {
+				m.picker.items = m.accountChoiceItems()
+				m.picker.sel = min(m.picker.sel, max(0, len(m.picker.items)-1))
+			}
 		}
 		return m, nil
 	}
@@ -499,6 +511,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.updateSearch(msg)
 	case modeListPicker:
 		return m.updateListPicker(msg)
+	case modeChoicePicker:
+		return m.updateChoicePicker(msg)
 	case modeThread:
 		return m.updateThread(msg)
 	}
@@ -588,6 +602,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.beginListPicker()
 	case "@":
 		return m, cycleAccountCmd()
+	case "n":
+		return m, m.beginColumnAdd()
+	case "x":
+		return m, m.removeColumn()
+	case "s":
+		return m, m.beginAccountPicker("column account", intentColumnAccountRetarget)
+	case "I":
+		m.beginChoicePicker("image mode", m.imageModeItems(), intentImageMode)
+		return m, m.imageRepaint()
+	case "T":
+		m.beginChoicePicker("theme", m.themeItems(), intentTheme)
+		return m, m.imageRepaint()
 	case "R", "ctrl+r":
 		c := m.cur()
 		if len(c.posts) == 0 {
@@ -678,6 +704,11 @@ func (m *Model) applyLikeResult(msg likeMsg) tea.Cmd {
 func (m *Model) storePreview(msg previewMsg) *column {
 	c := m.columnByID(msg.colID)
 	if c == nil {
+		return nil
+	}
+	if msg.mode != "" && msg.mode != m.imageMode {
+		// Fetched for a renderer the user has since switched away from; its
+		// payload format no longer matches what the view draws.
 		return nil
 	}
 	m.previews[msg.postID] = previewState{

--- a/internal/timeline/model_test.go
+++ b/internal/timeline/model_test.go
@@ -70,6 +70,72 @@ func TestLikeIsOptimisticAndRollsBack(t *testing.T) {
 	}
 }
 
+func TestRepostIsOptimisticAndRollsBack(t *testing.T) {
+	m := New()
+	m.cur().loading = false
+	m.cur().posts = []api.TimelinePost{{ID: "1", Text: "post", RepostCount: 4}}
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
+	m = next.(Model)
+	if cmd == nil || !m.cur().posts[0].Reposted || m.cur().posts[0].RepostCount != 5 {
+		t.Fatalf("repost was not optimistic: %+v", m.cur().posts[0])
+	}
+	m = update(t, m, retweetMsg{id: "1", reposted: true, err: errors.New("nope")})
+	if m.cur().posts[0].Reposted || m.cur().posts[0].RepostCount != 4 {
+		t.Fatalf("failed repost did not roll back: %+v", m.cur().posts[0])
+	}
+}
+
+func TestRepostTogglesOffOnRepostedPost(t *testing.T) {
+	m := New()
+	m.cur().loading = false
+	m.cur().posts = []api.TimelinePost{{ID: "1", Text: "post", Reposted: true, RepostCount: 2}}
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
+	m = next.(Model)
+	if cmd == nil || m.cur().posts[0].Reposted || m.cur().posts[0].RepostCount != 1 {
+		t.Fatalf("unrepost was not optimistic: %+v", m.cur().posts[0])
+	}
+	m = update(t, m, retweetMsg{id: "1", reposted: false})
+	if m.cur().posts[0].Reposted || m.cur().posts[0].RepostCount != 1 {
+		t.Fatalf("successful unrepost changed state again: %+v", m.cur().posts[0])
+	}
+}
+
+func TestRepostSecondPressBlockedWhileFirstIsInFlight(t *testing.T) {
+	m := New()
+	m.cur().loading = false
+	m.cur().posts = []api.TimelinePost{{ID: "1", Text: "post", RepostCount: 4}}
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("first repost press produced no request")
+	}
+	next, cmd = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
+	m = next.(Model)
+	if cmd != nil || m.cur().posts[0].RepostCount != 5 {
+		t.Fatalf("second press fired a duplicate request: cmd=%v post=%+v", cmd, m.cur().posts[0])
+	}
+	m = update(t, m, retweetMsg{id: "1", reposted: true})
+	if m.reposting[likeKey("", "1")] {
+		t.Fatal("in-flight marker survived a settled repost")
+	}
+}
+
+func TestRepostWorksInThreadMode(t *testing.T) {
+	m := New()
+	m.cur().loading = false
+	m.mode = modeThread
+	m.cur().threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "1", Text: "post", RepostCount: 4}}}
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
+	m = next.(Model)
+	if cmd == nil || !m.cur().threadPosts[0].Reposted || m.cur().threadPosts[0].RepostCount != 5 {
+		t.Fatalf("thread repost was not optimistic: %+v", m.cur().threadPosts[0])
+	}
+	m = update(t, m, retweetMsg{id: "1", reposted: true, err: errors.New("nope")})
+	if m.cur().threadPosts[0].Reposted || m.cur().threadPosts[0].RepostCount != 4 {
+		t.Fatalf("failed thread repost did not roll back: %+v", m.cur().threadPosts[0])
+	}
+}
+
 func TestPostAction(t *testing.T) {
 	m := New()
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'P'}})

--- a/internal/timeline/model_test.go
+++ b/internal/timeline/model_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/melqtx/xeet/pkg/api"
 
@@ -307,6 +308,85 @@ func TestRefreshMergesOnTopAndKeepsPosition(t *testing.T) {
 	m = update(t, m, pageMsg{page: &api.TimelinePage{Posts: posts(8), Cursor: "third"}})
 	if len(m.cur().posts) != 8 || !strings.Contains(m.toast, "caught up") {
 		t.Fatalf("no-change refresh misbehaved: %d posts, toast %q", len(m.cur().posts), m.toast)
+	}
+}
+
+func TestPollTickRefreshesFocusedColumn(t *testing.T) {
+	m := New()
+	m.pollInterval = time.Minute
+	m = update(t, m, pageMsg{page: &api.TimelinePage{Posts: posts(3), Cursor: "c"}})
+	next, cmd := m.Update(pollTickMsg{})
+	m = next.(Model)
+	if !m.cur().refreshing {
+		t.Fatal("poll tick did not start a refresh of the focused column")
+	}
+	if cmd == nil {
+		t.Fatal("poll tick did not reschedule the next poll")
+	}
+}
+
+func TestPollTickSkipsRefreshOutsideFeedMode(t *testing.T) {
+	m := New()
+	m.pollInterval = time.Minute
+	m = update(t, m, pageMsg{page: &api.TimelinePage{Posts: posts(3), Cursor: "c"}})
+	m.mode = modeThread
+	next, cmd := m.Update(pollTickMsg{})
+	m = next.(Model)
+	if m.cur().refreshing {
+		t.Fatal("poll tick refreshed while the thread view was open")
+	}
+	if cmd == nil {
+		t.Fatal("poll tick must still reschedule when the refresh is skipped")
+	}
+}
+
+func TestAutoRefreshSkipsBusyHelpAndErrorStates(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(*Model)
+	}{
+		{"help open", func(m *Model) { m.help = true }},
+		{"thread mode", func(m *Model) { m.mode = modeThread }},
+		{"column loading", func(m *Model) { m.cur().loading = true }},
+		{"column refreshing", func(m *Model) { m.cur().refreshing = true }},
+		{"column error", func(m *Model) { m.cur().err = errors.New("boom") }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := New()
+			m.cur().loading = false
+			m.cur().posts = posts(2)
+			tc.setup(&m)
+			if cmd := m.autoRefresh(); cmd != nil {
+				t.Fatal("autoRefresh started a fetch despite the guard")
+			}
+		})
+	}
+}
+
+func TestPollTickDoesNothingWithoutInterval(t *testing.T) {
+	m := New()
+	m.cur().loading = false
+	m.cur().posts = posts(2)
+	if cmd := m.pollTick(); cmd != nil {
+		t.Fatal("pollTick fired with a zero interval; polling must stay opt-in")
+	}
+}
+
+func TestAutoRefreshStaysSilentWhenCaughtUp(t *testing.T) {
+	m := New()
+	m = update(t, m, pageMsg{page: &api.TimelinePage{Posts: posts(5), Cursor: "first"}})
+	m.toast = ""
+	m = update(t, m, pageMsg{page: &api.TimelinePage{Posts: posts(5), Cursor: "second"}, auto: true})
+	if m.toast != "" {
+		t.Fatalf("auto refresh showed a toast with no new posts: %q", m.toast)
+	}
+	m = update(t, m, pageMsg{page: &api.TimelinePage{Posts: posts(7), Cursor: "third"}, auto: true})
+	if !strings.Contains(m.toast, "2 new") {
+		t.Fatalf("auto refresh hid the new-posts toast: %q", m.toast)
+	}
+	if len(m.cur().posts) != 7 || m.cur().posts[0].ID != "f" {
+		t.Fatalf("auto refresh did not prepend new posts: %+v", m.cur().posts[:3])
 	}
 }
 

--- a/internal/timeline/model_test.go
+++ b/internal/timeline/model_test.go
@@ -3,6 +3,7 @@ package timeline
 import (
 	"context"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -40,31 +41,31 @@ func TestHelpAllowsImmediateQuit(t *testing.T) {
 func TestPageLoadsAndNavigation(t *testing.T) {
 	m := New()
 	m = update(t, m, pageMsg{page: &api.TimelinePage{Posts: posts(10), Cursor: "next"}})
-	if m.loading || len(m.posts) != 10 {
+	if m.cur().loading || len(m.cur().posts) != 10 {
 		t.Fatalf("page did not load: %+v", m)
 	}
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
-	if m.selected != 1 {
-		t.Fatalf("selected=%d", m.selected)
+	if m.cur().selected != 1 {
+		t.Fatalf("selected=%d", m.cur().selected)
 	}
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
-	if m.selected != 0 {
-		t.Fatalf("selected=%d", m.selected)
+	if m.cur().selected != 0 {
+		t.Fatalf("selected=%d", m.cur().selected)
 	}
 }
 
 func TestLikeIsOptimisticAndRollsBack(t *testing.T) {
 	m := New()
-	m.loading = false
-	m.posts = []api.TimelinePost{{ID: "1", Text: "post", LikeCount: 4}}
+	m.cur().loading = false
+	m.cur().posts = []api.TimelinePost{{ID: "1", Text: "post", LikeCount: 4}}
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
 	m = next.(Model)
-	if cmd == nil || !m.posts[0].Liked || m.posts[0].LikeCount != 5 {
-		t.Fatalf("like was not optimistic: %+v", m.posts[0])
+	if cmd == nil || !m.cur().posts[0].Liked || m.cur().posts[0].LikeCount != 5 {
+		t.Fatalf("like was not optimistic: %+v", m.cur().posts[0])
 	}
 	m = update(t, m, likeMsg{id: "1", liked: true, err: errors.New("nope")})
-	if m.posts[0].Liked || m.posts[0].LikeCount != 4 {
-		t.Fatalf("failed like did not roll back: %+v", m.posts[0])
+	if m.cur().posts[0].Liked || m.cur().posts[0].LikeCount != 4 {
+		t.Fatalf("failed like did not roll back: %+v", m.cur().posts[0])
 	}
 }
 
@@ -79,8 +80,8 @@ func TestPostAction(t *testing.T) {
 
 func TestExpiredSessionOffersReconnectAction(t *testing.T) {
 	m := New()
-	m.loading = false
-	m.err = api.ErrSessionExpired
+	m.cur().loading = false
+	m.cur().err = api.ErrSessionExpired
 	if view := m.View(); !strings.Contains(view, "a reconnect") || !strings.Contains(view, "xeet auth") {
 		t.Fatalf("expired-session guidance missing: %s", view)
 	}
@@ -93,8 +94,8 @@ func TestExpiredSessionOffersReconnectAction(t *testing.T) {
 
 func TestReconnectKeyIgnoredForOtherErrors(t *testing.T) {
 	m := New()
-	m.loading = false
-	m.err = &api.ConnectionError{Kind: "offline", Err: errors.New("offline")}
+	m.cur().loading = false
+	m.cur().err = &api.ConnectionError{Kind: "offline", Err: errors.New("offline")}
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
 	m = next.(Model)
 	if m.action.Kind == ActionAuthenticate || cmd != nil {
@@ -104,8 +105,8 @@ func TestReconnectKeyIgnoredForOtherErrors(t *testing.T) {
 
 func TestAltTextPanelListsEveryImageWithoutRenderer(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.loading = false
-	m.posts = []api.TimelinePost{{ID: "1", Text: "photos", AuthorName: "Alice", Handle: "alice", Media: []api.TimelineMedia{
+	m.cur().loading = false
+	m.cur().posts = []api.TimelinePost{{ID: "1", Text: "photos", AuthorName: "Alice", Handle: "alice", Media: []api.TimelineMedia{
 		{AltText: "a cat on a windowsill"}, {},
 	}}}
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'A'}})
@@ -127,9 +128,9 @@ func TestAltTextPanelListsEveryImageWithoutRenderer(t *testing.T) {
 
 func TestAltTextPanelScrollsLongDescriptions(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.loading = false
+	m.cur().loading = false
 	m.height = 12
-	m.posts = []api.TimelinePost{{ID: "1", Media: []api.TimelineMedia{{
+	m.cur().posts = []api.TimelinePost{{ID: "1", Media: []api.TimelineMedia{{
 		AltText: strings.Repeat("a long accessible description ", 30),
 	}}}}
 	m.altText = true
@@ -145,51 +146,51 @@ func TestAltTextPanelScrollsLongDescriptions(t *testing.T) {
 
 func TestAltTextPanelProcessesBackgroundResults(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.loading = false
+	m.cur().loading = false
 	m.altText = true
-	m.posts = []api.TimelinePost{{ID: "1", Liked: true, LikeCount: 1, Media: []api.TimelineMedia{{}}}}
+	m.cur().posts = []api.TimelinePost{{ID: "1", Liked: true, LikeCount: 1, Media: []api.TimelineMedia{{}}}}
 	m.liking["1"] = true
 	next, _ := m.Update(likeMsg{id: "1", liked: true, err: errors.New("rejected")})
 	m = next.(Model)
 	if !m.altText {
 		t.Fatal("background result unexpectedly closed alt text")
 	}
-	if m.liking["1"] || m.posts[0].Liked || m.posts[0].LikeCount != 0 {
-		t.Fatalf("like result was dropped: liking=%v post=%+v", m.liking, m.posts[0])
+	if m.liking["1"] || m.cur().posts[0].Liked || m.cur().posts[0].LikeCount != 0 {
+		t.Fatalf("like result was dropped: liking=%v post=%+v", m.liking, m.cur().posts[0])
 	}
 }
 
 func TestHelpProcessesBackgroundResults(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.loading = false
+	m.cur().loading = false
 	m.help = true
-	m.posts = []api.TimelinePost{{ID: "1", Liked: true, LikeCount: 1}}
+	m.cur().posts = []api.TimelinePost{{ID: "1", Liked: true, LikeCount: 1}}
 	m.liking["1"] = true
 	next, _ := m.Update(likeMsg{id: "1", liked: true, err: errors.New("rejected")})
 	m = next.(Model)
 	if !m.help {
 		t.Fatal("background result unexpectedly closed help")
 	}
-	if m.liking["1"] || m.posts[0].Liked || m.posts[0].LikeCount != 0 {
-		t.Fatalf("like result was dropped: liking=%v post=%+v", m.liking, m.posts[0])
+	if m.liking["1"] || m.cur().posts[0].Liked || m.cur().posts[0].LikeCount != 0 {
+		t.Fatalf("like result was dropped: liking=%v post=%+v", m.liking, m.cur().posts[0])
 	}
 }
 
 func TestRefreshKey(t *testing.T) {
 	m := New()
-	m.loading = false
-	m.posts = posts(1)
+	m.cur().loading = false
+	m.cur().posts = posts(1)
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'R'}})
 	m = next.(Model)
-	if !m.refreshing || cmd == nil {
+	if !m.cur().refreshing || cmd == nil {
 		t.Fatal("R did not refresh in place")
 	}
 }
 
 func TestReplyOpensInPlaceAndReturnsToFeed(t *testing.T) {
 	m := New()
-	m.loading = false
-	m.posts = []api.TimelinePost{{ID: "123", Handle: "alice", Text: "hello"}}
+	m.cur().loading = false
+	m.cur().posts = []api.TimelinePost{{ID: "123", Handle: "alice", Text: "hello"}}
 	m.syncViewport()
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
 	m = next.(Model)
@@ -204,8 +205,8 @@ func TestReplyOpensInPlaceAndReturnsToFeed(t *testing.T) {
 
 func TestReplyPostsWithoutLeavingProgram(t *testing.T) {
 	m := New()
-	m.loading = false
-	m.posts = []api.TimelinePost{{ID: "123", Handle: "alice", Text: "hello"}}
+	m.cur().loading = false
+	m.cur().posts = []api.TimelinePost{{ID: "123", Handle: "alice", Text: "hello"}}
 	m.syncViewport()
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
 	m.replyEditor.SetValue("hey back")
@@ -288,24 +289,24 @@ func TestRefreshMergesOnTopAndKeepsPosition(t *testing.T) {
 	m = update(t, m, pageMsg{page: &api.TimelinePage{Posts: posts(5), Cursor: "first"}})
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
 	m = update(t, m, pageMsg{page: &api.TimelinePage{Posts: posts(8), Cursor: "second"}})
-	if len(m.posts) != 8 {
-		t.Fatalf("refresh did not merge: %d posts", len(m.posts))
+	if len(m.cur().posts) != 8 {
+		t.Fatalf("refresh did not merge: %d posts", len(m.cur().posts))
 	}
-	if m.posts[0].ID != "f" || m.posts[3].ID != "a" {
-		t.Fatalf("new posts were not prepended in order: %+v", m.posts[:4])
+	if m.cur().posts[0].ID != "f" || m.cur().posts[3].ID != "a" {
+		t.Fatalf("new posts were not prepended in order: %+v", m.cur().posts[:4])
 	}
-	if m.posts[m.selected].ID != "b" {
-		t.Fatalf("selection moved off post b: selected=%d", m.selected)
+	if m.cur().posts[m.cur().selected].ID != "b" {
+		t.Fatalf("selection moved off post b: selected=%d", m.cur().selected)
 	}
-	if m.cursor != "first" {
-		t.Fatalf("refresh clobbered the pagination cursor: %q", m.cursor)
+	if m.cur().cursor != "first" {
+		t.Fatalf("refresh clobbered the pagination cursor: %q", m.cur().cursor)
 	}
 	if !strings.Contains(m.toast, "3 new") {
 		t.Fatalf("no new-posts toast: %q", m.toast)
 	}
 	m = update(t, m, pageMsg{page: &api.TimelinePage{Posts: posts(8), Cursor: "third"}})
-	if len(m.posts) != 8 || !strings.Contains(m.toast, "caught up") {
-		t.Fatalf("no-change refresh misbehaved: %d posts, toast %q", len(m.posts), m.toast)
+	if len(m.cur().posts) != 8 || !strings.Contains(m.toast, "caught up") {
+		t.Fatalf("no-change refresh misbehaved: %d posts, toast %q", len(m.cur().posts), m.toast)
 	}
 }
 
@@ -328,144 +329,144 @@ func TestToastExpiresOnlyForLatestSequence(t *testing.T) {
 
 func TestEnterOpensRepliesAndEscRestoresFeed(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.loading = false
-	m.posts = []api.TimelinePost{
+	m.cur().loading = false
+	m.cur().posts = []api.TimelinePost{
 		{ID: "first", Handle: "one", Text: "first"},
 		{ID: "root", Handle: "alice", Text: "root"},
 	}
-	m.selected = 1
+	m.cur().selected = 1
 	m.syncViewport()
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = next.(Model)
-	if cmd == nil || m.mode != modeThread || m.threadRootID != "root" || m.feedSelected != 1 {
-		t.Fatalf("thread did not open: mode=%v root=%q feedSelected=%d", m.mode, m.threadRootID, m.feedSelected)
+	if cmd == nil || m.mode != modeThread || m.cur().threadRootID != "root" || m.cur().feedSelected != 1 {
+		t.Fatalf("thread did not open: mode=%v root=%q feedSelected=%d", m.mode, m.cur().threadRootID, m.cur().feedSelected)
 	}
 	m = update(t, m, threadMsg{rootID: "root", seq: 1, page: &api.ConversationPage{Posts: []api.ConversationPost{
 		{TimelinePost: api.TimelinePost{ID: "root", Handle: "alice", Text: "root"}},
 		{TimelinePost: api.TimelinePost{ID: "reply", Handle: "bob", Text: "hello", InReplyToID: "root"}, Depth: 1},
 	}}})
 	view := m.View()
-	if m.threadLoading || len(m.threadPosts) != 2 || !strings.Contains(view, "@bob") {
-		t.Fatalf("thread did not render: loading=%v posts=%+v", m.threadLoading, m.threadPosts)
+	if m.cur().threadLoading || len(m.cur().threadPosts) != 2 || !strings.Contains(view, "@bob") {
+		t.Fatalf("thread did not render: loading=%v posts=%+v", m.cur().threadLoading, m.cur().threadPosts)
 	}
 	if !strings.Contains(view, "replies to @alice") {
 		t.Fatalf("thread header does not name the focal author:\n%s", view)
 	}
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyEsc})
-	if m.mode != modeFeed || m.selected != 1 || m.posts[m.selected].ID != "root" {
-		t.Fatalf("feed position was not restored: mode=%v selected=%d", m.mode, m.selected)
+	if m.mode != modeFeed || m.cur().selected != 1 || m.cur().posts[m.cur().selected].ID != "root" {
+		t.Fatalf("feed position was not restored: mode=%v selected=%d", m.mode, m.cur().selected)
 	}
 }
 
 func TestThreadIgnoresStaleConversationAndKeepsFeedUpdatesAlive(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.loading = false
-	m.posts = []api.TimelinePost{{ID: "root", Text: "root"}}
+	m.cur().loading = false
+	m.cur().posts = []api.TimelinePost{{ID: "root", Text: "root"}}
 	m.mode = modeThread
-	m.threadRootID = "root"
-	m.threadPosts = []api.ConversationPost{{TimelinePost: m.posts[0]}}
-	m.threadLoading = true
+	m.cur().threadRootID = "root"
+	m.cur().threadPosts = []api.ConversationPost{{TimelinePost: m.cur().posts[0]}}
+	m.cur().threadLoading = true
 	m = update(t, m, threadMsg{rootID: "old", page: &api.ConversationPage{Posts: []api.ConversationPost{{
 		TimelinePost: api.TimelinePost{ID: "wrong", Text: "wrong"},
 	}}}})
-	if len(m.threadPosts) != 1 || m.threadPosts[0].ID != "root" || !m.threadLoading {
-		t.Fatalf("stale thread result was applied: %+v", m.threadPosts)
+	if len(m.cur().threadPosts) != 1 || m.cur().threadPosts[0].ID != "root" || !m.cur().threadLoading {
+		t.Fatalf("stale thread result was applied: %+v", m.cur().threadPosts)
 	}
-	m.loadingMore = true
+	m.cur().loadingMore = true
 	m = update(t, m, pageMsg{more: true, page: &api.TimelinePage{Posts: []api.TimelinePost{{ID: "next", Text: "next"}}}})
-	if m.loadingMore || len(m.posts) != 2 || m.mode != modeThread || m.selected != 0 {
-		t.Fatalf("feed update was dropped in thread mode: loadingMore=%v posts=%d selected=%d", m.loadingMore, len(m.posts), m.selected)
+	if m.cur().loadingMore || len(m.cur().posts) != 2 || m.mode != modeThread || m.cur().selected != 0 {
+		t.Fatalf("feed update was dropped in thread mode: loadingMore=%v posts=%d selected=%d", m.cur().loadingMore, len(m.cur().posts), m.cur().selected)
 	}
 }
 
 func TestThreadContinuationResolvesParentFromEarlierPage(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.loading = false
+	m.cur().loading = false
 	m.mode = modeThread
-	m.threadRootID = "root"
-	m.threadSeq = 1
-	m.threadMore = true
-	m.threadPosts = []api.ConversationPost{
+	m.cur().threadRootID = "root"
+	m.cur().threadSeq = 1
+	m.cur().threadMore = true
+	m.cur().threadPosts = []api.ConversationPost{
 		{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}},
 		{TimelinePost: api.TimelinePost{ID: "parent", Text: "parent", InReplyToID: "root"}, Depth: 1},
 	}
 	m = update(t, m, threadMsg{rootID: "root", seq: 1, more: true, page: &api.ConversationPage{
 		Unresolved: []api.TimelinePost{{ID: "nested", Text: "nested", InReplyToID: "parent"}},
 	}})
-	if len(m.threadPosts) != 3 || m.threadPosts[2].ID != "nested" || m.threadPosts[2].Depth != 2 {
-		t.Fatalf("continuation was not resolved: %+v", m.threadPosts)
+	if len(m.cur().threadPosts) != 3 || m.cur().threadPosts[2].ID != "nested" || m.cur().threadPosts[2].Depth != 2 {
+		t.Fatalf("continuation was not resolved: %+v", m.cur().threadPosts)
 	}
 }
 
 func TestThreadResultCompletesWhileReplyEditorIsOpen(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.loading = false
+	m.cur().loading = false
 	m.mode = modeThread
-	m.threadRootID = "root"
-	m.threadSeq = 1
-	m.threadLoading = true
-	m.threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}}}
+	m.cur().threadRootID = "root"
+	m.cur().threadSeq = 1
+	m.cur().threadLoading = true
+	m.cur().threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}}}
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
 	m = update(t, m, threadMsg{rootID: "root", seq: 1, page: &api.ConversationPage{Posts: []api.ConversationPost{
 		{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}},
 		{TimelinePost: api.TimelinePost{ID: "reply", Text: "reply"}, Depth: 1},
 	}}})
-	if m.mode != modeReply || m.threadLoading || len(m.threadPosts) != 2 {
-		t.Fatalf("background thread result was dropped: mode=%v loading=%v posts=%d", m.mode, m.threadLoading, len(m.threadPosts))
+	if m.mode != modeReply || m.cur().threadLoading || len(m.cur().threadPosts) != 2 {
+		t.Fatalf("background thread result was dropped: mode=%v loading=%v posts=%d", m.mode, m.cur().threadLoading, len(m.cur().threadPosts))
 	}
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyEsc})
-	if m.mode != modeThread || len(m.threadPosts) != 2 {
-		t.Fatalf("cancel did not reveal loaded thread: mode=%v posts=%d", m.mode, len(m.threadPosts))
+	if m.mode != modeThread || len(m.cur().threadPosts) != 2 {
+		t.Fatalf("cancel did not reveal loaded thread: mode=%v posts=%d", m.mode, len(m.cur().threadPosts))
 	}
 }
 
 func TestFeedResultDuringThreadReplyPreservesBothSelections(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.loading = false
-	m.posts = []api.TimelinePost{{ID: "a", Text: "a"}, {ID: "root", Text: "root"}}
-	m.feedSelected = 1
+	m.cur().loading = false
+	m.cur().posts = []api.TimelinePost{{ID: "a", Text: "a"}, {ID: "root", Text: "root"}}
+	m.cur().feedSelected = 1
 	m.mode = modeThread
-	m.threadRootID = "root"
-	m.threadPosts = []api.ConversationPost{
+	m.cur().threadRootID = "root"
+	m.cur().threadPosts = []api.ConversationPost{
 		{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}},
 		{TimelinePost: api.TimelinePost{ID: "reply", Text: "reply"}, Depth: 1},
 	}
-	m.selected = 1
+	m.cur().selected = 1
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
 	m = update(t, m, pageMsg{page: &api.TimelinePage{Posts: []api.TimelinePost{{ID: "new", Text: "new"}}}})
-	if m.mode != modeReply || m.selected != 1 || m.feedSelected != 2 {
-		t.Fatalf("background feed result corrupted selections: mode=%v thread=%d feed=%d", m.mode, m.selected, m.feedSelected)
+	if m.mode != modeReply || m.cur().selected != 1 || m.cur().feedSelected != 2 {
+		t.Fatalf("background feed result corrupted selections: mode=%v thread=%d feed=%d", m.mode, m.cur().selected, m.cur().feedSelected)
 	}
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyEsc})
-	if m.mode != modeThread || m.selected != 1 || m.threadPosts[m.selected].ID != "reply" {
-		t.Fatalf("thread selection was not restored: mode=%v selected=%d", m.mode, m.selected)
+	if m.mode != modeThread || m.cur().selected != 1 || m.cur().threadPosts[m.cur().selected].ID != "reply" {
+		t.Fatalf("thread selection was not restored: mode=%v selected=%d", m.mode, m.cur().selected)
 	}
 }
 
 func TestThreadIgnoresOlderRequestForSameRoot(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.loading = false
+	m.cur().loading = false
 	m.mode = modeThread
-	m.threadRootID = "root"
-	m.threadSeq = 2
-	m.threadLoading = true
-	m.threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "new root"}}}
+	m.cur().threadRootID = "root"
+	m.cur().threadSeq = 2
+	m.cur().threadLoading = true
+	m.cur().threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "new root"}}}
 	m = update(t, m, threadMsg{rootID: "root", seq: 1, page: &api.ConversationPage{Posts: []api.ConversationPost{{
 		TimelinePost: api.TimelinePost{ID: "root", Text: "stale root"},
 	}}}})
-	if !m.threadLoading || m.threadPosts[0].Text != "new root" {
-		t.Fatalf("older same-root request was applied: loading=%v post=%+v", m.threadLoading, m.threadPosts[0])
+	if !m.cur().threadLoading || m.cur().threadPosts[0].Text != "new root" {
+		t.Fatalf("older same-root request was applied: loading=%v post=%+v", m.cur().threadLoading, m.cur().threadPosts[0])
 	}
 }
 
 func TestThreadErrorIsVisibleWithSeededRoot(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.loading = false
+	m.cur().loading = false
 	m.mode = modeThread
-	m.threadRootID = "root"
-	m.threadSeq = 1
-	m.threadLoading = true
-	m.threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}}}
+	m.cur().threadRootID = "root"
+	m.cur().threadSeq = 1
+	m.cur().threadLoading = true
+	m.cur().threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}}}
 	m = update(t, m, threadMsg{rootID: "root", seq: 1, err: errors.New("discovery failed badly")})
 	view := m.View()
 	if !strings.Contains(view, "discovery failed badly") || !strings.Contains(view, "R retry") {
@@ -475,12 +476,12 @@ func TestThreadErrorIsVisibleWithSeededRoot(t *testing.T) {
 
 func TestThreadSessionExpiryOffersReconnect(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.loading = false
+	m.cur().loading = false
 	m.mode = modeThread
-	m.threadRootID = "root"
-	m.threadSeq = 1
-	m.threadLoading = true
-	m.threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}}}
+	m.cur().threadRootID = "root"
+	m.cur().threadSeq = 1
+	m.cur().threadLoading = true
+	m.cur().threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}}}
 	m = update(t, m, threadMsg{rootID: "root", seq: 1, err: api.ErrSessionExpired})
 	if !strings.Contains(m.View(), "a reconnect") {
 		t.Fatalf("session-expired thread did not offer reconnect:\n%s", m.View())
@@ -494,14 +495,14 @@ func TestThreadSessionExpiryOffersReconnect(t *testing.T) {
 
 func TestThreadEscPromotesSessionExpiryToFeed(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.loading = false
+	m.cur().loading = false
 	m.mode = modeThread
-	m.threadRootID = "root"
-	m.threadErr = api.ErrSessionExpired
-	m.threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}}}
+	m.cur().threadRootID = "root"
+	m.cur().threadErr = api.ErrSessionExpired
+	m.cur().threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}}}
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyEsc})
-	if m.mode != modeFeed || !errors.Is(m.err, api.ErrSessionExpired) {
-		t.Fatalf("esc dropped the expired session: mode=%v err=%v", m.mode, m.err)
+	if m.mode != modeFeed || !errors.Is(m.cur().err, api.ErrSessionExpired) {
+		t.Fatalf("esc dropped the expired session: mode=%v err=%v", m.mode, m.cur().err)
 	}
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
 	m = next.(Model)
@@ -512,49 +513,49 @@ func TestThreadEscPromotesSessionExpiryToFeed(t *testing.T) {
 
 func TestThreadEscKeepsOrdinaryErrorsOutOfFeed(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.loading = false
+	m.cur().loading = false
 	m.mode = modeThread
-	m.threadRootID = "root"
-	m.threadErr = errors.New("replies timed out")
-	m.threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}}}
+	m.cur().threadRootID = "root"
+	m.cur().threadErr = errors.New("replies timed out")
+	m.cur().threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}}}
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyEsc})
-	if m.mode != modeFeed || m.err != nil {
-		t.Fatalf("thread-only error leaked into the feed: err=%v", m.err)
+	if m.mode != modeFeed || m.cur().err != nil {
+		t.Fatalf("thread-only error leaked into the feed: err=%v", m.cur().err)
 	}
 }
 
 func TestThreadRefreshKeepsRootWhenPageOmitsIt(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.loading = false
+	m.cur().loading = false
 	m.mode = modeThread
-	m.threadRootID = "root"
-	m.threadSeq = 1
-	m.threadLoading = true
-	m.threadPosts = []api.ConversationPost{
+	m.cur().threadRootID = "root"
+	m.cur().threadSeq = 1
+	m.cur().threadLoading = true
+	m.cur().threadPosts = []api.ConversationPost{
 		{TimelinePost: api.TimelinePost{ID: "root", Text: "the focal post"}},
 		{TimelinePost: api.TimelinePost{ID: "old", Text: "old reply", InReplyToID: "root"}, Depth: 1},
 	}
 	m = update(t, m, threadMsg{rootID: "root", seq: 1, page: &api.ConversationPage{Posts: []api.ConversationPost{
 		{TimelinePost: api.TimelinePost{ID: "reply", Text: "only reply", InReplyToID: "root"}, Depth: 1},
 	}}})
-	if len(m.threadPosts) != 2 || m.threadPosts[0].ID != "root" || m.threadPosts[0].Depth != 0 {
-		t.Fatalf("refresh dropped the focal post: %+v", m.threadPosts)
+	if len(m.cur().threadPosts) != 2 || m.cur().threadPosts[0].ID != "root" || m.cur().threadPosts[0].Depth != 0 {
+		t.Fatalf("refresh dropped the focal post: %+v", m.cur().threadPosts)
 	}
-	if m.threadPosts[1].ID != "reply" {
-		t.Fatalf("refresh lost the new reply: %+v", m.threadPosts)
+	if m.cur().threadPosts[1].ID != "reply" {
+		t.Fatalf("refresh lost the new reply: %+v", m.cur().threadPosts)
 	}
 }
 
 func TestThreadReplyTargetsSelectedReplyAndReturnsToThread(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.loading = false
+	m.cur().loading = false
 	m.mode = modeThread
-	m.threadRootID = "root"
-	m.threadPosts = []api.ConversationPost{
+	m.cur().threadRootID = "root"
+	m.cur().threadPosts = []api.ConversationPost{
 		{TimelinePost: api.TimelinePost{ID: "root", Handle: "alice", Text: "root"}},
 		{TimelinePost: api.TimelinePost{ID: "reply", Handle: "bob", Text: "hello"}, Depth: 1},
 	}
-	m.selected = 1
+	m.cur().selected = 1
 	m.syncViewport()
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
 	if m.mode != modeReply || m.replyReturn != modeThread || m.replyPost.ID != "reply" {
@@ -562,24 +563,24 @@ func TestThreadReplyTargetsSelectedReplyAndReturnsToThread(t *testing.T) {
 	}
 	m.replyEditor.SetValue("nested answer")
 	m = update(t, m, replyResultMsg{id: "new"})
-	if m.mode != modeThread || !m.threadLoading || m.toast != "reply sent ♥" {
-		t.Fatalf("reply did not return and refresh thread: mode=%v loading=%v toast=%q", m.mode, m.threadLoading, m.toast)
+	if m.mode != modeThread || !m.cur().threadLoading || m.toast != "reply sent ♥" {
+		t.Fatalf("reply did not return and refresh thread: mode=%v loading=%v toast=%q", m.mode, m.cur().threadLoading, m.toast)
 	}
 }
 
 func TestReadKeyExpandsTruncatedPost(t *testing.T) {
 	m := New()
-	m.loading = false
-	m.posts = []api.TimelinePost{{
+	m.cur().loading = false
+	m.cur().posts = []api.TimelinePost{{
 		ID: "1", Handle: "alice",
 		Text: strings.Repeat("word ", 60) + "ENDMARKER",
 	}}
 	m = update(t, m, tea.WindowSizeMsg{Width: 80, Height: 24})
-	if strings.Contains(m.viewport.View(), "ENDMARKER") {
+	if strings.Contains(m.cur().viewport.View(), "ENDMARKER") {
 		t.Fatal("long post was not truncated")
 	}
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
-	if !m.expanded {
+	if !m.cur().expanded {
 		t.Fatal("e did not expand the post")
 	}
 	content, _, _ := m.renderFeedContent()
@@ -587,44 +588,44 @@ func TestReadKeyExpandsTruncatedPost(t *testing.T) {
 		t.Fatal("expanded post is still truncated")
 	}
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
-	if m.expanded {
+	if m.cur().expanded {
 		t.Fatal("e did not collapse the post")
 	}
 }
 
 func TestHalfPageJumpAndScrolloff(t *testing.T) {
 	m := New()
-	m.loading = false
-	m.posts = posts(30)
+	m.cur().loading = false
+	m.cur().posts = posts(30)
 	m = update(t, m, tea.WindowSizeMsg{Width: 80, Height: 20})
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyCtrlD})
-	if m.selected != 5 {
-		t.Fatalf("ctrl+d selected=%d", m.selected)
+	if m.cur().selected != 5 {
+		t.Fatalf("ctrl+d selected=%d", m.cur().selected)
 	}
 	for i := 0; i < 4; i++ {
 		m = update(t, m, tea.KeyMsg{Type: tea.KeyCtrlD})
 	}
-	if m.selected != 25 {
-		t.Fatalf("selected=%d", m.selected)
+	if m.cur().selected != 25 {
+		t.Fatalf("selected=%d", m.cur().selected)
 	}
-	top := m.viewport.YOffset
-	maxTop := m.ends[len(m.ends)-1] + 1 - m.viewport.Height
-	if end := m.ends[m.selected]; end >= top+m.viewport.Height {
+	top := m.cur().viewport.YOffset
+	maxTop := m.cur().ends[len(m.cur().ends)-1] + 1 - m.cur().viewport.Height
+	if end := m.cur().ends[m.cur().selected]; end >= top+m.cur().viewport.Height {
 		t.Fatalf("selection scrolled out of view: end=%d top=%d", end, top)
 	}
-	if end := m.ends[m.selected]; end+2 >= top+m.viewport.Height && top != maxTop {
+	if end := m.cur().ends[m.cur().selected]; end+2 >= top+m.cur().viewport.Height && top != maxTop {
 		t.Fatal("no scroll margin below the selection")
 	}
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyCtrlU})
-	if m.selected != 20 {
-		t.Fatalf("ctrl+u selected=%d", m.selected)
+	if m.cur().selected != 20 {
+		t.Fatalf("ctrl+u selected=%d", m.cur().selected)
 	}
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyCtrlU})
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyCtrlU})
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyCtrlU})
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyCtrlU})
-	if m.selected != 0 || m.viewport.YOffset != 0 {
-		t.Fatalf("ctrl+u did not clamp: selected=%d offset=%d", m.selected, m.viewport.YOffset)
+	if m.cur().selected != 0 || m.cur().viewport.YOffset != 0 {
+		t.Fatalf("ctrl+u did not clamp: selected=%d offset=%d", m.cur().selected, m.cur().viewport.YOffset)
 	}
 }
 
@@ -632,16 +633,72 @@ func TestPaginationDeduplicates(t *testing.T) {
 	m := New()
 	m = update(t, m, pageMsg{page: &api.TimelinePage{Posts: posts(2), Cursor: "one"}})
 	m = update(t, m, pageMsg{page: &api.TimelinePage{Posts: posts(3), Cursor: "two"}, more: true})
-	if len(m.posts) != 3 || m.cursor != "two" {
-		t.Fatalf("unexpected posts: %+v", m.posts)
+	if len(m.cur().posts) != 3 || m.cur().cursor != "two" {
+		t.Fatalf("unexpected posts: %+v", m.cur().posts)
+	}
+}
+
+func TestPageForRemovedColumnIsDropped(t *testing.T) {
+	m := New()
+	before := m
+
+	m = update(t, m, pageMsg{
+		colID: 99,
+		page:  &api.TimelinePage{Posts: posts(2), Cursor: "removed"},
+	})
+
+	if !reflect.DeepEqual(m, before) {
+		t.Fatal("page for a removed column changed the model")
+	}
+}
+
+func TestPageRoutedToNonFocusedColumnDoesNotTouchFocusedColumn(t *testing.T) {
+	m := New()
+	m.columns = []column{
+		{
+			id:       7,
+			feedSeq:  4,
+			posts:    []api.TimelinePost{{ID: "focused", Text: "focused"}},
+			cursor:   "focused-cursor",
+			selected: 0,
+			viewport: m.cur().viewport,
+		},
+		{
+			id:          8,
+			feedSeq:     4,
+			posts:       []api.TimelinePost{{ID: "background", Text: "background"}},
+			cursor:      "background-cursor",
+			loadingMore: true,
+		},
+	}
+	m.focus = 0
+	m.nextColID = 9
+	focusedBefore := m.columns[0]
+
+	m = update(t, m, pageMsg{
+		colID: 8,
+		seq:   4,
+		more:  true,
+		page: &api.TimelinePage{
+			Posts:  []api.TimelinePost{{ID: "routed", Text: "routed"}},
+			Cursor: "routed-cursor",
+		},
+	})
+
+	if !reflect.DeepEqual(m.columns[0], focusedBefore) {
+		t.Fatal("page for a non-focused column changed the focused column")
+	}
+	if got := m.columns[1]; len(got.posts) != 2 || got.posts[1].ID != "routed" ||
+		got.cursor != "routed-cursor" || got.loadingMore {
+		t.Fatalf("page was not applied to its originating column: %+v", got)
 	}
 }
 
 func TestViewIsFixedHeightAndDoesNotDuplicateRows(t *testing.T) {
 	for _, size := range []struct{ width, height int }{{40, 15}, {80, 24}, {100, 30}, {160, 50}} {
 		m := New()
-		m.loading = false
-		m.posts = []api.TimelinePost{
+		m.cur().loading = false
+		m.cur().posts = []api.TimelinePost{
 			{ID: "1", AuthorName: "Alice", Handle: "alice", Text: "hello from the timeline with enough words to wrap cleanly", MediaCount: 1},
 			{ID: "2", AuthorName: "Bob", Handle: "bob", Text: "another post"},
 		}

--- a/internal/timeline/model_test.go
+++ b/internal/timeline/model_test.go
@@ -288,6 +288,59 @@ func TestReplyPostsWithoutLeavingProgram(t *testing.T) {
 	}
 }
 
+func TestQuoteOpensInPlaceAndReturnsToFeed(t *testing.T) {
+	m := New()
+	m.cur().loading = false
+	m.cur().posts = []api.TimelinePost{{ID: "123", Handle: "alice", Text: "hello"}}
+	m.syncViewport()
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'Q'}})
+	m = next.(Model)
+	if cmd == nil || m.mode != modeQuote || m.replyPost.ID != "123" {
+		t.Fatal("quote did not open in place")
+	}
+	if view := m.View(); !strings.Contains(view, "quoting @alice") {
+		t.Fatalf("quote title missing: %s", view)
+	}
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyEsc})
+	if m.mode != modeFeed {
+		t.Fatal("quote did not return to feed")
+	}
+}
+
+func TestQuotePostsWithoutLeavingProgram(t *testing.T) {
+	m := New()
+	m.cur().loading = false
+	m.cur().posts = []api.TimelinePost{{ID: "123", Handle: "alice", Text: "hello"}}
+	m.syncViewport()
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'Q'}})
+	m.replyEditor.SetValue("so true")
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if cmd == nil || !m.replyPosting || m.mode != modeQuote {
+		t.Fatal("quote did not start posting")
+	}
+	m = update(t, m, replyResultMsg{id: "456"})
+	if m.mode != modeFeed || m.toast != "quote sent ♥" {
+		t.Fatalf("quote did not return to feed: mode=%v toast=%q", m.mode, m.toast)
+	}
+}
+
+func TestQuoteRejectsEmptyText(t *testing.T) {
+	m := New()
+	m.cur().loading = false
+	m.cur().posts = []api.TimelinePost{{ID: "123", Handle: "alice", Text: "hello"}}
+	m.syncViewport()
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'Q'}})
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if cmd != nil || m.replyPosting {
+		t.Fatal("empty quote started posting")
+	}
+	if m.replyErr == nil || m.replyErr.Error() != "write the quote text first" {
+		t.Fatalf("replyErr = %v", m.replyErr)
+	}
+}
+
 func TestRejectedReplyOffersBrowserFallback(t *testing.T) {
 	m := New()
 	m.mode = modeReply

--- a/internal/timeline/model_test.go
+++ b/internal/timeline/model_test.go
@@ -149,13 +149,13 @@ func TestAltTextPanelProcessesBackgroundResults(t *testing.T) {
 	m.cur().loading = false
 	m.altText = true
 	m.cur().posts = []api.TimelinePost{{ID: "1", Liked: true, LikeCount: 1, Media: []api.TimelineMedia{{}}}}
-	m.liking["1"] = true
+	m.liking[likeKey("", "1")] = true
 	next, _ := m.Update(likeMsg{id: "1", liked: true, err: errors.New("rejected")})
 	m = next.(Model)
 	if !m.altText {
 		t.Fatal("background result unexpectedly closed alt text")
 	}
-	if m.liking["1"] || m.cur().posts[0].Liked || m.cur().posts[0].LikeCount != 0 {
+	if m.liking[likeKey("", "1")] || m.cur().posts[0].Liked || m.cur().posts[0].LikeCount != 0 {
 		t.Fatalf("like result was dropped: liking=%v post=%+v", m.liking, m.cur().posts[0])
 	}
 }
@@ -165,13 +165,13 @@ func TestHelpProcessesBackgroundResults(t *testing.T) {
 	m.cur().loading = false
 	m.help = true
 	m.cur().posts = []api.TimelinePost{{ID: "1", Liked: true, LikeCount: 1}}
-	m.liking["1"] = true
+	m.liking[likeKey("", "1")] = true
 	next, _ := m.Update(likeMsg{id: "1", liked: true, err: errors.New("rejected")})
 	m = next.(Model)
 	if !m.help {
 		t.Fatal("background result unexpectedly closed help")
 	}
-	if m.liking["1"] || m.cur().posts[0].Liked || m.cur().posts[0].LikeCount != 0 {
+	if m.liking[likeKey("", "1")] || m.cur().posts[0].Liked || m.cur().posts[0].LikeCount != 0 {
 		t.Fatalf("like result was dropped: liking=%v post=%+v", m.liking, m.cur().posts[0])
 	}
 }

--- a/internal/timeline/notifications_test.go
+++ b/internal/timeline/notifications_test.go
@@ -1,0 +1,62 @@
+package timeline
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/melqtx/xeet/pkg/config"
+)
+
+func TestFetchPageSeqRoutesNotificationsFeedToNotificationsOperation(t *testing.T) {
+	secrets := &fakeRequestSecretStore{data: map[string]string{}}
+	manager := config.NewConfigManagerAt(t.TempDir(), secrets)
+	if err := manager.Save(&config.Config{
+		UserID: "42", Handle: "alice", AuthToken: "alice-auth", CT0: "alice-csrf",
+		NotificationsTimelineQID: "notif-qid",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	useRequestConfigManager(t, manager)
+
+	originalTransport := http.DefaultTransport
+	var path string
+	http.DefaultTransport = requestRoundTripper(func(request *http.Request) (*http.Response, error) {
+		path = request.URL.Path
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"data":{"entries":[]}}`)),
+			Request:    request,
+		}, nil
+	})
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	msg := fetchPageSeq(
+		context.Background(), FeedNotifications, "", "", "", "", false, 0, 0, false,
+	)().(pageMsg)
+	if msg.err != nil {
+		t.Fatalf("notifications fetch: %v", msg.err)
+	}
+	if !strings.HasSuffix(path, "/NotificationsTimeline") {
+		t.Fatalf("request path = %q, want the NotificationsTimeline operation", path)
+	}
+}
+
+func TestNotificationsColumnLabelsAndSearchBackLabels(t *testing.T) {
+	m := New()
+	m.cur().feed = FeedNotifications
+	m.cur().loading = false
+
+	if status := m.columnFeedLabel(m.cur(), 40); status != "notifications" {
+		t.Fatalf("column label = %q, want notifications", status)
+	}
+	if label := m.searchBackLabel(); label != "back to notifications" {
+		t.Fatalf("search back label = %q", label)
+	}
+	if label := m.searchBackShortLabel(); label != "notifications" {
+		t.Fatalf("search back short label = %q", label)
+	}
+}

--- a/internal/timeline/notifications_test.go
+++ b/internal/timeline/notifications_test.go
@@ -35,7 +35,7 @@ func TestFetchPageSeqRoutesNotificationsFeedToNotificationsOperation(t *testing.
 	t.Cleanup(func() { http.DefaultTransport = originalTransport })
 
 	msg := fetchPageSeq(
-		context.Background(), FeedNotifications, "", "", "", "", false, 0, 0, false,
+		context.Background(), FeedNotifications, "", "", "", "", "", false, 0, 0, false,
 	)().(pageMsg)
 	if msg.err != nil {
 		t.Fatalf("notifications fetch: %v", msg.err)

--- a/internal/timeline/picker.go
+++ b/internal/timeline/picker.go
@@ -117,6 +117,8 @@ func (m Model) updateChoicePicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case retweetMsg:
 		m.settleRepost(msg)
 		return m, nil
+	case profileMsg:
+		return m, m.applyProfileResult(msg)
 	case previewMsg:
 		m.storePreview(msg)
 		return m, nil

--- a/internal/timeline/picker.go
+++ b/internal/timeline/picker.go
@@ -60,6 +60,8 @@ func (m *Model) beginColumnAdd() tea.Cmd {
 		{label: "bookmarks", hint: "your saved posts", value: "bookmarks"},
 		{label: "list", hint: "pick one of your lists next", value: "list"},
 		{label: "search", hint: "type a query next", value: "search"},
+		// Appended last on purpose: picker tests index these items by position.
+		{label: "notifications", hint: "likes, reposts, and replies to you", value: "notifications"},
 	}, intentColumnKind)
 	return m.imageRepaint()
 }
@@ -158,6 +160,8 @@ func (m Model) applyChoice(value string) (tea.Model, tea.Cmd) {
 			m.columnDraft.Kind = FeedFollowing
 		case "bookmarks":
 			m.columnDraft.Kind = FeedBookmarks
+		case "notifications":
+			m.columnDraft.Kind = FeedNotifications
 		default:
 			m.columnDraft.Kind = FeedForYou
 		}

--- a/internal/timeline/picker.go
+++ b/internal/timeline/picker.go
@@ -114,6 +114,9 @@ func (m Model) updateChoicePicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case likeMsg:
 		m.settleLike(msg)
 		return m, nil
+	case retweetMsg:
+		m.settleRepost(msg)
+		return m, nil
 	case previewMsg:
 		m.storePreview(msg)
 		return m, nil

--- a/internal/timeline/picker.go
+++ b/internal/timeline/picker.go
@@ -1,0 +1,291 @@
+package timeline
+
+import (
+	"fmt"
+
+	"github.com/melqtx/xeet/internal/theme"
+	"github.com/melqtx/xeet/internal/tui"
+	"github.com/melqtx/xeet/pkg/config"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// pickerTarget tells the search and list pickers whether their result edits
+// the focused column (the historical behavior) or fills the draft of a column
+// being added. The zero value keeps every existing call site unchanged.
+type pickerTarget int
+
+const (
+	targetFocusedColumn pickerTarget = iota
+	targetNewColumn
+)
+
+// choiceIntent identifies what a choicePicker selection means, so one picker
+// implementation can back column kinds, accounts, image modes, and themes.
+type choiceIntent int
+
+const (
+	intentColumnKind choiceIntent = iota
+	intentColumnAccount
+	intentColumnAccountRetarget
+	intentImageMode
+	intentTheme
+)
+
+type choiceItem struct {
+	label string
+	hint  string
+	value string
+}
+
+type choicePicker struct {
+	title  string
+	items  []choiceItem
+	sel    int
+	intent choiceIntent
+}
+
+// beginColumnAdd starts the kind -> detail -> account flow that ends in
+// addColumn. The draft accumulates one decision per stage; escape at any
+// stage throws the whole draft away.
+func (m *Model) beginColumnAdd() tea.Cmd {
+	if len(m.columns) >= maxColumns {
+		return m.showToast("already at 4 columns")
+	}
+	m.columnDraft = ColumnSpec{}
+	m.beginChoicePicker("new column · feed", []choiceItem{
+		{label: "for you", hint: "the recommended timeline", value: "foryou"},
+		{label: "following", hint: "accounts you follow", value: "following"},
+		{label: "bookmarks", hint: "your saved posts", value: "bookmarks"},
+		{label: "list", hint: "pick one of your lists next", value: "list"},
+		{label: "search", hint: "type a query next", value: "search"},
+	}, intentColumnKind)
+	return m.imageRepaint()
+}
+
+func (m *Model) beginChoicePicker(title string, items []choiceItem, intent choiceIntent) {
+	m.picker = choicePicker{title: title, items: items, intent: intent}
+	m.mode = modeChoicePicker
+}
+
+// beginAccountPicker offers every saved account plus an empty-id entry that
+// follows the active account. Unlike the @ key it never calls SetActive: a
+// per-column account is session state, not a config change.
+func (m *Model) beginAccountPicker(title string, intent choiceIntent) tea.Cmd {
+	if len(m.accounts) == 0 {
+		return m.showToast("no saved accounts; run 'xeet auth' first")
+	}
+	m.beginChoicePicker(title, m.accountChoiceItems(), intent)
+	return m.imageRepaint(loadAccountsCmd())
+}
+
+func (m Model) accountChoiceItems() []choiceItem {
+	items := []choiceItem{{
+		label: "active account",
+		hint:  "follows the @ key",
+		value: "",
+	}}
+	for _, account := range m.accounts {
+		hint := account.UserID
+		if account.Active {
+			hint += " · active"
+		}
+		items = append(items, choiceItem{
+			label: accountInfoLabel(account),
+			hint:  hint,
+			value: account.UserID,
+		})
+	}
+	return items
+}
+
+func (m Model) updateChoicePicker(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case listsMsg:
+		if !msg.picker && msg.err == nil {
+			m.nameListColumns(msg.accountID, msg.lists)
+		}
+		return m, nil
+	case pageMsg:
+		return m.applyFeedPage(msg)
+	case likeMsg:
+		m.settleLike(msg)
+		return m, nil
+	case previewMsg:
+		m.storePreview(msg)
+		return m, nil
+	case spinner.TickMsg:
+		if m.columnsLoading() {
+			var cmd tea.Cmd
+			m.spinner, cmd = m.spinner.Update(msg)
+			return m, cmd
+		}
+		return m, nil
+	}
+
+	key, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+	switch key.String() {
+	case "esc":
+		return m.cancelChoicePicker()
+	case "j", "down":
+		m.picker.sel = min(max(0, len(m.picker.items)-1), m.picker.sel+1)
+	case "k", "up":
+		m.picker.sel = max(0, m.picker.sel-1)
+	case "enter":
+		if m.picker.sel < 0 || m.picker.sel >= len(m.picker.items) {
+			return m, nil
+		}
+		return m.applyChoice(m.picker.items[m.picker.sel].value)
+	}
+	return m, nil
+}
+
+func (m Model) applyChoice(value string) (tea.Model, tea.Cmd) {
+	switch m.picker.intent {
+	case intentColumnKind:
+		switch value {
+		case "list":
+			m.listFor = targetNewColumn
+			return m, m.beginListPicker()
+		case "search":
+			m.searchFor = targetNewColumn
+			return m, m.beginSearch()
+		case "following":
+			m.columnDraft.Kind = FeedFollowing
+		case "bookmarks":
+			m.columnDraft.Kind = FeedBookmarks
+		default:
+			m.columnDraft.Kind = FeedForYou
+		}
+		return m, m.beginAccountPicker("new column · account", intentColumnAccount)
+	case intentColumnAccount:
+		m.columnDraft.AccountID = value
+		draft := m.columnDraft
+		m.columnDraft = ColumnSpec{}
+		m.mode = modeFeed
+		return m, m.addColumn(draft)
+	case intentColumnAccountRetarget:
+		m.mode = modeFeed
+		return m, m.setColumnAccount(value)
+	case intentImageMode:
+		m.mode = modeFeed
+		return m, m.setImageMode(imageMode(value))
+	case intentTheme:
+		m.mode = modeFeed
+		return m, m.setTheme(value)
+	}
+	return m, nil
+}
+
+func (m Model) cancelChoicePicker() (tea.Model, tea.Cmd) {
+	// Mid-add-flow intents abandon the draft; retarget/display intents have no
+	// draft to lose.
+	if m.picker.intent == intentColumnKind || m.picker.intent == intentColumnAccount {
+		m.columnDraft = ColumnSpec{}
+	}
+	m.mode = modeFeed
+	m.syncViewport()
+	m.ensureSelectedVisible()
+	return m, m.imageRepaint(m.requestPreviews())
+}
+
+func (m Model) imageModeItems() []choiceItem {
+	detected, note := resolveImageMode("auto")
+	items := []choiceItem{
+		{label: "off", hint: "no image previews", value: string(imageModeOff)},
+		{label: "ansi", hint: "half-block pixels, works everywhere", value: string(imageModeANSI)},
+	}
+	if detected == imageModeNative || detected == imageModeWezTerm {
+		items = append(items, choiceItem{
+			label: string(detected),
+			hint:  "native graphics for this terminal",
+			value: string(detected),
+		})
+	} else if note != "" {
+		items[1].hint = note
+	}
+	for i := range items {
+		if items[i].value == string(m.imageMode) {
+			items[i].hint += " · current"
+		}
+	}
+	return items
+}
+
+// setImageMode swaps the renderer mid-session. Cached previews hold payloads
+// in the old renderer's format, so every entry is dropped; stragglers still
+// downloading for the old mode are rejected by the mode guard in storePreview.
+func (m *Model) setImageMode(mode imageMode) tea.Cmd {
+	if mode == m.imageMode {
+		return m.showToast("images already " + string(mode))
+	}
+	previous := m.imageMode
+	m.imageMode = mode
+	m.imageNote = ""
+	m.enforceMultiColumnImageMode()
+	for id, preview := range m.previews {
+		m.evictPreview(id, preview)
+	}
+	m.resize()
+	cmds := []tea.Cmd{m.requestPreviews(), m.showToast("images: " + string(m.imageMode))}
+	if previous == imageModeNative || previous == imageModeWezTerm {
+		// Pixel graphics leave residue the line diff cannot erase.
+		cmds = append(cmds, func() tea.Msg { return tea.ClearScreen() })
+	}
+	return m.imageRepaint(cmds...)
+}
+
+// activeThemeName tracks the live palette so the picker can mark the current
+// entry; cmd sets it at startup from the flag or config.
+var activeThemeName = theme.DefaultName
+
+func SetThemeName(name string) { activeThemeName = name }
+
+func (m Model) themeItems() []choiceItem {
+	names := theme.Names()
+	items := make([]choiceItem, 0, len(names))
+	for _, name := range names {
+		item := choiceItem{label: name, value: name}
+		if name == activeThemeName {
+			item.hint = "current"
+		}
+		items = append(items, item)
+	}
+	return items
+}
+
+// setTheme recolors immediately -- every style is rebuilt per frame from the
+// package-level colors -- and saves the choice like `xeet theme` does.
+func (m *Model) setTheme(name string) tea.Cmd {
+	palette, ok := theme.Named(name)
+	if !ok {
+		return m.showToast("unknown theme " + name)
+	}
+	ApplyTheme(palette)
+	tui.ApplyTheme(palette)
+	activeThemeName = name
+	return m.imageRepaint(m.showToast("theme: "+name), saveThemeCmd(name))
+}
+
+type themeSaver interface{ SaveTheme(string) error }
+
+var openThemeSaver = func() (themeSaver, error) {
+	return config.NewConfigManager()
+}
+
+func saveThemeCmd(name string) tea.Cmd {
+	return func() tea.Msg {
+		saver, err := openThemeSaver()
+		if err != nil {
+			return actionMsg{err: fmt.Errorf("save theme: %w", err)}
+		}
+		if err := saver.SaveTheme(name); err != nil {
+			return actionMsg{err: fmt.Errorf("save theme: %w", err)}
+		}
+		return nil
+	}
+}

--- a/internal/timeline/picker.go
+++ b/internal/timeline/picker.go
@@ -117,6 +117,9 @@ func (m Model) updateChoicePicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case retweetMsg:
 		m.settleRepost(msg)
 		return m, nil
+	case bookmarkMsg:
+		m.settleBookmark(msg)
+		return m, nil
 	case profileMsg:
 		return m, m.applyProfileResult(msg)
 	case previewMsg:

--- a/internal/timeline/picker_test.go
+++ b/internal/timeline/picker_test.go
@@ -1,0 +1,323 @@
+package timeline
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/melqtx/xeet/internal/theme"
+	"github.com/melqtx/xeet/pkg/api"
+	"github.com/melqtx/xeet/pkg/config"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func runeKey(r rune) tea.KeyMsg { return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}} }
+
+func twoAccounts() []config.AccountInfo {
+	return []config.AccountInfo{
+		{UserID: "42", Handle: "alice", Active: true},
+		{UserID: "84", Handle: "bob"},
+	}
+}
+
+func TestColumnAddFullFlowThroughPickers(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.configureColumns(repeatedColumnSpecs(1, FeedForYou, "", ""))
+	m.columns[0].loading = false
+	m.accounts = twoAccounts()
+
+	m = update(t, m, runeKey('n'))
+	if m.mode != modeChoicePicker || m.picker.intent != intentColumnKind {
+		t.Fatalf("n opened mode=%v intent=%v, want the kind picker", m.mode, m.picker.intent)
+	}
+
+	m = update(t, m, runeKey('j'))
+	m = update(t, m, runeKey('j')) // bookmarks
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.mode != modeChoicePicker || m.picker.intent != intentColumnAccount {
+		t.Fatalf("kind enter landed on mode=%v intent=%v, want the account picker", m.mode, m.picker.intent)
+	}
+	if m.columnDraft.Kind != FeedBookmarks {
+		t.Fatalf("draft kind = %v, want bookmarks", m.columnDraft.Kind)
+	}
+	if m.picker.items[0].value != "" {
+		t.Error("account picker's first entry should follow the active account (empty id)")
+	}
+
+	m = update(t, m, runeKey('j')) // @alice
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.mode != modeFeed {
+		t.Fatalf("mode = %v after the final pick, want the feed", m.mode)
+	}
+	if len(m.columns) != 2 {
+		t.Fatalf("columns = %d, want the draft added as a second column", len(m.columns))
+	}
+	added := m.columns[1]
+	if added.feed != FeedBookmarks || added.accountID != "42" {
+		t.Fatalf("added column = {feed:%v account:%q}, want bookmarks on 42", added.feed, added.accountID)
+	}
+	if m.columnDraft != (ColumnSpec{}) {
+		t.Error("draft was not cleared after the column was added")
+	}
+}
+
+func TestColumnAddEscapeDiscardsDraft(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.configureColumns(repeatedColumnSpecs(1, FeedForYou, "", ""))
+	m.columns[0].loading = false
+	m.accounts = twoAccounts()
+
+	m = update(t, m, runeKey('n'))
+	m = update(t, m, runeKey('j')) // following
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.picker.intent != intentColumnAccount {
+		t.Fatalf("intent = %v, want the account stage", m.picker.intent)
+	}
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyEsc})
+	if m.mode != modeFeed {
+		t.Fatalf("mode = %v after esc, want the feed", m.mode)
+	}
+	if len(m.columns) != 1 {
+		t.Error("esc at the account stage still added the column")
+	}
+	if m.columnDraft != (ColumnSpec{}) {
+		t.Error("esc left a draft behind")
+	}
+}
+
+func TestColumnAddSearchFlowDoesNotApplyOrQuit(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.configureColumns(repeatedColumnSpecs(1, FeedForYou, "", ""))
+	m.columns[0].loading = false
+	m.accounts = twoAccounts()
+
+	m = update(t, m, runeKey('n'))
+	m.picker.sel = 4 // search
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.mode != modeSearch || m.searchFor != targetNewColumn {
+		t.Fatalf("search kind landed on mode=%v target=%v, want a new-column search", m.mode, m.searchFor)
+	}
+
+	m.searchInput.SetValue("terminal cats")
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.mode != modeChoicePicker || m.picker.intent != intentColumnAccount {
+		t.Fatalf("search enter landed on mode=%v, want the account picker", m.mode)
+	}
+	if m.columnDraft.Kind != FeedSearch || m.columnDraft.Query != "terminal cats" {
+		t.Fatalf("draft = %+v, want the search on terminal cats", m.columnDraft)
+	}
+	if m.columns[0].feed == FeedSearch {
+		t.Error("the new-column search overwrote the focused column's feed")
+	}
+
+	// Escape mid-flow abandons the draft instead of quitting like `xeet search`.
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyEsc})
+	if m.mode != modeFeed || len(m.columns) != 1 {
+		t.Fatalf("esc left mode=%v columns=%d, want the feed with one column", m.mode, len(m.columns))
+	}
+}
+
+func TestColumnAddSearchEscapeSkipsTheQuitSpecialCase(t *testing.T) {
+	// A direct `xeet search` session has an empty search column; escape in the
+	// add flow must still cancel rather than quit.
+	m := NewWithImageMode("off")
+	m.configureColumns([]ColumnSpec{{Kind: FeedSearch}})
+	m.cur().loading = false
+	m.accounts = twoAccounts()
+
+	m = update(t, m, runeKey('n'))
+	m.picker.sel = 4
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyEsc})
+	if m.mode != modeFeed {
+		t.Fatalf("esc in the add-flow search left mode=%v, want the feed (not a quit)", m.mode)
+	}
+	if m.searchFor != targetFocusedColumn {
+		t.Error("searchFor was not reset by the cancel")
+	}
+}
+
+func TestColumnAddListFlowUsesActiveAccount(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.configureColumns([]ColumnSpec{{Kind: FeedForYou, AccountID: "42"}})
+	m.columns[0].loading = false
+	m.accounts = twoAccounts()
+
+	m = update(t, m, runeKey('n'))
+	m.picker.sel = 3 // list
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.mode != modeListPicker || m.listFor != targetNewColumn {
+		t.Fatalf("list kind landed on mode=%v target=%v, want a new-column list pick", m.mode, m.listFor)
+	}
+
+	// A pick destined for another column's account must not fill this picker.
+	m = update(t, m, listsMsg{picker: true, accountID: "84", lists: []api.ListInfo{{ID: "9", Name: "wrong"}}})
+	if len(m.listPicker) != 0 {
+		t.Error("the picker accepted lists fetched for a specific column account")
+	}
+	m = update(t, m, listsMsg{picker: true, accountID: "", lists: []api.ListInfo{{ID: "7", Name: "Frens"}}})
+	if len(m.listPicker) != 1 {
+		t.Fatalf("listPicker = %v, want the active account's lists", m.listPicker)
+	}
+
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.mode != modeChoicePicker || m.picker.intent != intentColumnAccount {
+		t.Fatalf("list enter landed on mode=%v, want the account picker", m.mode)
+	}
+	if m.columnDraft.Kind != FeedList || m.columnDraft.ListID != "7" {
+		t.Fatalf("draft = %+v, want list 7", m.columnDraft)
+	}
+}
+
+func TestColumnAccountRetargetFlow(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.configureColumns([]ColumnSpec{{Kind: FeedForYou, AccountID: "42"}})
+	m.columns[0].loading = false
+	m.accounts = twoAccounts()
+
+	m = update(t, m, runeKey('s'))
+	if m.mode != modeChoicePicker || m.picker.intent != intentColumnAccountRetarget {
+		t.Fatalf("s opened mode=%v intent=%v, want the retarget picker", m.mode, m.picker.intent)
+	}
+	m = update(t, m, runeKey('j'))
+	m = update(t, m, runeKey('j')) // @bob
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.cur().accountID != "84" {
+		t.Fatalf("accountID = %q, want 84", m.cur().accountID)
+	}
+}
+
+func TestAccountPickerRefreshesItemsOnLoad(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.configureColumns(repeatedColumnSpecs(1, FeedForYou, "", ""))
+	m.accounts = twoAccounts()
+	m.beginAccountPicker("column account", intentColumnAccountRetarget)
+	before := len(m.picker.items)
+
+	m = update(t, m, accountsLoadedMsg{accounts: []config.AccountInfo{
+		{UserID: "42", Handle: "alice", Active: true},
+	}})
+
+	if len(m.picker.items) != before-1 {
+		t.Fatalf("items = %d, want %d after an account vanished", len(m.picker.items), before-1)
+	}
+}
+
+func TestRemoveColumnKey(t *testing.T) {
+	m := modelWithNamedColumns("one", "two")
+	m = update(t, m, runeKey('x'))
+	if len(m.columns) != 1 {
+		t.Fatalf("x left %d columns, want 1", len(m.columns))
+	}
+}
+
+func TestSetImageModeEvictsPreviewsAndToasts(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.configureColumns(repeatedColumnSpecs(1, FeedForYou, "", ""))
+	m.previews["p1"] = previewState{content: "old ansi art"}
+
+	cmd := m.setImageMode(imageModeANSI)
+
+	if cmd == nil {
+		t.Fatal("setImageMode returned no command; nothing would repaint")
+	}
+	if m.imageMode != imageModeANSI {
+		t.Fatalf("imageMode = %q, want ansi", m.imageMode)
+	}
+	if len(m.previews) != 0 {
+		t.Error("stale previews survived the renderer switch")
+	}
+	if !strings.Contains(m.toast, "ansi") {
+		t.Fatalf("toast = %q, want the new mode named", m.toast)
+	}
+}
+
+func TestSetImageModeMultiColumnFallsBack(t *testing.T) {
+	m := modelWithNamedColumns("one", "two")
+
+	m.setImageMode(imageModeWezTerm)
+
+	if m.imageMode != imageModeANSI {
+		t.Fatalf("imageMode = %q, want the ansi fallback for multiple columns", m.imageMode)
+	}
+	if m.imageNote != multiColumnImageNote {
+		t.Fatalf("imageNote = %q, want the multi-column explanation", m.imageNote)
+	}
+}
+
+func TestStorePreviewDropsMismatchedMode(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.configureColumns(repeatedColumnSpecs(1, FeedForYou, "", ""))
+	m.imageMode = imageModeANSI
+	colID := m.cur().id
+
+	m.storePreview(previewMsg{postID: "stale", colID: colID, mode: imageModeWezTerm, nativeData: "png"})
+	if _, ok := m.previews["stale"]; ok {
+		t.Error("a preview from the previous renderer was stored")
+	}
+	m.storePreview(previewMsg{postID: "fresh", colID: colID, mode: imageModeANSI, content: "art"})
+	if _, ok := m.previews["fresh"]; !ok {
+		t.Error("a preview for the current renderer was dropped")
+	}
+}
+
+type fakeThemeSaver struct {
+	saved []string
+	err   error
+}
+
+func (f *fakeThemeSaver) SaveTheme(name string) error {
+	f.saved = append(f.saved, name)
+	return f.err
+}
+
+func TestSetThemeAppliesPaletteAndSaves(t *testing.T) {
+	saver := &fakeThemeSaver{}
+	previous := openThemeSaver
+	openThemeSaver = func() (themeSaver, error) { return saver, nil }
+	t.Cleanup(func() { openThemeSaver = previous })
+
+	m := NewWithImageMode("off")
+	m.configureColumns(repeatedColumnSpecs(1, FeedForYou, "", ""))
+	before := blue
+
+	name := activeThemeName
+	for _, candidate := range theme.Names() {
+		if candidate != activeThemeName {
+			name = candidate
+			break
+		}
+	}
+	m.setTheme(name)
+
+	if blue == before {
+		t.Error("the palette colors did not change")
+	}
+	if activeThemeName != name {
+		t.Fatalf("activeThemeName = %q, want %q", activeThemeName, name)
+	}
+	msg := saveThemeCmd(name)()
+	if msg != nil {
+		t.Fatalf("saveThemeCmd returned %v, want nil on success", msg)
+	}
+	if len(saver.saved) != 1 || saver.saved[0] != name {
+		t.Fatalf("saved = %v, want [%s]", saver.saved, name)
+	}
+	t.Cleanup(func() { ApplyTheme(theme.Default()) })
+
+	m.setTheme("no-such-theme")
+	if !strings.Contains(m.toast, "unknown theme") {
+		t.Fatalf("toast = %q, want an unknown-theme notice", m.toast)
+	}
+}
+
+func TestHelpListsColumnAndDisplayKeys(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.width, m.height = 100, 40
+	view := m.viewHelp()
+	for _, want := range []string{"add column", "remove column", "column account", "image mode", "theme"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("help is missing %q", want)
+		}
+	}
+}

--- a/internal/timeline/preview.go
+++ b/internal/timeline/preview.go
@@ -327,16 +327,16 @@ func fetchPreview(parent context.Context, postID string, media api.TimelineMedia
 	return func() tea.Msg {
 		parsed, err := url.Parse(previewMediaURL(media.URL, mode))
 		if err != nil {
-			return previewMsg{postID: postID, colID: colID, err: err}
+			return previewMsg{postID: postID, colID: colID, mode: mode, err: err}
 		}
 		if err := validateMediaURL(parsed); err != nil {
-			return previewMsg{postID: postID, colID: colID, err: err}
+			return previewMsg{postID: postID, colID: colID, mode: mode, err: err}
 		}
 		ctx, cancel := context.WithTimeout(parent, 20*time.Second)
 		defer cancel()
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
 		if err != nil {
-			return previewMsg{postID: postID, colID: colID, err: err}
+			return previewMsg{postID: postID, colID: colID, mode: mode, err: err}
 		}
 		req.Header.Set("User-Agent", "github.com/melqtx/xeet/terminal-image-preview")
 		client := &http.Client{
@@ -350,38 +350,38 @@ func fetchPreview(parent context.Context, postID string, media api.TimelineMedia
 		}
 		resp, err := client.Do(req)
 		if err != nil {
-			return previewMsg{postID: postID, colID: colID, err: fmt.Errorf("load image: %w", err)}
+			return previewMsg{postID: postID, colID: colID, mode: mode, err: fmt.Errorf("load image: %w", err)}
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
-			return previewMsg{postID: postID, colID: colID, err: fmt.Errorf("load image: HTTP %d", resp.StatusCode)}
+			return previewMsg{postID: postID, colID: colID, mode: mode, err: fmt.Errorf("load image: HTTP %d", resp.StatusCode)}
 		}
 		if !strings.HasPrefix(strings.ToLower(resp.Header.Get("Content-Type")), "image/") {
-			return previewMsg{postID: postID, colID: colID, err: fmt.Errorf("media is not an image")}
+			return previewMsg{postID: postID, colID: colID, mode: mode, err: fmt.Errorf("media is not an image")}
 		}
 		imageData, err := io.ReadAll(io.LimitReader(resp.Body, maxPreviewBytes+1))
 		if err != nil {
-			return previewMsg{postID: postID, colID: colID, err: err}
+			return previewMsg{postID: postID, colID: colID, mode: mode, err: err}
 		}
 		if len(imageData) > maxPreviewBytes {
-			return previewMsg{postID: postID, colID: colID, err: fmt.Errorf("image is too large to preview")}
+			return previewMsg{postID: postID, colID: colID, mode: mode, err: fmt.Errorf("image is too large to preview")}
 		}
 		config, _, err := image.DecodeConfig(bytes.NewReader(imageData))
 		if err != nil {
-			return previewMsg{postID: postID, colID: colID, err: fmt.Errorf("decode image: %w", err)}
+			return previewMsg{postID: postID, colID: colID, mode: mode, err: fmt.Errorf("decode image: %w", err)}
 		}
 		if config.Width <= 0 || config.Height <= 0 || int64(config.Width)*int64(config.Height) > 50_000_000 {
-			return previewMsg{postID: postID, colID: colID, err: fmt.Errorf("image dimensions are too large to preview")}
+			return previewMsg{postID: postID, colID: colID, mode: mode, err: fmt.Errorf("image dimensions are too large to preview")}
 		}
 		decoded, _, err := image.Decode(bytes.NewReader(imageData))
 		if err != nil {
-			return previewMsg{postID: postID, colID: colID, err: fmt.Errorf("decode image: %w", err)}
+			return previewMsg{postID: postID, colID: colID, mode: mode, err: fmt.Errorf("decode image: %w", err)}
 		}
 		if mode == imageModeNative {
 			columns, rows := nativeCellSize(decoded.Bounds(), width, maxRows)
 			path, err := writePreviewPNG(downscaleForCells(decoded, columns, rows))
 			if err != nil {
-				return previewMsg{postID: postID, colID: colID, err: err}
+				return previewMsg{postID: postID, colID: colID, mode: mode, err: err}
 			}
 			return previewMsg{
 				postID: postID, colID: colID, nativePath: path, imageID: previewImageID(postID),
@@ -392,11 +392,11 @@ func fetchPreview(parent context.Context, postID string, media api.TimelineMedia
 			columns, rows := nativeCellSize(decoded.Bounds(), width, maxRows)
 			encoded, err := encodePreviewPNG(downscaleForCells(decoded, columns, rows))
 			if err != nil {
-				return previewMsg{postID: postID, colID: colID, err: err}
+				return previewMsg{postID: postID, colID: colID, mode: mode, err: err}
 			}
-			return previewMsg{postID: postID, colID: colID, nativeData: encoded, columns: columns, rows: rows}
+			return previewMsg{postID: postID, colID: colID, mode: mode, nativeData: encoded, columns: columns, rows: rows}
 		}
-		return previewMsg{postID: postID, colID: colID, content: renderANSIImage(decoded, width, maxRows)}
+		return previewMsg{postID: postID, colID: colID, mode: mode, content: renderANSIImage(decoded, width, maxRows)}
 	}
 }
 

--- a/internal/timeline/preview.go
+++ b/internal/timeline/preview.go
@@ -105,8 +105,9 @@ func resolveImageMode(requested string) (imageMode, string) {
 }
 
 func (m *Model) requestPreviews() tea.Cmd {
+	c := m.cur()
 	posts := m.activePosts()
-	if m.imageMode == imageModeOff || len(posts) == 0 || m.selected < 0 || m.selected >= len(posts) {
+	if m.imageMode == imageModeOff || len(posts) == 0 || c.selected < 0 || c.selected >= len(posts) {
 		return nil
 	}
 	width := max(12, m.contentWidth()-4)
@@ -116,7 +117,7 @@ func (m *Model) requestPreviews() tea.Cmd {
 		// preview usable at whatever depth a later page settles its post on.
 		width = max(12, m.contentWidth()-4-2*maxRailDepth)
 	}
-	rows := min(16, max(3, m.viewport.Height-5))
+	rows := min(16, max(3, c.viewport.Height-5))
 	if m.imageMode == imageModeNative {
 		// Kitty Unicode placeholders encode cell coordinates through the
 		// diacritics table, so native previews cannot exceed its size.
@@ -125,17 +126,17 @@ func (m *Model) requestPreviews() tea.Cmd {
 
 	var cmds []tea.Cmd
 	selectedChanged := false
-	from := max(0, m.selected-prefetchBehind)
-	to := min(len(posts)-1, m.selected+prefetchAhead)
+	from := max(0, c.selected-prefetchBehind)
+	to := min(len(posts)-1, c.selected+prefetchAhead)
 	if m.imageMode == imageModeNative || m.imageMode == imageModeWezTerm {
 		// Native terminals can render every image currently visible without the
 		// large text payload of ANSI previews. Include the viewport so images in
 		// tall windows load before the cursor lands directly on their post.
 		for i := range posts {
-			if i >= len(m.starts) || i >= len(m.ends) {
+			if i >= len(c.starts) || i >= len(c.ends) {
 				break
 			}
-			if m.ends[i] >= m.viewport.YOffset && m.starts[i] < m.viewport.YOffset+m.viewport.Height {
+			if c.ends[i] >= c.viewport.YOffset && c.starts[i] < c.viewport.YOffset+c.viewport.Height {
 				from = min(from, max(0, i-1))
 				to = max(to, min(len(posts)-1, i+1))
 			}
@@ -154,15 +155,15 @@ func (m *Model) requestPreviews() tea.Cmd {
 			// the width they are given, so the refetch cannot repeat.
 			tooWide := !state.loading && state.err == nil && previewColumns(state) > width
 			// A failed fetch retries only once its post is selected again.
-			if !tooWide && (i != m.selected || state.loading || state.err == nil) {
+			if !tooWide && (i != c.selected || state.loading || state.err == nil) {
 				continue
 			}
 		}
 		m.previews[post.ID] = previewState{loading: true}
-		if i == m.selected {
+		if i == c.selected {
 			selectedChanged = true
 		}
-		cmds = append(cmds, fetchPreview(m.requestContext(), post.ID, post.Media[0], width, rows, m.imageMode))
+		cmds = append(cmds, fetchPreview(m.requestContext(), post.ID, post.Media[0], width, rows, m.imageMode, c.id))
 	}
 	if selectedChanged {
 		m.syncViewport()
@@ -194,7 +195,7 @@ func (m *Model) requestZoom() tea.Cmd {
 		width = min(width, len(kittyDiacritics))
 		rows = min(rows, len(kittyDiacritics))
 	}
-	return fetchPreview(m.requestContext(), key, post.Media[0], width, rows, m.imageMode)
+	return fetchPreview(m.requestContext(), key, post.Media[0], width, rows, m.imageMode, m.cur().id)
 }
 
 func (m Model) zoomLoading() bool {
@@ -239,7 +240,7 @@ func (m *Model) evictDistantPreviews() {
 		if preview.loading || id == activeZoom {
 			continue
 		}
-		if pos, ok := index[id]; ok && abs(pos-m.selected) <= previewKeepRadius {
+		if pos, ok := index[id]; ok && abs(pos-m.cur().selected) <= previewKeepRadius {
 			continue
 		}
 		m.evictPreview(id, preview)
@@ -264,20 +265,20 @@ func abs(value int) int {
 // flight when the program stops cannot write a native PNG after
 // cleanupPreviews has already run, which would strand it in the temp dir for
 // the rest of a compose handoff.
-func fetchPreview(parent context.Context, postID string, media api.TimelineMedia, width, maxRows int, mode imageMode) tea.Cmd {
+func fetchPreview(parent context.Context, postID string, media api.TimelineMedia, width, maxRows int, mode imageMode, colID int) tea.Cmd {
 	return func() tea.Msg {
 		parsed, err := url.Parse(previewMediaURL(media.URL, mode))
 		if err != nil {
-			return previewMsg{postID: postID, err: err}
+			return previewMsg{postID: postID, colID: colID, err: err}
 		}
 		if err := validateMediaURL(parsed); err != nil {
-			return previewMsg{postID: postID, err: err}
+			return previewMsg{postID: postID, colID: colID, err: err}
 		}
 		ctx, cancel := context.WithTimeout(parent, 20*time.Second)
 		defer cancel()
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
 		if err != nil {
-			return previewMsg{postID: postID, err: err}
+			return previewMsg{postID: postID, colID: colID, err: err}
 		}
 		req.Header.Set("User-Agent", "github.com/melqtx/xeet/terminal-image-preview")
 		client := &http.Client{
@@ -291,41 +292,41 @@ func fetchPreview(parent context.Context, postID string, media api.TimelineMedia
 		}
 		resp, err := client.Do(req)
 		if err != nil {
-			return previewMsg{postID: postID, err: fmt.Errorf("load image: %w", err)}
+			return previewMsg{postID: postID, colID: colID, err: fmt.Errorf("load image: %w", err)}
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
-			return previewMsg{postID: postID, err: fmt.Errorf("load image: HTTP %d", resp.StatusCode)}
+			return previewMsg{postID: postID, colID: colID, err: fmt.Errorf("load image: HTTP %d", resp.StatusCode)}
 		}
 		if !strings.HasPrefix(strings.ToLower(resp.Header.Get("Content-Type")), "image/") {
-			return previewMsg{postID: postID, err: fmt.Errorf("media is not an image")}
+			return previewMsg{postID: postID, colID: colID, err: fmt.Errorf("media is not an image")}
 		}
 		imageData, err := io.ReadAll(io.LimitReader(resp.Body, maxPreviewBytes+1))
 		if err != nil {
-			return previewMsg{postID: postID, err: err}
+			return previewMsg{postID: postID, colID: colID, err: err}
 		}
 		if len(imageData) > maxPreviewBytes {
-			return previewMsg{postID: postID, err: fmt.Errorf("image is too large to preview")}
+			return previewMsg{postID: postID, colID: colID, err: fmt.Errorf("image is too large to preview")}
 		}
 		config, _, err := image.DecodeConfig(bytes.NewReader(imageData))
 		if err != nil {
-			return previewMsg{postID: postID, err: fmt.Errorf("decode image: %w", err)}
+			return previewMsg{postID: postID, colID: colID, err: fmt.Errorf("decode image: %w", err)}
 		}
 		if config.Width <= 0 || config.Height <= 0 || int64(config.Width)*int64(config.Height) > 50_000_000 {
-			return previewMsg{postID: postID, err: fmt.Errorf("image dimensions are too large to preview")}
+			return previewMsg{postID: postID, colID: colID, err: fmt.Errorf("image dimensions are too large to preview")}
 		}
 		decoded, _, err := image.Decode(bytes.NewReader(imageData))
 		if err != nil {
-			return previewMsg{postID: postID, err: fmt.Errorf("decode image: %w", err)}
+			return previewMsg{postID: postID, colID: colID, err: fmt.Errorf("decode image: %w", err)}
 		}
 		if mode == imageModeNative {
 			columns, rows := nativeCellSize(decoded.Bounds(), width, maxRows)
 			path, err := writePreviewPNG(downscaleForCells(decoded, columns, rows))
 			if err != nil {
-				return previewMsg{postID: postID, err: err}
+				return previewMsg{postID: postID, colID: colID, err: err}
 			}
 			return previewMsg{
-				postID: postID, nativePath: path, imageID: previewImageID(postID),
+				postID: postID, colID: colID, nativePath: path, imageID: previewImageID(postID),
 				columns: columns, rows: rows,
 			}
 		}
@@ -333,11 +334,11 @@ func fetchPreview(parent context.Context, postID string, media api.TimelineMedia
 			columns, rows := nativeCellSize(decoded.Bounds(), width, maxRows)
 			encoded, err := encodePreviewPNG(downscaleForCells(decoded, columns, rows))
 			if err != nil {
-				return previewMsg{postID: postID, err: err}
+				return previewMsg{postID: postID, colID: colID, err: err}
 			}
-			return previewMsg{postID: postID, nativeData: encoded, columns: columns, rows: rows}
+			return previewMsg{postID: postID, colID: colID, nativeData: encoded, columns: columns, rows: rows}
 		}
-		return previewMsg{postID: postID, content: renderANSIImage(decoded, width, maxRows)}
+		return previewMsg{postID: postID, colID: colID, content: renderANSIImage(decoded, width, maxRows)}
 	}
 }
 

--- a/internal/timeline/preview.go
+++ b/internal/timeline/preview.go
@@ -35,12 +35,13 @@ const (
 	// inlineImageRadius bounds how many posts around the selection render
 	// their cached image inline; further posts show a media chip instead,
 	// which keeps each frame's render cost flat.
-	inlineImageRadius = 6
-	// maxCachedPreviews bounds memory and temp-file usage; entries further
-	// than previewKeepRadius posts from the selection are eligible to evict.
-	maxCachedPreviews = 48
-	previewKeepRadius = 16
+	inlineImageRadius      = 6
+	previewsPerColumn      = 48
+	maxPreviewCacheEntries = 144
+	previewKeepRadius      = 16
 )
+
+const multiColumnImageNote = "multi-column: iTerm2/WezTerm images fall back to ANSI"
 
 type imageMode string
 
@@ -104,18 +105,57 @@ func resolveImageMode(requested string) (imageMode, string) {
 	return imageModeANSI, "this terminal has no native image protocol"
 }
 
+// enforceMultiColumnImageMode keeps relative-cursor iTerm2 image commands out
+// of JoinHorizontal frames, where neighbouring text can land between their
+// reserved cells and cursor restoration.
+func (m *Model) enforceMultiColumnImageMode() {
+	if m.imageMode == imageModeWezTerm && len(m.columns) > 1 {
+		m.imageMode = imageModeANSI
+		m.imageNote = multiColumnImageNote
+	}
+}
+
+func maxCachedPreviews(columnCount int) int {
+	return min(maxPreviewCacheEntries, previewsPerColumn*max(1, columnCount))
+}
+
 func (m *Model) requestPreviews() tea.Cmd {
-	c := m.cur()
-	posts := m.activePosts()
-	if m.imageMode == imageModeOff || len(posts) == 0 || c.selected < 0 || c.selected >= len(posts) {
+	if m.imageMode == imageModeOff {
 		return nil
 	}
-	width := max(12, m.contentWidth()-4)
 	if m.mode == modeThread {
+		width := max(12, columnContentWidth(m.width, 1)-4)
 		// Replies sit behind a rail, so reserve the deepest indent for every
 		// post in the conversation. One width for all of them keeps a cached
 		// preview usable at whatever depth a later page settles its post on.
-		width = max(12, m.contentWidth()-4-2*maxRailDepth)
+		width = max(12, width-2*maxRailDepth)
+		cmds, selectedChanged := m.requestColumnPreviews(m.cur(), m.activePosts(), width)
+		if selectedChanged {
+			m.syncViewport()
+			m.ensureSelectedVisible()
+		}
+		return batchPreviewCommands(cmds)
+	}
+
+	first, count := m.visibleColumnRange()
+	width := max(12, columnContentWidth(m.width, count)-4)
+	var cmds []tea.Cmd
+	selectedChanged := false
+	for index := first; index < first+count; index++ {
+		c := &m.columns[index]
+		columnCmds, changed := m.requestColumnPreviews(c, c.posts, width)
+		cmds = append(cmds, columnCmds...)
+		selectedChanged = selectedChanged || changed
+	}
+	if selectedChanged {
+		m.resize()
+	}
+	return batchPreviewCommands(cmds)
+}
+
+func (m *Model) requestColumnPreviews(c *column, posts []api.TimelinePost, width int) ([]tea.Cmd, bool) {
+	if len(posts) == 0 || c.selected < 0 || c.selected >= len(posts) {
+		return nil, false
 	}
 	rows := min(16, max(3, c.viewport.Height-5))
 	if m.imageMode == imageModeNative {
@@ -165,10 +205,10 @@ func (m *Model) requestPreviews() tea.Cmd {
 		}
 		cmds = append(cmds, fetchPreview(m.requestContext(), post.ID, post.Media[0], width, rows, m.imageMode, c.id))
 	}
-	if selectedChanged {
-		m.syncViewport()
-		m.ensureSelectedVisible()
-	}
+	return cmds, selectedChanged
+}
+
+func batchPreviewCommands(cmds []tea.Cmd) tea.Cmd {
 	if len(cmds) == 0 {
 		return nil
 	}
@@ -210,13 +250,34 @@ func (m Model) zoomLoading() bool {
 }
 
 func (m *Model) evictDistantPreviews() {
-	if len(m.previews) <= maxCachedPreviews {
+	budget := maxCachedPreviews(len(m.columns))
+	if len(m.previews) <= budget {
 		return
 	}
-	posts := m.activePosts()
-	index := make(map[string]int, len(posts))
-	for i := range posts {
-		index[posts[i].ID] = i
+	inFeed := make(map[string]bool)
+	keep := make(map[string]bool)
+	addWindow := func(posts []api.TimelinePost, selected int) {
+		for index := range posts {
+			inFeed[posts[index].ID] = true
+		}
+		if selected < 0 || selected >= len(posts) {
+			return
+		}
+		from := max(0, selected-previewKeepRadius)
+		to := min(len(posts)-1, selected+previewKeepRadius)
+		for index := from; index <= to; index++ {
+			keep[posts[index].ID] = true
+		}
+		keep[posts[selected].ID] = true
+	}
+	if m.mode == modeThread {
+		addWindow(m.activePosts(), m.cur().selected)
+	} else {
+		first, count := m.visibleColumnRange()
+		for index := first; index < first+count; index++ {
+			c := &m.columns[index]
+			addWindow(c.posts, c.selected)
+		}
 	}
 	activeZoom := ""
 	if post, ok := m.currentPost(); ok && m.zoom {
@@ -228,19 +289,16 @@ func (m *Model) evictDistantPreviews() {
 		if preview.loading || id == activeZoom {
 			continue
 		}
-		if _, inFeed := index[id]; inFeed {
+		if inFeed[id] {
 			continue
 		}
 		m.evictPreview(id, preview)
 	}
 	for id, preview := range m.previews {
-		if len(m.previews) <= maxCachedPreviews {
+		if len(m.previews) <= budget {
 			return
 		}
-		if preview.loading || id == activeZoom {
-			continue
-		}
-		if pos, ok := index[id]; ok && abs(pos-m.cur().selected) <= previewKeepRadius {
+		if preview.loading || id == activeZoom || keep[id] {
 			continue
 		}
 		m.evictPreview(id, preview)

--- a/internal/timeline/preview_test.go
+++ b/internal/timeline/preview_test.go
@@ -113,8 +113,8 @@ func TestKittyPlaceholderBlockClampsToDiacriticsTable(t *testing.T) {
 
 func TestZoomOpensFetchesAndCloses(t *testing.T) {
 	m := New()
-	m.loading = false
-	m.posts = mediaPosts(2)
+	m.cur().loading = false
+	m.cur().posts = mediaPosts(2)
 	m.syncViewport()
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
 	m = next.(Model)
@@ -129,7 +129,7 @@ func TestZoomOpensFetchesAndCloses(t *testing.T) {
 	}
 	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
 	m = next.(Model)
-	if m.selected != 0 {
+	if m.cur().selected != 0 {
 		t.Fatal("feed keys leaked through the zoom view")
 	}
 	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
@@ -146,8 +146,8 @@ func TestZoomOpensFetchesAndCloses(t *testing.T) {
 
 func TestZoomWithoutMediaIsIgnored(t *testing.T) {
 	m := New()
-	m.loading = false
-	m.posts = []api.TimelinePost{{ID: "1", Text: "text only", Handle: "cat"}}
+	m.cur().loading = false
+	m.cur().posts = []api.TimelinePost{{ID: "1", Text: "text only", Handle: "cat"}}
 	m.syncViewport()
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
 	m = next.(Model)
@@ -238,8 +238,8 @@ func TestDownscaleForCellsKeepsSmallImages(t *testing.T) {
 func TestWezRepaintClearsOnlyWhenFrameMoves(t *testing.T) {
 	m := New()
 	m.imageMode = imageModeWezTerm
-	m.loading = false
-	m.posts = mediaPosts(6)
+	m.cur().loading = false
+	m.cur().posts = mediaPosts(6)
 	m.width, m.height = 80, 24
 	m.resize()
 
@@ -254,7 +254,7 @@ func TestWezRepaintClearsOnlyWhenFrameMoves(t *testing.T) {
 		t.Fatal("unmoved frame still cleared the screen (iTerm2 flicker)")
 	}
 
-	m.viewport.YOffset += 3
+	m.cur().viewport.YOffset += 3
 	next, cmd = m.Update(wezRepaintMsg{})
 	m = next.(Model)
 	if cmd == nil {
@@ -275,8 +275,8 @@ func TestWezRepaintIgnoredOutsideWezTermMode(t *testing.T) {
 func TestWezTermTimelineFrameKeepsStableHeight(t *testing.T) {
 	m := New()
 	m.imageMode = imageModeWezTerm
-	m.loading = false
-	m.posts = []api.TimelinePost{{
+	m.cur().loading = false
+	m.cur().posts = []api.TimelinePost{{
 		ID: "1", AuthorName: "Alice", Handle: "alice", Text: "image post",
 		Media: []api.TimelineMedia{{URL: "https://pbs.twimg.com/media/a"}},
 	}}
@@ -294,8 +294,8 @@ func TestWezTermTimelineFrameKeepsStableHeight(t *testing.T) {
 
 func TestNativeFrameDoesNotDeleteCachedImages(t *testing.T) {
 	m := NewWithImageMode("native")
-	m.loading = false
-	m.posts = []api.TimelinePost{{
+	m.cur().loading = false
+	m.cur().posts = []api.TimelinePost{{
 		ID: "1", AuthorName: "Alice", Handle: "alice", Text: "image post",
 		Media: []api.TimelineMedia{{URL: "https://pbs.twimg.com/media/a"}},
 	}}
@@ -314,9 +314,9 @@ func TestNativeFrameDoesNotDeleteCachedImages(t *testing.T) {
 func TestNativeCachedPreviewStaysRenderedAwayFromSelection(t *testing.T) {
 	m := NewWithImageMode("native")
 	m.imageMode = imageModeNative
-	m.loading = false
-	m.posts = mediaPosts(inlineImageRadius + 3)
-	m.selected = len(m.posts) - 1
+	m.cur().loading = false
+	m.cur().posts = mediaPosts(inlineImageRadius + 3)
+	m.cur().selected = len(m.cur().posts) - 1
 	m.previews["p0"] = previewState{nativePath: "/tmp/image.png", imageID: 7, columns: 20, rows: 4}
 	content, _, _ := m.renderFeedContent()
 	if !strings.Contains(content, "\x1b_Ga=t") {
@@ -336,8 +336,8 @@ func TestBubbleTeaTruncationPreservesNativePlacement(t *testing.T) {
 
 func TestSelectedPostRequestsInlinePreview(t *testing.T) {
 	m := New()
-	m.loading = false
-	m.posts = []api.TimelinePost{{
+	m.cur().loading = false
+	m.cur().posts = []api.TimelinePost{{
 		ID: "123", Text: "photo",
 		Media: []api.TimelineMedia{{URL: "https://pbs.twimg.com/media/abc", Type: "photo"}},
 	}}
@@ -346,7 +346,7 @@ func TestSelectedPostRequestsInlinePreview(t *testing.T) {
 	if cmd == nil || !m.previews["123"].loading {
 		t.Fatal("inline preview was not requested")
 	}
-	if !strings.Contains(m.viewport.View(), "loading image") {
+	if !strings.Contains(m.cur().viewport.View(), "loading image") {
 		t.Fatal("loading state is not rendered in the timeline")
 	}
 }
@@ -364,14 +364,14 @@ func mediaPosts(count int) []api.TimelinePost {
 
 func TestPreviewsPrefetchAroundSelection(t *testing.T) {
 	m := New()
-	m.loading = false
-	m.posts = mediaPosts(20)
-	m.selected = 5
+	m.cur().loading = false
+	m.cur().posts = mediaPosts(20)
+	m.cur().selected = 5
 	m.syncViewport()
 	if cmd := m.requestPreviews(); cmd == nil {
 		t.Fatal("prefetch requested nothing")
 	}
-	for i := m.selected - prefetchBehind; i <= m.selected+prefetchAhead; i++ {
+	for i := m.cur().selected - prefetchBehind; i <= m.cur().selected+prefetchAhead; i++ {
 		if !m.previews[fmt.Sprintf("p%d", i)].loading {
 			t.Fatalf("post %d was not prefetched", i)
 		}
@@ -387,11 +387,11 @@ func TestPreviewsPrefetchAroundSelection(t *testing.T) {
 
 func TestThreadRefetchesAPreviewTooWideForItsRail(t *testing.T) {
 	m := NewWithImageMode("ansi")
-	m.loading = false
+	m.cur().loading = false
 	m.mode = modeThread
-	m.threadRootID = "root"
-	m.threadPosts = []api.ConversationPost{{TimelinePost: mediaPosts(1)[0]}}
-	m.threadPosts[0].ID = "root"
+	m.cur().threadRootID = "root"
+	m.cur().threadPosts = []api.ConversationPost{{TimelinePost: mediaPosts(1)[0]}}
+	m.cur().threadPosts[0].ID = "root"
 	m.syncViewport()
 
 	// A preview cached at the feed's full width cannot fit a thread, where
@@ -410,10 +410,10 @@ func TestThreadRefetchesAPreviewTooWideForItsRail(t *testing.T) {
 
 func TestThreadSelectionRequestsInlinePreview(t *testing.T) {
 	m := NewWithImageMode("ansi")
-	m.loading = false
+	m.cur().loading = false
 	m.mode = modeThread
-	m.threadRootID = "root"
-	m.threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{
+	m.cur().threadRootID = "root"
+	m.cur().threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{
 		ID: "root", Text: "photo", Media: []api.TimelineMedia{{URL: "https://example.com/photo.jpg"}},
 	}}}
 	m.syncViewport()
@@ -425,12 +425,12 @@ func TestThreadSelectionRequestsInlinePreview(t *testing.T) {
 func TestNativePrefetchIncludesVisiblePosts(t *testing.T) {
 	m := NewWithImageMode("native")
 	m.imageMode = imageModeNative
-	m.loading = false
-	m.posts = mediaPosts(20)
-	m.selected = 10
+	m.cur().loading = false
+	m.cur().posts = mediaPosts(20)
+	m.cur().selected = 10
 	m.syncViewport()
-	m.viewport.YOffset = 0
-	m.viewport.Height = m.ends[4] + 1
+	m.cur().viewport.YOffset = 0
+	m.cur().viewport.Height = m.cur().ends[4] + 1
 	if cmd := m.requestPreviews(); cmd == nil {
 		t.Fatal("native visible prefetch requested nothing")
 	}
@@ -441,9 +441,9 @@ func TestNativePrefetchIncludesVisiblePosts(t *testing.T) {
 
 func TestFailedPreviewRetriesOnlyWhenSelected(t *testing.T) {
 	m := New()
-	m.loading = false
-	m.posts = mediaPosts(3)
-	m.selected = 0
+	m.cur().loading = false
+	m.cur().posts = mediaPosts(3)
+	m.cur().selected = 0
 	m.syncViewport()
 	m.previews["p0"] = previewState{err: fmt.Errorf("boom")}
 	m.previews["p1"] = previewState{err: fmt.Errorf("boom")}
@@ -460,9 +460,9 @@ func TestFailedPreviewRetriesOnlyWhenSelected(t *testing.T) {
 
 func TestPreviewCacheEvictsDistantEntries(t *testing.T) {
 	m := New()
-	m.loading = false
-	m.posts = mediaPosts(80)
-	m.selected = 70
+	m.cur().loading = false
+	m.cur().posts = mediaPosts(80)
+	m.cur().selected = 70
 	for i := 0; i < 80; i++ {
 		m.previews[fmt.Sprintf("p%d", i)] = previewState{content: "img"}
 	}
@@ -471,7 +471,7 @@ func TestPreviewCacheEvictsDistantEntries(t *testing.T) {
 	if len(m.previews) > maxCachedPreviews {
 		t.Fatalf("cache holds %d entries", len(m.previews))
 	}
-	for i := m.selected - previewKeepRadius; i <= 79; i++ {
+	for i := m.cur().selected - previewKeepRadius; i <= 79; i++ {
 		if _, ok := m.previews[fmt.Sprintf("p%d", i)]; !ok {
 			t.Fatalf("evicted preview %d near the selection", i)
 		}

--- a/internal/timeline/preview_test.go
+++ b/internal/timeline/preview_test.go
@@ -73,6 +73,57 @@ func TestNativeModeDetection(t *testing.T) {
 	}
 }
 
+func TestMultiColumnForcesANSIOnWezTermWithVisibleNote(t *testing.T) {
+	setWezTermEnvironment(t)
+	m := NewWithImageMode("native")
+	m.configureColumns(2, FeedForYou, "", "")
+	m.width, m.height = 120, 32
+	m.resize()
+	m.help = true
+
+	if m.imageMode != imageModeANSI {
+		t.Fatalf("multi-column WezTerm mode=%q, want ansi", m.imageMode)
+	}
+	if m.imageNote != multiColumnImageNote {
+		t.Fatalf("multi-column WezTerm note=%q", m.imageNote)
+	}
+	view := strings.Join(strings.Fields(ansi.Strip(m.View())), " ")
+	if !strings.Contains(view, "multi-column:") || !strings.Contains(view, "back to ANSI") {
+		t.Fatalf("image downgrade note is not visible in help:\n%s", view)
+	}
+}
+
+func TestWezTermPathNeverRunsMultiColumn(t *testing.T) {
+	setWezTermEnvironment(t)
+	m := NewWithImageMode("native")
+	m.configureColumns(1, FeedForYou, "", "")
+	if m.imageMode != imageModeWezTerm {
+		t.Fatalf("single-column WezTerm mode=%q", m.imageMode)
+	}
+	_ = m.imageFrameKey()
+
+	m.configureColumns(2, FeedForYou, "", "")
+	if m.imageMode == imageModeWezTerm {
+		t.Fatal("iTerm2-protocol renderer survived multi-column configuration")
+	}
+	if cmd := m.imageRepaint(); cmd != nil {
+		t.Fatal("multi-column mode still scheduled an iTerm2 full-screen repaint")
+	}
+}
+
+func setWezTermEnvironment(t *testing.T) {
+	t.Helper()
+	t.Setenv("ZELLIJ", "")
+	t.Setenv("TMUX", "")
+	t.Setenv("__CFBundleIdentifier", "")
+	t.Setenv("LC_TERMINAL", "")
+	t.Setenv("ITERM_SESSION_ID", "")
+	t.Setenv("WEZTERM_PANE", "")
+	t.Setenv("WEZTERM_EXECUTABLE", "")
+	t.Setenv("TERM", "xterm-256color")
+	t.Setenv("TERM_PROGRAM", "WezTerm")
+}
+
 func TestEmbeddedGhosttyHostDowngrades(t *testing.T) {
 	t.Setenv("ZELLIJ", "")
 	t.Setenv("TMUX", "")
@@ -168,6 +219,16 @@ func TestKittyPlaceholderBlockOccupiesCells(t *testing.T) {
 	}
 	if !strings.Contains(block, "\x1b[38;2;3;2;1m") {
 		t.Fatal("native placeholder does not encode its 24-bit image id as truecolor")
+	}
+}
+
+func TestNativePlaceholderRowsMeasureAtDeclaredWidth(t *testing.T) {
+	m := NewWithImageMode("native")
+	preview := previewState{nativePath: "/tmp/image.png", imageID: 0x030201, columns: 37, rows: 6}
+	for rowIndex, row := range strings.Split(m.nativePreviewBlock(preview), "\n") {
+		if width := lipgloss.Width(row); width != preview.columns {
+			t.Fatalf("native placeholder row %d width=%d, want %d", rowIndex, width, preview.columns)
+		}
 	}
 }
 
@@ -351,6 +412,49 @@ func TestSelectedPostRequestsInlinePreview(t *testing.T) {
 	}
 }
 
+func TestPreviewRequestsCoverVisibleNonFocusedColumns(t *testing.T) {
+	m := NewWithImageMode("ansi")
+	m.configureColumns(2, FeedForYou, "", "")
+	m.width, m.height = 120, 30
+	for index, id := range []string{"left", "right"} {
+		c := &m.columns[index]
+		c.loading = false
+		c.posts = []api.TimelinePost{{
+			ID: id, Text: "photo",
+			Media: []api.TimelineMedia{{URL: "https://pbs.twimg.com/media/" + id, Type: "photo"}},
+		}}
+	}
+	m.resize()
+
+	if cmd := m.requestPreviews(); cmd == nil {
+		t.Fatal("visible columns requested no previews")
+	}
+	for _, id := range []string{"left", "right"} {
+		if !m.previews[id].loading {
+			t.Fatalf("visible post %q was not requested", id)
+		}
+	}
+}
+
+func TestPreviewArrivalRepaintsVisibleNonFocusedColumn(t *testing.T) {
+	m := NewWithImageMode("ansi")
+	m.configureColumns(2, FeedForYou, "", "")
+	m.width, m.height = 120, 30
+	right := &m.columns[1]
+	right.loading = false
+	right.posts = []api.TimelinePost{{
+		ID: "right", Text: "photo",
+		Media: []api.TimelineMedia{{URL: "https://pbs.twimg.com/media/right", Type: "photo"}},
+	}}
+	m.resize()
+
+	m.applyPreview(previewMsg{postID: "right", colID: right.id, content: "RIGHT-PREVIEW"})
+
+	if !strings.Contains(m.columns[1].viewport.View(), "RIGHT-PREVIEW") {
+		t.Fatal("visible non-focused column did not repaint its arrived preview")
+	}
+}
+
 func mediaPosts(count int) []api.TimelinePost {
 	result := make([]api.TimelinePost, count)
 	for i := range result {
@@ -468,7 +572,7 @@ func TestPreviewCacheEvictsDistantEntries(t *testing.T) {
 	}
 	m.previews["gone-from-feed"] = previewState{content: "img"}
 	m.evictDistantPreviews()
-	if len(m.previews) > maxCachedPreviews {
+	if len(m.previews) > maxCachedPreviews(1) {
 		t.Fatalf("cache holds %d entries", len(m.previews))
 	}
 	for i := m.cur().selected - previewKeepRadius; i <= 79; i++ {
@@ -478,5 +582,43 @@ func TestPreviewCacheEvictsDistantEntries(t *testing.T) {
 	}
 	if _, ok := m.previews["gone-from-feed"]; ok {
 		t.Fatal("orphaned preview survived eviction")
+	}
+}
+
+func TestEvictionKeepsPreviewsVisibleInNonFocusedColumns(t *testing.T) {
+	m := NewWithImageMode("ansi")
+	m.configureColumns(2, FeedForYou, "", "")
+	m.width = 120
+	m.columns[0].posts = []api.TimelinePost{{ID: "focused"}}
+	m.columns[1].posts = []api.TimelinePost{{ID: "non-focused"}}
+	m.previews["focused"] = previewState{content: "img"}
+	m.previews["non-focused"] = previewState{content: "img"}
+	for index := 0; index < maxCachedPreviews(2); index++ {
+		m.previews[fmt.Sprintf("orphan-%d", index)] = previewState{content: "img"}
+	}
+
+	m.evictDistantPreviews()
+
+	if _, ok := m.previews["non-focused"]; !ok {
+		t.Fatal("eviction removed a preview selected in a visible non-focused column")
+	}
+	if len(m.previews) > maxCachedPreviews(2) {
+		t.Fatalf("two-column cache holds %d entries", len(m.previews))
+	}
+}
+
+func TestPreviewBudgetScalesWithColumnCount(t *testing.T) {
+	for _, test := range []struct {
+		columns int
+		want    int
+	}{
+		{columns: 1, want: 48},
+		{columns: 2, want: 96},
+		{columns: 3, want: 144},
+		{columns: 4, want: 144},
+	} {
+		if got := maxCachedPreviews(test.columns); got != test.want {
+			t.Fatalf("maxCachedPreviews(%d)=%d, want %d", test.columns, got, test.want)
+		}
 	}
 }

--- a/internal/timeline/preview_test.go
+++ b/internal/timeline/preview_test.go
@@ -76,7 +76,7 @@ func TestNativeModeDetection(t *testing.T) {
 func TestMultiColumnForcesANSIOnWezTermWithVisibleNote(t *testing.T) {
 	setWezTermEnvironment(t)
 	m := NewWithImageMode("native")
-	m.configureColumns(2, FeedForYou, "", "")
+	m.configureColumns(repeatedColumnSpecs(2, FeedForYou, "", ""))
 	m.width, m.height = 120, 32
 	m.resize()
 	m.help = true
@@ -96,13 +96,13 @@ func TestMultiColumnForcesANSIOnWezTermWithVisibleNote(t *testing.T) {
 func TestWezTermPathNeverRunsMultiColumn(t *testing.T) {
 	setWezTermEnvironment(t)
 	m := NewWithImageMode("native")
-	m.configureColumns(1, FeedForYou, "", "")
+	m.configureColumns(repeatedColumnSpecs(1, FeedForYou, "", ""))
 	if m.imageMode != imageModeWezTerm {
 		t.Fatalf("single-column WezTerm mode=%q", m.imageMode)
 	}
 	_ = m.imageFrameKey()
 
-	m.configureColumns(2, FeedForYou, "", "")
+	m.configureColumns(repeatedColumnSpecs(2, FeedForYou, "", ""))
 	if m.imageMode == imageModeWezTerm {
 		t.Fatal("iTerm2-protocol renderer survived multi-column configuration")
 	}
@@ -414,7 +414,7 @@ func TestSelectedPostRequestsInlinePreview(t *testing.T) {
 
 func TestPreviewRequestsCoverVisibleNonFocusedColumns(t *testing.T) {
 	m := NewWithImageMode("ansi")
-	m.configureColumns(2, FeedForYou, "", "")
+	m.configureColumns(repeatedColumnSpecs(2, FeedForYou, "", ""))
 	m.width, m.height = 120, 30
 	for index, id := range []string{"left", "right"} {
 		c := &m.columns[index]
@@ -438,7 +438,7 @@ func TestPreviewRequestsCoverVisibleNonFocusedColumns(t *testing.T) {
 
 func TestPreviewArrivalRepaintsVisibleNonFocusedColumn(t *testing.T) {
 	m := NewWithImageMode("ansi")
-	m.configureColumns(2, FeedForYou, "", "")
+	m.configureColumns(repeatedColumnSpecs(2, FeedForYou, "", ""))
 	m.width, m.height = 120, 30
 	right := &m.columns[1]
 	right.loading = false
@@ -587,7 +587,7 @@ func TestPreviewCacheEvictsDistantEntries(t *testing.T) {
 
 func TestEvictionKeepsPreviewsVisibleInNonFocusedColumns(t *testing.T) {
 	m := NewWithImageMode("ansi")
-	m.configureColumns(2, FeedForYou, "", "")
+	m.configureColumns(repeatedColumnSpecs(2, FeedForYou, "", ""))
 	m.width = 120
 	m.columns[0].posts = []api.TimelinePost{{ID: "focused"}}
 	m.columns[1].posts = []api.TimelinePost{{ID: "non-focused"}}

--- a/internal/timeline/probe_test.go
+++ b/internal/timeline/probe_test.go
@@ -30,8 +30,8 @@ func TestParseProbeReply(t *testing.T) {
 
 func TestCtrlLTriggersRedraw(t *testing.T) {
 	m := New()
-	m.loading = false
-	m.posts = mediaPosts(2)
+	m.cur().loading = false
+	m.cur().posts = mediaPosts(2)
 	m.syncViewport()
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlL})
 	if cmd == nil {

--- a/internal/timeline/profile.go
+++ b/internal/timeline/profile.go
@@ -1,0 +1,74 @@
+package timeline
+
+import (
+	"context"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/melqtx/xeet/pkg/api"
+)
+
+// profileMsg carries the handle→id resolution for a FeedProfile column.
+// Posts only carry the author's handle while UserTweets pages by numeric id,
+// so opening a profile is two hops: resolve once, then page by id.
+type profileMsg struct {
+	colID  int
+	handle string
+	userID string
+	err    error
+}
+
+func resolveProfile(parent context.Context, colID int, accountID, handle string) tea.Cmd {
+	return func() tea.Msg {
+		mgr, err := openRequestConfigManager()
+		if err != nil {
+			return profileMsg{colID: colID, handle: handle, err: err}
+		}
+		cfg, err := loadRequestConfig(mgr, accountID)
+		if err != nil {
+			return profileMsg{colID: colID, handle: handle, err: err}
+		}
+		ctx, cancel := context.WithTimeout(parent, 30*time.Second)
+		defer cancel()
+		client := api.NewWebClient(cfg)
+		userID, err := client.FetchUserByScreenName(ctx, handle)
+		if client.ApplyRefreshedQueryIDs(cfg) {
+			_ = mgr.SaveQueryIDs(cfg)
+		}
+		return profileMsg{colID: colID, handle: handle, userID: userID, err: err}
+	}
+}
+
+// beginProfile switches the focused column to the selected post author's
+// timeline, in place — the same way f, b, L, and / replace the feed rather
+// than opening another column.
+func (m Model) beginProfile(post api.TimelinePost) (tea.Model, tea.Cmd) {
+	c := m.cur()
+	c.profileHandle = post.Handle
+	c.profileUserID = ""
+	// resetColumnFeed's fetch cmd is dropped on purpose: UserTweets cannot run
+	// until the handle resolves, so resolveProfile kicks the first page.
+	_ = m.resetColumnFeed(c, FeedProfile)
+	m.mode = modeFeed
+	m.syncViewport()
+	return m, m.imageRepaint(tea.Batch(m.spinner.Tick, resolveProfile(
+		m.requestContext(), c.id, c.accountID, post.Handle,
+	)))
+}
+
+func (m *Model) applyProfileResult(msg profileMsg) tea.Cmd {
+	c := m.columnByID(msg.colID)
+	if c == nil || c.feed != FeedProfile {
+		return nil
+	}
+	if msg.err != nil {
+		c.loading = false
+		c.err = msg.err
+		return m.showToast("couldn't load @" + msg.handle)
+	}
+	c.profileUserID = msg.userID
+	return tea.Batch(m.spinner.Tick, fetchPageSeq(
+		m.requestContext(), c.feed, c.searchQuery, c.listID, c.profileUserID, c.accountID, "", false, c.feedSeq, c.id, false,
+	))
+}

--- a/internal/timeline/profile_test.go
+++ b/internal/timeline/profile_test.go
@@ -1,0 +1,137 @@
+package timeline
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/melqtx/xeet/pkg/api"
+	"github.com/melqtx/xeet/pkg/config"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestFetchPageSeqRoutesProfileFeedToUserTweetsOperation(t *testing.T) {
+	secrets := &fakeRequestSecretStore{data: map[string]string{}}
+	manager := config.NewConfigManagerAt(t.TempDir(), secrets)
+	if err := manager.Save(&config.Config{
+		UserID: "42", Handle: "alice", AuthToken: "alice-auth", CT0: "alice-csrf",
+		UserTweetsQID: "ut-qid",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	useRequestConfigManager(t, manager)
+
+	originalTransport := http.DefaultTransport
+	var path, userID string
+	http.DefaultTransport = requestRoundTripper(func(request *http.Request) (*http.Response, error) {
+		path = request.URL.Path
+		userID = request.URL.Query().Get("variables")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"data":{"entries":[]}}`)),
+			Request:    request,
+		}, nil
+	})
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	msg := fetchPageSeq(
+		context.Background(), FeedProfile, "", "", "999", "42", "", false, 0, 0, false,
+	)().(pageMsg)
+	if msg.err != nil {
+		t.Fatalf("profile fetch: %v", msg.err)
+	}
+	if !strings.HasSuffix(path, "/UserTweets") {
+		t.Fatalf("request path = %q, want the UserTweets operation", path)
+	}
+	if !strings.Contains(userID, `"userId":"999"`) {
+		t.Fatalf("variables = %q, want the resolved user id", userID)
+	}
+}
+
+func TestProfileKeySwitchesFocusedColumn(t *testing.T) {
+	m := New()
+	m.cur().loading = false
+	m.cur().posts = posts(3)
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}})
+	m = next.(Model)
+	c := m.cur()
+	if cmd == nil {
+		t.Fatal("u produced no resolve request")
+	}
+	if c.feed != FeedProfile || c.profileHandle != "cat" || c.profileUserID != "" {
+		t.Fatalf("column after u: feed=%v handle=%q uid=%q", c.feed, c.profileHandle, c.profileUserID)
+	}
+	if !c.loading || len(c.posts) != 0 {
+		t.Fatalf("column was not reset for the profile: loading=%v posts=%d", c.loading, len(c.posts))
+	}
+}
+
+func TestProfileResolveSuccessStoresIDAndFetches(t *testing.T) {
+	m := New()
+	m.cur().loading = false
+	m.cur().posts = posts(3)
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}})
+	m = next.(Model)
+
+	cmd := m.applyProfileResult(profileMsg{colID: m.cur().id, handle: "cat", userID: "999"})
+	if cmd == nil {
+		t.Fatal("successful resolve kicked no first-page fetch")
+	}
+	if m.cur().profileUserID != "999" {
+		t.Fatalf("profileUserID = %q, want 999", m.cur().profileUserID)
+	}
+}
+
+func TestProfileResolveFailureSurfacesError(t *testing.T) {
+	m := New()
+	m.cur().loading = false
+	m.cur().posts = posts(3)
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}})
+	m = next.(Model)
+
+	m.applyProfileResult(profileMsg{colID: m.cur().id, handle: "cat", err: errors.New("boom")})
+	c := m.cur()
+	if c.err == nil || c.loading {
+		t.Fatalf("failed resolve: err=%v loading=%v", c.err, c.loading)
+	}
+	if !strings.Contains(m.toast, "couldn't load @cat") {
+		t.Fatalf("toast = %q", m.toast)
+	}
+}
+
+func TestProfileKeyFromThreadCollapsesToFeed(t *testing.T) {
+	m := New()
+	m.cur().loading = false
+	m.mode = modeThread
+	m.cur().threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "1", Text: "post", Handle: "alice"}}}
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}})
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("u in thread produced no resolve request")
+	}
+	if m.mode != modeFeed || m.cur().feed != FeedProfile || m.cur().profileHandle != "alice" {
+		t.Fatalf("mode=%v feed=%v handle=%q", m.mode, m.cur().feed, m.cur().profileHandle)
+	}
+}
+
+func TestProfileColumnLabels(t *testing.T) {
+	m := New()
+	m.cur().feed = FeedProfile
+	m.cur().profileHandle = "cat"
+	m.cur().loading = false
+
+	if status := m.columnFeedLabel(m.cur(), 40); status != "@cat" {
+		t.Fatalf("column label = %q, want @cat", status)
+	}
+	if label := m.searchBackLabel(); label != "back to @cat" {
+		t.Fatalf("search back label = %q", label)
+	}
+	if label := m.searchBackShortLabel(); label != "@cat" {
+		t.Fatalf("search back short label = %q", label)
+	}
+}

--- a/internal/timeline/pty_test.go
+++ b/internal/timeline/pty_test.go
@@ -53,8 +53,8 @@ func TestTimelinePTYHelper(t *testing.T) {
 		return
 	}
 	m := New()
-	m.loading = false
-	m.posts = []api.TimelinePost{
+	m.cur().loading = false
+	m.cur().posts = []api.TimelinePost{
 		{ID: "1", AuthorName: "Alice", Handle: "alice", Text: "hello from the PTY", LikeCount: 3},
 		{ID: "2", AuthorName: "Bob", Handle: "bob", Text: "unicode: 🐈 café 日本語", MediaCount: 1},
 	}

--- a/internal/timeline/pty_test.go
+++ b/internal/timeline/pty_test.go
@@ -53,7 +53,7 @@ func TestTimelinePTYHelper(t *testing.T) {
 		return
 	}
 	m := New()
-	m.configureColumns(2, FeedForYou, "", "")
+	m.configureColumns(repeatedColumnSpecs(2, FeedForYou, "", ""))
 	m.columns[0].loading = false
 	m.columns[0].posts = []api.TimelinePost{
 		{ID: "1", AuthorName: "Alice", Handle: "alice", Text: "hello from the PTY", LikeCount: 3},

--- a/internal/timeline/pty_test.go
+++ b/internal/timeline/pty_test.go
@@ -53,12 +53,17 @@ func TestTimelinePTYHelper(t *testing.T) {
 		return
 	}
 	m := New()
-	m.cur().loading = false
-	m.cur().posts = []api.TimelinePost{
+	m.configureColumns(2, FeedForYou, "", "")
+	m.columns[0].loading = false
+	m.columns[0].posts = []api.TimelinePost{
 		{ID: "1", AuthorName: "Alice", Handle: "alice", Text: "hello from the PTY", LikeCount: 3},
 		{ID: "2", AuthorName: "Bob", Handle: "bob", Text: "unicode: 🐈 café 日本語", MediaCount: 1},
 	}
-	m.syncViewport()
+	m.columns[1].loading = false
+	m.columns[1].posts = []api.TimelinePost{
+		{ID: "3", AuthorName: "Carol", Handle: "carol", Text: "second PTY column"},
+	}
+	m.resize()
 	if _, err := tea.NewProgram(ptyModel{Model: m}, tea.WithAltScreen(), tea.WithInput(os.Stdin), tea.WithOutput(os.Stdout)).Run(); err != nil {
 		t.Fatal(err)
 	}
@@ -115,7 +120,7 @@ func TestTimelinePTYNavigationResizeAndHelp(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 	output := captured.String()
-	for _, want := range []string{"xeet", "Alice", "search posts", "timeline keys"} {
+	for _, want := range []string{"xeet", "Alice", "search posts", "timeline keys", "+1 more (widen terminal)"} {
 		if !strings.Contains(output, want) {
 			t.Errorf("PTY output missing %q; output:\n%s", want, output)
 		}

--- a/internal/timeline/readability_test.go
+++ b/internal/timeline/readability_test.go
@@ -1,0 +1,114 @@
+package timeline
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/melqtx/xeet/pkg/api"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+)
+
+func TestViewColumnsDrawsSeparator(t *testing.T) {
+	m := modelWithNamedColumns("Alice", "Bob")
+	m = update(t, m, tea.WindowSizeMsg{Width: 100, Height: 24})
+
+	view := ansi.Strip(m.View())
+	for _, line := range strings.Split(view, "\n") {
+		if strings.Contains(line, "for you") && !strings.Contains(line, "│") {
+			t.Fatalf("the header row lost its column separator: %q\n%s", line, view)
+		}
+	}
+}
+
+func TestColumnHeadersAlignOnOneRow(t *testing.T) {
+	m := modelWithNamedColumns("Alice", "Bob", "Carol")
+	m = update(t, m, tea.WindowSizeMsg{Width: 160, Height: 24})
+
+	view := ansi.Strip(m.View())
+	for _, line := range strings.Split(view, "\n") {
+		if strings.Contains(line, "for you") {
+			if got := strings.Count(line, "for you"); got != 3 {
+				t.Fatalf("headers spread across rows, one row holds %d of 3:\n%s", got, view)
+			}
+			return
+		}
+	}
+	t.Fatalf("no header row found:\n%s", view)
+}
+
+func TestColumnHeaderShowsAccountWhenMultiple(t *testing.T) {
+	m := modelWithNamedColumns("Alice", "Bob")
+	m.accounts = twoAccounts()
+	m = update(t, m, tea.WindowSizeMsg{Width: 100, Height: 24})
+
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "@alice · for you") {
+		t.Fatalf("multi-account headers did not name their account:\n%s", view)
+	}
+}
+
+func TestColumnHeaderHidesAccountWhenSingle(t *testing.T) {
+	m := modelWithNamedColumns("Alice", "Bob")
+	m.accounts = twoAccounts()[:1]
+	m = update(t, m, tea.WindowSizeMsg{Width: 100, Height: 24})
+
+	view := ansi.Strip(m.View())
+	if strings.Contains(view, "@alice ·") {
+		t.Fatalf("single-account headers wasted space on the account name:\n%s", view)
+	}
+	if !strings.Contains(view, "▸ for you") {
+		t.Fatalf("single-account header lost its feed label:\n%s", view)
+	}
+}
+
+func TestPostTextKeepsLineBreaks(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.cur().loading = false
+	m.cur().posts = []api.TimelinePost{{
+		ID: "1", AuthorName: "Alice", Handle: "alice",
+		Text: "first  line\nsecond line\n\nthird line",
+	}}
+	m.syncViewport()
+
+	content, _, _ := m.renderFeedContent()
+	lines := strings.Split(ansi.Strip(content), "\n")
+	at := -1
+	for i, line := range lines {
+		if strings.Contains(line, "first line") {
+			at = i
+			break
+		}
+	}
+	if at < 0 {
+		t.Fatalf("post body missing:\n%s", content)
+	}
+	if !strings.Contains(lines[at+1], "second line") {
+		t.Fatalf("the second line did not stay on its own row:\n%s", content)
+	}
+	if !strings.Contains(lines[at+2], "third line") {
+		t.Fatalf("the blank line was not dropped before the third line:\n%s", content)
+	}
+	if got := cleanText("a  b\r\n\nc"); got != "a b\nc" {
+		t.Fatalf("cleanText = %q, want whitespace collapsed per line with blanks dropped", got)
+	}
+}
+
+func TestSelectedPostUsesHeavyMarker(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.cur().loading = false
+	m.cur().posts = []api.TimelinePost{
+		{ID: "1", AuthorName: "Alice", Handle: "alice", Text: "chosen"},
+		{ID: "2", AuthorName: "Bob", Handle: "bob", Text: "not chosen"},
+	}
+	m.cur().selected = 0
+	m.syncViewport()
+
+	content, _, _ := m.renderFeedContent()
+	for _, line := range strings.Split(ansi.Strip(content), "\n") {
+		if strings.Contains(line, "Alice") && !strings.Contains(line, "▌") {
+			t.Fatalf("the selected post lost its heavy marker: %q\n%s", line, content)
+		}
+	}
+}

--- a/internal/timeline/reply.go
+++ b/internal/timeline/reply.go
@@ -77,6 +77,10 @@ func (m Model) updateReply(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Same as the like above: settle without surfacing anything.
 		m.settleRepost(msg)
 		return m, nil
+	case profileMsg:
+		// Resolution keeps moving under the composer; its pageMsg lands in
+		// this same switch.
+		return m, m.applyProfileResult(msg)
 	case previewMsg:
 		m.storePreview(msg)
 		return m, nil

--- a/internal/timeline/reply.go
+++ b/internal/timeline/reply.go
@@ -77,6 +77,10 @@ func (m Model) updateReply(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Same as the like above: settle without surfacing anything.
 		m.settleRepost(msg)
 		return m, nil
+	case bookmarkMsg:
+		// Same as the like above: settle without surfacing anything.
+		m.settleBookmark(msg)
+		return m, nil
 	case profileMsg:
 		// Resolution keeps moving under the composer; its pageMsg lands in
 		// this same switch.

--- a/internal/timeline/reply.go
+++ b/internal/timeline/reply.go
@@ -15,7 +15,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-func sendReply(parent context.Context, accountID, tweetID, text string) tea.Cmd {
+func sendReply(parent context.Context, accountID, tweetID, quoteID, text string) tea.Cmd {
 	return func() tea.Msg {
 		mgr, err := openRequestConfigManager()
 		if err != nil {
@@ -28,7 +28,7 @@ func sendReply(parent context.Context, accountID, tweetID, text string) tea.Cmd 
 		ctx, cancel := context.WithTimeout(parent, 40*time.Second)
 		defer cancel()
 		client := api.NewWebClient(cfg)
-		id, err := client.PostTweet(ctx, text, tweetID, nil, nil)
+		id, err := client.PostTweet(ctx, text, tweetID, quoteID, nil, nil)
 		if client.ApplyRefreshedQueryIDs(cfg) {
 			_ = mgr.SaveQueryIDs(cfg)
 		}
@@ -46,6 +46,17 @@ func (m Model) beginReply(post api.TimelinePost) (tea.Model, tea.Cmd) {
 	m.replyEditor.Reset()
 	m.resize()
 	return m, m.imageRepaint(m.replyEditor.Focus())
+}
+
+// beginQuote reuses the reply composer state wholesale: the only difference
+// is the mode flag, which decides whether the post id goes out as a reply
+// target or a quote attachment. Sharing the fields keeps the two from
+// drifting apart.
+func (m Model) beginQuote(post api.TimelinePost) (tea.Model, tea.Cmd) {
+	next, cmd := m.beginReply(post)
+	model := next.(Model)
+	model.mode = modeQuote
+	return model, cmd
 }
 
 func (m Model) updateReply(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -82,10 +93,14 @@ func (m Model) updateReply(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.replyNotice = ""
 			return m, m.replyEditor.Focus()
 		}
+		quoting := m.mode == modeQuote
 		m.mode = m.replyReturn
 		m.replyEditor.Blur()
 		m.replyEditor.Reset()
 		toast := m.showToast("reply sent ♥")
+		if quoting {
+			toast = m.showToast("quote sent ♥")
+		}
 		m.syncViewport()
 		m.ensureSelectedVisible()
 		if m.mode == modeThread {
@@ -123,15 +138,25 @@ func (m Model) updateReply(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, m.imageRepaint(m.requestPreviews())
 		case "enter":
 			if strings.TrimSpace(m.replyEditor.Value()) == "" {
-				m.replyErr = fmt.Errorf("write a reply first")
+				if m.mode == modeQuote {
+					m.replyErr = fmt.Errorf("write the quote text first")
+				} else {
+					m.replyErr = fmt.Errorf("write a reply first")
+				}
 				return m, nil
 			}
 			m.replyPosting = true
 			m.replyErr = nil
 			m.replyNotice = ""
 			m.replyEditor.Blur()
+			// A reply carries the target as in_reply_to_tweet_id; a quote
+			// carries it as attachment_url. Never both.
+			replyTo, quoteID := m.replyPost.ID, ""
+			if m.mode == modeQuote {
+				replyTo, quoteID = "", m.replyPost.ID
+			}
 			return m, tea.Batch(m.spinner.Tick, sendReply(
-				m.requestContext(), m.replyAccountID, m.replyPost.ID, m.replyEditor.Value(),
+				m.requestContext(), m.replyAccountID, replyTo, quoteID, m.replyEditor.Value(),
 			))
 		case "alt+enter", "ctrl+j":
 			m.replyEditor.InsertString("\n")

--- a/internal/timeline/reply.go
+++ b/internal/timeline/reply.go
@@ -31,7 +31,7 @@ func sendReply(parent context.Context, tweetID, text string) tea.Cmd {
 		client := api.NewWebClient(cfg)
 		id, err := client.PostTweet(ctx, text, tweetID, nil, nil)
 		if client.ApplyRefreshedQueryIDs(cfg) {
-			_ = mgr.Save(cfg)
+			_ = mgr.SaveQueryIDs(cfg)
 		}
 		return replyResultMsg{id: id, err: err}
 	}

--- a/internal/timeline/reply.go
+++ b/internal/timeline/reply.go
@@ -85,8 +85,8 @@ func (m Model) updateReply(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.syncViewport()
 		m.ensureSelectedVisible()
 		if m.mode == modeThread {
-			m.threadLoading = true
-			m.threadMore = false
+			m.cur().threadLoading = true
+			m.cur().threadMore = false
 			return m, m.imageRepaint(tea.Batch(toast, m.spinner.Tick, m.requestThread("", false)))
 		}
 		return m, m.imageRepaint(toast)

--- a/internal/timeline/reply.go
+++ b/internal/timeline/reply.go
@@ -10,19 +10,18 @@ import (
 	"time"
 
 	"github.com/melqtx/xeet/pkg/api"
-	"github.com/melqtx/xeet/pkg/config"
 
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-func sendReply(parent context.Context, tweetID, text string) tea.Cmd {
+func sendReply(parent context.Context, accountID, tweetID, text string) tea.Cmd {
 	return func() tea.Msg {
-		mgr, err := config.NewConfigManager()
+		mgr, err := openRequestConfigManager()
 		if err != nil {
 			return replyResultMsg{err: err}
 		}
-		cfg, err := mgr.Load()
+		cfg, err := loadRequestConfig(mgr, accountID)
 		if err != nil {
 			return replyResultMsg{err: err}
 		}
@@ -41,6 +40,7 @@ func (m Model) beginReply(post api.TimelinePost) (tea.Model, tea.Cmd) {
 	m.replyReturn = m.mode
 	m.mode = modeReply
 	m.replyPost = post
+	m.replyAccountID = m.cur().accountID
 	m.replyErr = nil
 	m.replyNotice = ""
 	m.replyEditor.Reset()
@@ -126,7 +126,9 @@ func (m Model) updateReply(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.replyErr = nil
 			m.replyNotice = ""
 			m.replyEditor.Blur()
-			return m, tea.Batch(m.spinner.Tick, sendReply(m.requestContext(), m.replyPost.ID, m.replyEditor.Value()))
+			return m, tea.Batch(m.spinner.Tick, sendReply(
+				m.requestContext(), m.replyAccountID, m.replyPost.ID, m.replyEditor.Value(),
+			))
 		case "alt+enter", "ctrl+j":
 			m.replyEditor.InsertString("\n")
 			return m, nil

--- a/internal/timeline/reply.go
+++ b/internal/timeline/reply.go
@@ -62,6 +62,10 @@ func (m Model) updateReply(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// toast, and no re-render of a list nobody can see.
 		m.settleLike(msg)
 		return m, nil
+	case retweetMsg:
+		// Same as the like above: settle without surfacing anything.
+		m.settleRepost(msg)
+		return m, nil
 	case previewMsg:
 		m.storePreview(msg)
 		return m, nil

--- a/internal/timeline/search.go
+++ b/internal/timeline/search.go
@@ -19,7 +19,7 @@ func (m Model) cancelSearch() (tea.Model, tea.Cmd) {
 	// `xeet search` starts directly in an empty prompt. There is no previous
 	// feed to reveal in that case, so escape should leave instead of exposing
 	// an empty search-results screen.
-	if m.searchReturn == modeFeed && m.feed == FeedSearch && m.searchQuery == "" && len(m.posts) == 0 {
+	if m.searchReturn == modeFeed && m.cur().feed == FeedSearch && m.cur().searchQuery == "" && len(m.cur().posts) == 0 {
 		return m, tea.Quit
 	}
 	m.mode = m.searchReturn

--- a/internal/timeline/search.go
+++ b/internal/timeline/search.go
@@ -57,6 +57,8 @@ func (m Model) updateSearch(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case retweetMsg:
 		m.settleRepost(msg)
 		return m, nil
+	case profileMsg:
+		return m, m.applyProfileResult(msg)
 	case previewMsg:
 		m.storePreview(msg)
 		return m, nil

--- a/internal/timeline/search.go
+++ b/internal/timeline/search.go
@@ -9,13 +9,27 @@ import (
 
 func (m *Model) beginSearch() tea.Cmd {
 	m.searchReturn = m.mode
-	m.searchInput.SetValue(m.cur().searchQuery)
+	if m.searchFor == targetNewColumn {
+		m.searchInput.SetValue(m.columnDraft.Query)
+	} else {
+		m.searchInput.SetValue(m.cur().searchQuery)
+	}
 	m.mode = modeSearch
 	return m.imageRepaint(m.searchInput.Focus())
 }
 
 func (m Model) cancelSearch() (tea.Model, tea.Cmd) {
 	m.searchInput.Blur()
+	if m.searchFor == targetNewColumn {
+		// Escape abandons the whole add-column draft; it never quits, unlike
+		// the direct `xeet search` prompt below.
+		m.searchFor = targetFocusedColumn
+		m.columnDraft = ColumnSpec{}
+		m.mode = modeFeed
+		m.syncViewport()
+		m.ensureSelectedVisible()
+		return m, m.imageRepaint(m.requestPreviews())
+	}
 	// `xeet search` starts directly in an empty prompt. There is no previous
 	// feed to reveal in that case, so escape should leave instead of exposing
 	// an empty search-results screen.
@@ -59,6 +73,13 @@ func (m Model) updateSearch(msg tea.Msg) (tea.Model, tea.Cmd) {
 			query := strings.TrimSpace(m.searchInput.Value())
 			if query == "" {
 				return m.cancelSearch()
+			}
+			if m.searchFor == targetNewColumn {
+				m.columnDraft.Kind = FeedSearch
+				m.columnDraft.Query = query
+				m.searchFor = targetFocusedColumn
+				m.searchInput.Blur()
+				return m, m.beginAccountPicker("new column · account", intentColumnAccount)
 			}
 			m.cur().searchQuery = query
 			m.searchInput.Blur()

--- a/internal/timeline/search.go
+++ b/internal/timeline/search.go
@@ -57,6 +57,9 @@ func (m Model) updateSearch(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case retweetMsg:
 		m.settleRepost(msg)
 		return m, nil
+	case bookmarkMsg:
+		m.settleBookmark(msg)
+		return m, nil
 	case profileMsg:
 		return m, m.applyProfileResult(msg)
 	case previewMsg:

--- a/internal/timeline/search.go
+++ b/internal/timeline/search.go
@@ -9,7 +9,7 @@ import (
 
 func (m *Model) beginSearch() tea.Cmd {
 	m.searchReturn = m.mode
-	m.searchInput.SetValue(m.searchQuery)
+	m.searchInput.SetValue(m.cur().searchQuery)
 	m.mode = modeSearch
 	return m.imageRepaint(m.searchInput.Focus())
 }
@@ -44,7 +44,7 @@ func (m Model) updateSearch(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.storePreview(msg)
 		return m, nil
 	case spinner.TickMsg:
-		if m.loading || m.loadingMore || m.refreshing || m.threadLoading || m.threadMore {
+		if m.cur().loading || m.cur().loadingMore || m.cur().refreshing || m.cur().threadLoading || m.cur().threadMore {
 			var cmd tea.Cmd
 			m.spinner, cmd = m.spinner.Update(msg)
 			return m, cmd
@@ -60,7 +60,7 @@ func (m Model) updateSearch(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if query == "" {
 				return m.cancelSearch()
 			}
-			m.searchQuery = query
+			m.cur().searchQuery = query
 			m.searchInput.Blur()
 			m.mode = modeFeed
 			return m, m.setFeed(FeedSearch)

--- a/internal/timeline/search.go
+++ b/internal/timeline/search.go
@@ -54,6 +54,9 @@ func (m Model) updateSearch(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case likeMsg:
 		m.settleLike(msg)
 		return m, nil
+	case retweetMsg:
+		m.settleRepost(msg)
+		return m, nil
 	case previewMsg:
 		m.storePreview(msg)
 		return m, nil

--- a/internal/timeline/search_test.go
+++ b/internal/timeline/search_test.go
@@ -188,9 +188,9 @@ func TestSearchPromptExplainsWhereEscapeReturns(t *testing.T) {
 			m := NewWithImageMode("off")
 			m.width = 80
 			m.height = 24
-			m.loading = false
-			m.feed = test.feed
-			m.searchQuery = test.query
+			m.cur().loading = false
+			m.cur().feed = test.feed
+			m.cur().searchQuery = test.query
 			m.mode = modeSearch
 			m.searchReturn = test.returnMode
 			if view := m.View(); !strings.Contains(view, test.want) {
@@ -202,8 +202,8 @@ func TestSearchPromptExplainsWhereEscapeReturns(t *testing.T) {
 
 func TestFreshSearchCommandEscapeQuits(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.loading = false
-	m.feed = FeedSearch
+	m.cur().loading = false
+	m.cur().feed = FeedSearch
 	m.mode = modeSearch
 	m.searchReturn = modeFeed
 
@@ -222,22 +222,22 @@ func TestSearchResultsHavePurposeBuiltLoadingEmptyAndErrorStates(t *testing.T) {
 	m.width = 80
 	m.height = 24
 	m.resize()
-	m.feed = FeedSearch
-	m.searchQuery = "from:alice terminal ui"
+	m.cur().feed = FeedSearch
+	m.cur().searchQuery = "from:alice terminal ui"
 
 	if view := m.View(); !strings.Contains(view, "searching “from:alice terminal ui”…") ||
 		!strings.Contains(view, "/ edit search") {
 		t.Fatalf("search loading state is unclear:\n%s", view)
 	}
 
-	m.loading = false
+	m.cur().loading = false
 	if view := m.View(); !strings.Contains(view, "no posts found") ||
 		!strings.Contains(view, "try fewer words") ||
 		!strings.Contains(view, "f for you") {
 		t.Fatalf("search empty state is unclear:\n%s", view)
 	}
 
-	m.err = errors.New("offline")
+	m.cur().err = errors.New("offline")
 	if view := m.View(); !strings.Contains(view, "search couldn't reach X") ||
 		!strings.Contains(view, "R retry") ||
 		!strings.Contains(view, "/ edit search") {
@@ -248,10 +248,10 @@ func TestSearchResultsHavePurposeBuiltLoadingEmptyAndErrorStates(t *testing.T) {
 func TestSearchResultsFooterPrioritizesEditingTheQuery(t *testing.T) {
 	m := NewWithImageMode("off")
 	m.width = 80
-	m.loading = false
-	m.feed = FeedSearch
-	m.searchQuery = "cats"
-	m.posts = []api.TimelinePost{{ID: "1", Text: "cat"}}
+	m.cur().loading = false
+	m.cur().feed = FeedSearch
+	m.cur().searchQuery = "cats"
+	m.cur().posts = []api.TimelinePost{{ID: "1", Text: "cat"}}
 
 	footer := m.footer()
 	for _, want := range []string{"/ edit search", "R refresh", "enter replies"} {
@@ -266,15 +266,15 @@ func TestSearchResultStatesStayInsideTerminal(t *testing.T) {
 		for _, state := range []string{"loading", "empty", "error"} {
 			t.Run(fmt.Sprintf("%dx%d/%s", size.width, size.height, state), func(t *testing.T) {
 				m := NewWithImageMode("off")
-				m.feed = FeedSearch
-				m.searchQuery = strings.Repeat("猫 terminal ", 20)
+				m.cur().feed = FeedSearch
+				m.cur().searchQuery = strings.Repeat("猫 terminal ", 20)
 				m = update(t, m, tea.WindowSizeMsg{Width: size.width, Height: size.height})
 				switch state {
 				case "empty":
-					m.loading = false
+					m.cur().loading = false
 				case "error":
-					m.loading = false
-					m.err = errors.New("offline")
+					m.cur().loading = false
+					m.cur().err = errors.New("offline")
 				}
 
 				view := m.View()

--- a/internal/timeline/search_test.go
+++ b/internal/timeline/search_test.go
@@ -14,9 +14,9 @@ import (
 
 func TestSearchPromptOpensFromFeedWithPreviousQuery(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.loading = false
-	m.feed = FeedBookmarks
-	m.searchQuery = "from:alice cats"
+	m.cur().loading = false
+	m.cur().feed = FeedBookmarks
+	m.cur().searchQuery = "from:alice cats"
 
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
 	m = next.(Model)
@@ -24,8 +24,8 @@ func TestSearchPromptOpensFromFeedWithPreviousQuery(t *testing.T) {
 	if cmd == nil || m.mode != modeSearch || m.searchReturn != modeFeed {
 		t.Fatalf("search prompt did not open from feed: mode=%v return=%v cmd=%v", m.mode, m.searchReturn, cmd)
 	}
-	if m.feed != FeedBookmarks {
-		t.Fatalf("opening search changed the feed to %v; it should stay until a query is submitted", m.feed)
+	if m.cur().feed != FeedBookmarks {
+		t.Fatalf("opening search changed the feed to %v; it should stay until a query is submitted", m.cur().feed)
 	}
 	if got := m.searchInput.Value(); got != "from:alice cats" || !m.searchInput.Focused() {
 		t.Fatalf("search input was not pre-filled and focused: value=%q focused=%v", got, m.searchInput.Focused())
@@ -34,40 +34,40 @@ func TestSearchPromptOpensFromFeedWithPreviousQuery(t *testing.T) {
 
 func TestSearchPromptOpensFromThreadAndEscRestoresThread(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.loading = false
-	m.feed = FeedFollowing
-	m.searchQuery = "original"
+	m.cur().loading = false
+	m.cur().feed = FeedFollowing
+	m.cur().searchQuery = "original"
 	m.mode = modeThread
-	m.threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}}}
+	m.cur().threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}}}
 	m.syncViewport()
 
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
 	m.searchInput.SetValue("edited but cancelled")
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyEsc})
 
-	if m.mode != modeThread || m.feed != FeedFollowing {
-		t.Fatalf("esc did not restore the thread without changing feed: mode=%v feed=%v", m.mode, m.feed)
+	if m.mode != modeThread || m.cur().feed != FeedFollowing {
+		t.Fatalf("esc did not restore the thread without changing feed: mode=%v feed=%v", m.mode, m.cur().feed)
 	}
-	if m.searchQuery != "original" || m.searchInput.Focused() {
-		t.Fatalf("esc changed the query or kept focus: query=%q focused=%v", m.searchQuery, m.searchInput.Focused())
+	if m.cur().searchQuery != "original" || m.searchInput.Focused() {
+		t.Fatalf("esc changed the query or kept focus: query=%q focused=%v", m.cur().searchQuery, m.searchInput.Focused())
 	}
 }
 
 func TestEmptySearchSubmissionCancelsExactlyLikeEsc(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.loading = false
-	m.feed = FeedBookmarks
-	m.searchQuery = "keep me"
+	m.cur().loading = false
+	m.cur().feed = FeedBookmarks
+	m.cur().searchQuery = "keep me"
 	m.mode = modeThread
-	m.threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}}}
+	m.cur().threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}}}
 	m.syncViewport()
 
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
 	m.searchInput.SetValue(" \t ")
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyEnter})
 
-	if m.mode != modeThread || m.feed != FeedBookmarks || m.searchQuery != "keep me" {
-		t.Fatalf("empty enter did not cancel: mode=%v feed=%v query=%q", m.mode, m.feed, m.searchQuery)
+	if m.mode != modeThread || m.cur().feed != FeedBookmarks || m.cur().searchQuery != "keep me" {
+		t.Fatalf("empty enter did not cancel: mode=%v feed=%v query=%q", m.mode, m.cur().feed, m.cur().searchQuery)
 	}
 	if m.searchInput.Focused() {
 		t.Fatal("empty enter left the search input focused")
@@ -76,12 +76,12 @@ func TestEmptySearchSubmissionCancelsExactlyLikeEsc(t *testing.T) {
 
 func TestNonEmptySearchSubmissionLeavesThreadForSearchFeed(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.loading = false
-	m.feed = FeedBookmarks
-	m.feedSeq = 4
-	m.posts = []api.TimelinePost{{ID: "old", Text: "old"}}
+	m.cur().loading = false
+	m.cur().feed = FeedBookmarks
+	m.cur().feedSeq = 4
+	m.cur().posts = []api.TimelinePost{{ID: "old", Text: "old"}}
 	m.mode = modeThread
-	m.threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}}}
+	m.cur().threadPosts = []api.ConversationPost{{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}}}
 	m.syncViewport()
 
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
@@ -89,54 +89,54 @@ func TestNonEmptySearchSubmissionLeavesThreadForSearchFeed(t *testing.T) {
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = next.(Model)
 
-	if cmd == nil || m.mode != modeFeed || m.feed != FeedSearch {
-		t.Fatalf("search did not become a feed: mode=%v feed=%v cmd=%v", m.mode, m.feed, cmd)
+	if cmd == nil || m.mode != modeFeed || m.cur().feed != FeedSearch {
+		t.Fatalf("search did not become a feed: mode=%v feed=%v cmd=%v", m.mode, m.cur().feed, cmd)
 	}
-	if m.searchQuery != "golang tui" || m.feedSeq != 5 {
-		t.Fatalf("search query or stale-page sequence is wrong: query=%q seq=%d", m.searchQuery, m.feedSeq)
+	if m.cur().searchQuery != "golang tui" || m.cur().feedSeq != 5 {
+		t.Fatalf("search query or stale-page sequence is wrong: query=%q seq=%d", m.cur().searchQuery, m.cur().feedSeq)
 	}
-	if len(m.posts) != 0 || !m.loading || m.searchInput.Focused() {
-		t.Fatalf("search feed was not reset for its first page: posts=%d loading=%v focused=%v", len(m.posts), m.loading, m.searchInput.Focused())
+	if len(m.cur().posts) != 0 || !m.cur().loading || m.searchInput.Focused() {
+		t.Fatalf("search feed was not reset for its first page: posts=%d loading=%v focused=%v", len(m.cur().posts), m.cur().loading, m.searchInput.Focused())
 	}
 }
 
 func TestSearchPromptKeepsThreadSelectionDuringBackgroundFeedPage(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.loading = false
-	m.posts = []api.TimelinePost{{ID: "a", Text: "a"}, {ID: "root", Text: "root"}}
-	m.feedSelected = 1
+	m.cur().loading = false
+	m.cur().posts = []api.TimelinePost{{ID: "a", Text: "a"}, {ID: "root", Text: "root"}}
+	m.cur().feedSelected = 1
 	m.mode = modeThread
-	m.threadPosts = []api.ConversationPost{
+	m.cur().threadPosts = []api.ConversationPost{
 		{TimelinePost: api.TimelinePost{ID: "root", Text: "root"}},
 		{TimelinePost: api.TimelinePost{ID: "reply", Text: "reply"}, Depth: 1},
 	}
-	m.selected = 1
+	m.cur().selected = 1
 	m.syncViewport()
 
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
 	m = update(t, m, pageMsg{page: &api.TimelinePage{Posts: []api.TimelinePost{{ID: "new", Text: "new"}}}})
 
-	if m.mode != modeSearch || m.selected != 1 || m.feedSelected != 2 {
-		t.Fatalf("background feed page corrupted selections: mode=%v thread=%d feed=%d", m.mode, m.selected, m.feedSelected)
+	if m.mode != modeSearch || m.cur().selected != 1 || m.cur().feedSelected != 2 {
+		t.Fatalf("background feed page corrupted selections: mode=%v thread=%d feed=%d", m.mode, m.cur().selected, m.cur().feedSelected)
 	}
 	m = update(t, m, tea.KeyMsg{Type: tea.KeyEsc})
-	if m.mode != modeThread || m.threadPosts[m.selected].ID != "reply" {
-		t.Fatalf("cancel did not reveal the same thread selection: mode=%v selected=%d", m.mode, m.selected)
+	if m.mode != modeThread || m.cur().threadPosts[m.cur().selected].ID != "reply" {
+		t.Fatalf("cancel did not reveal the same thread selection: mode=%v selected=%d", m.mode, m.cur().selected)
 	}
 }
 
 func TestRefreshSearchFeedKeepsQuery(t *testing.T) {
 	m := NewWithImageMode("off")
-	m.loading = false
-	m.feed = FeedSearch
-	m.searchQuery = "golang tui"
-	m.posts = []api.TimelinePost{{ID: "result", Text: "result"}}
+	m.cur().loading = false
+	m.cur().feed = FeedSearch
+	m.cur().searchQuery = "golang tui"
+	m.cur().posts = []api.TimelinePost{{ID: "result", Text: "result"}}
 
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'R'}})
 	m = next.(Model)
 
-	if cmd == nil || !m.refreshing || m.feed != FeedSearch || m.searchQuery != "golang tui" {
-		t.Fatalf("R did not refresh the same search: refreshing=%v feed=%v query=%q cmd=%v", m.refreshing, m.feed, m.searchQuery, cmd)
+	if cmd == nil || !m.cur().refreshing || m.cur().feed != FeedSearch || m.cur().searchQuery != "golang tui" {
+		t.Fatalf("R did not refresh the same search: refreshing=%v feed=%v query=%q cmd=%v", m.cur().refreshing, m.cur().feed, m.cur().searchQuery, cmd)
 	}
 }
 
@@ -144,9 +144,9 @@ func TestSearchViewAndHeaderExposeQueryWithinWidth(t *testing.T) {
 	m := NewWithImageMode("off")
 	m.width = 42
 	m.height = 15
-	m.loading = false
-	m.feed = FeedSearch
-	m.searchQuery = strings.Repeat("long query ", 10)
+	m.cur().loading = false
+	m.cur().feed = FeedSearch
+	m.cur().searchQuery = strings.Repeat("long query ", 10)
 	m.beginSearch()
 
 	view := m.View()

--- a/internal/timeline/thread.go
+++ b/internal/timeline/thread.go
@@ -32,7 +32,7 @@ func fetchThread(parent context.Context, tweetID, cursor string, more bool, seq,
 		client := api.NewWebClient(cfg)
 		page, err := client.FetchTweetDetail(ctx, tweetID, cursor, 40)
 		if client.ApplyRefreshedQueryIDs(cfg) {
-			_ = mgr.Save(cfg)
+			_ = mgr.SaveQueryIDs(cfg)
 		}
 		return threadMsg{rootID: tweetID, seq: seq, colID: colID, page: page, err: err, more: more}
 	}

--- a/internal/timeline/thread.go
+++ b/internal/timeline/thread.go
@@ -11,19 +11,18 @@ import (
 	"time"
 
 	"github.com/melqtx/xeet/pkg/api"
-	"github.com/melqtx/xeet/pkg/config"
 
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-func fetchThread(parent context.Context, tweetID, cursor string, more bool, seq, colID int) tea.Cmd {
+func fetchThread(parent context.Context, accountID, tweetID, cursor string, more bool, seq, colID int) tea.Cmd {
 	return func() tea.Msg {
-		mgr, err := config.NewConfigManager()
+		mgr, err := openRequestConfigManager()
 		if err != nil {
 			return threadMsg{rootID: tweetID, seq: seq, colID: colID, err: err, more: more}
 		}
-		cfg, err := mgr.Load()
+		cfg, err := loadRequestConfig(mgr, accountID)
 		if err != nil {
 			return threadMsg{rootID: tweetID, seq: seq, colID: colID, err: err, more: more}
 		}
@@ -41,7 +40,7 @@ func fetchThread(parent context.Context, tweetID, cursor string, more bool, seq,
 func (m *Model) requestThread(cursor string, more bool) tea.Cmd {
 	c := m.cur()
 	c.threadSeq++
-	return fetchThread(m.requestContext(), c.threadRootID, cursor, more, c.threadSeq, c.id)
+	return fetchThread(m.requestContext(), c.accountID, c.threadRootID, cursor, more, c.threadSeq, c.id)
 }
 
 func (m Model) applyThreadPage(msg threadMsg, repaint bool) (tea.Model, tea.Cmd) {

--- a/internal/timeline/thread.go
+++ b/internal/timeline/thread.go
@@ -180,6 +180,8 @@ func (m Model) updateThread(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.applyLikeResult(msg)
 	case retweetMsg:
 		return m, m.applyRepostResult(msg)
+	case profileMsg:
+		return m, m.applyProfileResult(msg)
 	case previewMsg:
 		return m, m.applyPreview(msg)
 	case actionMsg:
@@ -254,6 +256,10 @@ func (m Model) updateThread(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case "Q":
 		if post, ok := m.currentPost(); ok {
 			return m.beginQuote(post)
+		}
+	case "u":
+		if post, ok := m.currentPost(); ok {
+			return m.beginProfile(post)
 		}
 	case "/":
 		return m, m.beginSearch()

--- a/internal/timeline/thread.go
+++ b/internal/timeline/thread.go
@@ -180,6 +180,8 @@ func (m Model) updateThread(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.applyLikeResult(msg)
 	case retweetMsg:
 		return m, m.applyRepostResult(msg)
+	case bookmarkMsg:
+		return m, m.applyBookmarkResult(msg)
 	case profileMsg:
 		return m, m.applyProfileResult(msg)
 	case previewMsg:
@@ -278,6 +280,8 @@ func (m Model) updateThread(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.toggleSelectedLike()
 	case "t":
 		return m, m.toggleSelectedRepost()
+	case "B":
+		return m, m.toggleSelectedBookmark()
 	case "y":
 		return m, m.copySelectedLink()
 	}

--- a/internal/timeline/thread.go
+++ b/internal/timeline/thread.go
@@ -178,6 +178,8 @@ func (m Model) updateThread(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.applyThreadPage(msg, true)
 	case likeMsg:
 		return m, m.applyLikeResult(msg)
+	case retweetMsg:
+		return m, m.applyRepostResult(msg)
 	case previewMsg:
 		return m, m.applyPreview(msg)
 	case actionMsg:
@@ -264,6 +266,8 @@ func (m Model) updateThread(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.zoomSelected()
 	case "l":
 		return m, m.toggleSelectedLike()
+	case "t":
+		return m, m.toggleSelectedRepost()
 	case "y":
 		return m, m.copySelectedLink()
 	}

--- a/internal/timeline/thread.go
+++ b/internal/timeline/thread.go
@@ -251,6 +251,10 @@ func (m Model) updateThread(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if post, ok := m.currentPost(); ok {
 			return m.beginReply(post)
 		}
+	case "Q":
+		if post, ok := m.currentPost(); ok {
+			return m.beginQuote(post)
+		}
 	case "/":
 		return m, m.beginSearch()
 	case "enter", " ", "e":

--- a/internal/timeline/thread.go
+++ b/internal/timeline/thread.go
@@ -17,15 +17,15 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-func fetchThread(parent context.Context, tweetID, cursor string, more bool, seq int) tea.Cmd {
+func fetchThread(parent context.Context, tweetID, cursor string, more bool, seq, colID int) tea.Cmd {
 	return func() tea.Msg {
 		mgr, err := config.NewConfigManager()
 		if err != nil {
-			return threadMsg{rootID: tweetID, seq: seq, err: err, more: more}
+			return threadMsg{rootID: tweetID, seq: seq, colID: colID, err: err, more: more}
 		}
 		cfg, err := mgr.Load()
 		if err != nil {
-			return threadMsg{rootID: tweetID, seq: seq, err: err, more: more}
+			return threadMsg{rootID: tweetID, seq: seq, colID: colID, err: err, more: more}
 		}
 		ctx, cancel := context.WithTimeout(parent, 40*time.Second)
 		defer cancel()
@@ -34,39 +34,41 @@ func fetchThread(parent context.Context, tweetID, cursor string, more bool, seq 
 		if client.ApplyRefreshedQueryIDs(cfg) {
 			_ = mgr.Save(cfg)
 		}
-		return threadMsg{rootID: tweetID, seq: seq, page: page, err: err, more: more}
+		return threadMsg{rootID: tweetID, seq: seq, colID: colID, page: page, err: err, more: more}
 	}
 }
 
 func (m *Model) requestThread(cursor string, more bool) tea.Cmd {
-	m.threadSeq++
-	return fetchThread(m.requestContext(), m.threadRootID, cursor, more, m.threadSeq)
+	c := m.cur()
+	c.threadSeq++
+	return fetchThread(m.requestContext(), c.threadRootID, cursor, more, c.threadSeq, c.id)
 }
 
 func (m Model) applyThreadPage(msg threadMsg, repaint bool) (tea.Model, tea.Cmd) {
-	if msg.rootID != m.threadRootID || msg.seq != m.threadSeq {
+	c := m.columnByID(msg.colID)
+	if c == nil || msg.rootID != c.threadRootID || msg.seq != c.threadSeq {
 		return m, nil
 	}
-	m.threadLoading = false
-	m.threadMore = false
+	c.threadLoading = false
+	c.threadMore = false
 	if msg.err != nil {
-		m.threadErr = msg.err
+		c.threadErr = msg.err
 		return m, nil
 	}
-	m.threadErr = nil
+	c.threadErr = nil
 	selectedID := ""
-	if m.selected >= 0 && m.selected < len(m.threadPosts) {
-		selectedID = m.threadPosts[m.selected].ID
+	if c.selected >= 0 && c.selected < len(c.threadPosts) {
+		selectedID = c.threadPosts[c.selected].ID
 	}
 	seen := map[string]bool{}
 	var merged []api.ConversationPost
 	if msg.more {
-		merged = append(merged, m.threadPosts...)
+		merged = append(merged, c.threadPosts...)
 		for _, post := range merged {
 			seen[post.ID] = true
 		}
 	}
-	for _, post := range m.resolveConversationPosts(msg.page) {
+	for _, post := range c.resolveConversationPosts(msg.page) {
 		if !seen[post.ID] {
 			merged = append(merged, post)
 			seen[post.ID] = true
@@ -75,19 +77,19 @@ func (m Model) applyThreadPage(msg threadMsg, repaint bool) (tea.Model, tea.Cmd)
 	// X can omit the focal post from a refresh while still returning replies.
 	// The conversation must always keep its root: without it a refresh would
 	// silently turn the thread into a list of orphaned replies.
-	if !seen[m.threadRootID] {
-		if root, ok := m.threadRootPost(); ok {
+	if !seen[c.threadRootID] {
+		if root, ok := c.threadRootPost(); ok {
 			merged = append([]api.ConversationPost{root}, merged...)
 		}
 	}
-	m.threadPosts = merged
-	m.normalizeThreadDepths()
-	m.threadCursor = msg.page.Cursor
-	m.selected = indexOfConversationPost(m.threadPosts, selectedID)
-	if m.selected < 0 {
-		m.selected = 0
+	c.threadPosts = merged
+	c.normalizeThreadDepths()
+	c.threadCursor = msg.page.Cursor
+	c.selected = indexOfConversationPost(c.threadPosts, selectedID)
+	if c.selected < 0 {
+		c.selected = 0
 	}
-	if repaint {
+	if repaint && c == m.cur() {
 		m.syncViewport()
 		m.ensureSelectedVisible()
 		return m, m.imageRepaint(m.requestPreviews())
@@ -95,9 +97,9 @@ func (m Model) applyThreadPage(msg threadMsg, repaint bool) (tea.Model, tea.Cmd)
 	return m, nil
 }
 
-func (m Model) threadRootPost() (api.ConversationPost, bool) {
-	for _, post := range m.threadPosts {
-		if post.ID == m.threadRootID {
+func (c *column) threadRootPost() (api.ConversationPost, bool) {
+	for _, post := range c.threadPosts {
+		if post.ID == c.threadRootID {
 			post.Depth = 0
 			return post, true
 		}
@@ -105,10 +107,10 @@ func (m Model) threadRootPost() (api.ConversationPost, bool) {
 	return api.ConversationPost{}, false
 }
 
-func (m Model) resolveConversationPosts(page *api.ConversationPage) []api.ConversationPost {
+func (c *column) resolveConversationPosts(page *api.ConversationPage) []api.ConversationPost {
 	resolved := append([]api.ConversationPost(nil), page.Posts...)
-	depths := make(map[string]int, len(m.threadPosts)+len(resolved))
-	for _, post := range m.threadPosts {
+	depths := make(map[string]int, len(c.threadPosts)+len(resolved))
+	for _, post := range c.threadPosts {
 		depths[post.ID] = post.Depth
 	}
 	for _, post := range resolved {
@@ -137,20 +139,20 @@ func (m Model) resolveConversationPosts(page *api.ConversationPage) []api.Conver
 	return resolved
 }
 
-func (m *Model) normalizeThreadDepths() {
-	byID := make(map[string]api.ConversationPost, len(m.threadPosts))
-	for _, post := range m.threadPosts {
+func (c *column) normalizeThreadDepths() {
+	byID := make(map[string]api.ConversationPost, len(c.threadPosts))
+	for _, post := range c.threadPosts {
 		byID[post.ID] = post
 	}
-	for i := range m.threadPosts {
-		if m.threadPosts[i].ID == m.threadRootID {
-			m.threadPosts[i].Depth = 0
+	for i := range c.threadPosts {
+		if c.threadPosts[i].ID == c.threadRootID {
+			c.threadPosts[i].Depth = 0
 			continue
 		}
 		depth := 1
-		parent := m.threadPosts[i].InReplyToID
-		visited := map[string]bool{m.threadPosts[i].ID: true}
-		for parent != "" && parent != m.threadRootID && !visited[parent] {
+		parent := c.threadPosts[i].InReplyToID
+		visited := map[string]bool{c.threadPosts[i].ID: true}
+		for parent != "" && parent != c.threadRootID && !visited[parent] {
 			visited[parent] = true
 			ancestor, ok := byID[parent]
 			if !ok {
@@ -159,14 +161,14 @@ func (m *Model) normalizeThreadDepths() {
 			parent = ancestor.InReplyToID
 			depth++
 		}
-		m.threadPosts[i].Depth = depth
+		c.threadPosts[i].Depth = depth
 	}
 }
 
 func (m Model) updateThread(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case spinner.TickMsg:
-		if m.threadLoading || m.threadMore || m.zoomLoading() {
+		if m.cur().threadLoading || m.cur().threadMore || m.zoomLoading() {
 			var cmd tea.Cmd
 			m.spinner, cmd = m.spinner.Update(msg)
 			return m, cmd
@@ -195,23 +197,23 @@ func (m Model) updateThread(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 	case "esc":
 		m.mode = modeFeed
-		m.selected = m.feedSelected
-		m.threadSeq++
-		m.threadRootID = ""
-		m.expanded = false
-		m.threadLoading = false
-		m.threadMore = false
+		m.cur().selected = m.cur().feedSelected
+		m.cur().threadSeq++
+		m.cur().threadRootID = ""
+		m.cur().expanded = false
+		m.cur().threadLoading = false
+		m.cur().threadMore = false
 		// An expired session affects every request, not just this thread.
 		// Hand the error to the feed so its reconnect flow stays reachable.
-		if errors.Is(m.threadErr, api.ErrSessionExpired) {
-			m.err = m.threadErr
+		if errors.Is(m.cur().threadErr, api.ErrSessionExpired) {
+			m.cur().err = m.cur().threadErr
 		}
-		m.threadErr = nil
+		m.cur().threadErr = nil
 		m.syncViewport()
 		m.ensureSelectedVisible()
 		return m, m.imageRepaint()
 	case "a":
-		if errors.Is(m.threadErr, api.ErrSessionExpired) {
+		if errors.Is(m.cur().threadErr, api.ErrSessionExpired) {
 			m.action = Action{Kind: ActionAuthenticate}
 			return m, tea.Quit
 		}
@@ -222,27 +224,27 @@ func (m Model) updateThread(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.help = true
 		return m, m.imageRepaint()
 	case "j", "down":
-		m.moveThreadSelection(m.selected + 1)
+		m.moveThreadSelection(m.cur().selected + 1)
 		return m, m.imageRepaint(m.requestPreviews(), m.maybeLoadMoreThread())
 	case "k", "up":
-		m.moveThreadSelection(m.selected - 1)
+		m.moveThreadSelection(m.cur().selected - 1)
 		return m, m.imageRepaint(m.requestPreviews())
 	case "ctrl+d":
-		m.moveThreadSelection(m.selected + 5)
+		m.moveThreadSelection(m.cur().selected + 5)
 		return m, m.imageRepaint(m.requestPreviews(), m.maybeLoadMoreThread())
 	case "ctrl+u":
-		m.moveThreadSelection(m.selected - 5)
+		m.moveThreadSelection(m.cur().selected - 5)
 		return m, m.imageRepaint(m.requestPreviews())
 	case "g", "home":
 		m.moveThreadSelection(0)
 		return m, m.imageRepaint(m.requestPreviews())
 	case "G", "end":
-		m.moveThreadSelection(len(m.threadPosts) - 1)
+		m.moveThreadSelection(len(m.cur().threadPosts) - 1)
 		return m, m.imageRepaint(m.requestPreviews(), m.maybeLoadMoreThread())
 	case "R", "ctrl+r":
-		m.threadLoading = true
-		m.threadMore = false
-		m.threadErr = nil
+		m.cur().threadLoading = true
+		m.cur().threadMore = false
+		m.cur().threadErr = nil
 		return m, m.imageRepaint(tea.Batch(m.spinner.Tick, m.requestThread("", false)))
 	case "r":
 		if post, ok := m.currentPost(); ok {
@@ -251,7 +253,7 @@ func (m Model) updateThread(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case "/":
 		return m, m.beginSearch()
 	case "enter", " ", "e":
-		m.expanded = !m.expanded
+		m.cur().expanded = !m.cur().expanded
 		m.syncViewport()
 		m.ensureSelectedVisible()
 		return m, m.imageRepaint()
@@ -270,20 +272,20 @@ func (m Model) updateThread(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) moveThreadSelection(target int) {
-	if len(m.threadPosts) == 0 {
+	if len(m.cur().threadPosts) == 0 {
 		return
 	}
-	m.selected = max(0, min(len(m.threadPosts)-1, target))
-	m.expanded = false
+	m.cur().selected = max(0, min(len(m.cur().threadPosts)-1, target))
+	m.cur().expanded = false
 	m.toast = ""
 	m.syncViewport()
 	m.ensureSelectedVisible()
 }
 
 func (m *Model) maybeLoadMoreThread() tea.Cmd {
-	if len(m.threadPosts) > 0 && m.selected >= len(m.threadPosts)-5 && m.threadCursor != "" && !m.threadLoading && !m.threadMore {
-		m.threadMore = true
-		return tea.Batch(m.spinner.Tick, m.requestThread(m.threadCursor, true))
+	if len(m.cur().threadPosts) > 0 && m.cur().selected >= len(m.cur().threadPosts)-5 && m.cur().threadCursor != "" && !m.cur().threadLoading && !m.cur().threadMore {
+		m.cur().threadMore = true
+		return tea.Batch(m.spinner.Tick, m.requestThread(m.cur().threadCursor, true))
 	}
 	return nil
 }

--- a/internal/timeline/view.go
+++ b/internal/timeline/view.go
@@ -31,6 +31,9 @@ func (m Model) View() string {
 	if m.mode == modeListPicker {
 		return m.viewListPicker()
 	}
+	if m.mode == modeChoicePicker {
+		return m.viewChoicePicker()
+	}
 	if m.mode == modeReply {
 		return m.viewReply()
 	}
@@ -801,6 +804,9 @@ func (m Model) viewSearch() string {
 }
 
 func (m Model) searchBackLabel() string {
+	if m.searchFor == targetNewColumn {
+		return "cancel"
+	}
 	if m.searchReturn == modeThread {
 		return "back to replies"
 	}
@@ -820,6 +826,9 @@ func (m Model) searchBackLabel() string {
 }
 
 func (m Model) searchBackShortLabel() string {
+	if m.searchFor == targetNewColumn {
+		return "cancel"
+	}
 	if m.searchReturn == modeThread {
 		return "replies"
 	}
@@ -882,6 +891,44 @@ func (m Model) viewListPicker() string {
 	hintText := "j/k move · enter select · esc cancel"
 	if len(m.listPicker) > max(1, m.height-9) {
 		hintText = fmt.Sprintf("%d/%d · %s", m.listPickerSel+1, len(m.listPicker), hintText)
+	}
+	hint := lipgloss.NewStyle().Foreground(muted).Render(hintText)
+	content := title + "\n\n" + panel + "\n\n" + hint
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, content)
+}
+
+func (m Model) viewChoicePicker() string {
+	w := columnContentWidth(m.width, 1)
+	title := lipgloss.NewStyle().Foreground(pink).Bold(true).Render(m.picker.title)
+	var body string
+	if len(m.picker.items) == 0 {
+		body = lipgloss.NewStyle().Foreground(muted).Render("nothing to choose from")
+	} else {
+		visible := min(len(m.picker.items), max(1, m.height-9))
+		start := max(0, m.picker.sel-visible/2)
+		start = min(start, len(m.picker.items)-visible)
+		rows := make([]string, 0, visible)
+		for index := start; index < start+visible; index++ {
+			item := m.picker.items[index]
+			marker := "  "
+			nameStyle := lipgloss.NewStyle().Foreground(bright)
+			if index == m.picker.sel {
+				marker = "› "
+				nameStyle = nameStyle.Foreground(blue).Bold(true)
+			}
+			row := marker + nameStyle.Render(item.label)
+			if item.hint != "" {
+				row += lipgloss.NewStyle().Foreground(muted).Render(" · " + item.hint)
+			}
+			rows = append(rows, ansi.Truncate(row, max(10, w-8), "…"))
+		}
+		body = strings.Join(rows, "\n")
+	}
+	panel := lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(blue).
+		Padding(0, 1).Width(w - 4).Render(body)
+	hintText := "j/k move · enter select · esc cancel"
+	if len(m.picker.items) > max(1, m.height-9) {
+		hintText = fmt.Sprintf("%d/%d · %s", m.picker.sel+1, len(m.picker.items), hintText)
 	}
 	hint := lipgloss.NewStyle().Foreground(muted).Render(hintText)
 	content := title + "\n\n" + panel + "\n\n" + hint
@@ -1000,12 +1047,12 @@ func (m Model) viewHelp() string {
 	if w > 54 {
 		w = 54
 	}
-	keys := "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nf           for you / following\nb           bookmarks / for you\n@           next account\n/           search\nL           lists\nl           like / unlike\nr           reply\nR           refresh\nenter       open replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\nP           new post\ng / G       top / bottom\nctrl+l      redraw screen\nq           quit"
+	keys := "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nf           for you / following\nb           bookmarks / for you\n@           next account\n/           search\nL           lists\nn           add column\nx           remove column\ns           column account\nI           image mode\nT           theme\nl           like / unlike\nr           reply\nR           refresh\nenter       open replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\nP           new post\ng / G       top / bottom\nctrl+l      redraw screen\nq           quit"
 	if m.mode == modeThread {
 		keys = "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\n/           search\nl           like / unlike\nr           reply to selected\nR           refresh replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\ng / G       top / bottom\nctrl+l      redraw screen\nesc         back to timeline\nq           quit"
 	}
 	if m.height < 25 {
-		keys = "\n\nj/k move · g/G ends · f feed\nl like · r reply · y copy\nenter replies · e read · i zoom · A alt text\nR refresh · o browser\nP new · / search · @ account\nL lists · b saved · q quit"
+		keys = "\n\nj/k move · g/G ends · f feed\nb saved · L lists · / search\nl like · r reply · y copy\nenter open · e read · i zoom\nA alt · o open · R reload\nP post · @ acct · q quit\nn/x col± · s acct · I/T img"
 		if m.mode == modeThread {
 			keys = "\n\nj/k move · g/G ends\nl like · r reply · y copy\ne read · i zoom · A alt text\nR refresh · o browser · / search\nesc back · q quit"
 		}

--- a/internal/timeline/view.go
+++ b/internal/timeline/view.go
@@ -227,6 +227,8 @@ func (m Model) columnFeedLabel(c *column, width int) string {
 		status = "following"
 	case FeedBookmarks:
 		status = "bookmarks"
+	case FeedNotifications:
+		status = "notifications"
 	case FeedSearch:
 		status = ansi.Truncate("search · “"+c.searchQuery+"”", max(9, width-12), "…")
 	case FeedList:
@@ -853,6 +855,8 @@ func (m Model) searchBackLabel() string {
 		return "back to following"
 	case FeedBookmarks:
 		return "back to bookmarks"
+	case FeedNotifications:
+		return "back to notifications"
 	case FeedSearch:
 		if m.cur().searchQuery == "" && len(m.cur().posts) == 0 {
 			return "quit"
@@ -875,6 +879,8 @@ func (m Model) searchBackShortLabel() string {
 		return "following"
 	case FeedBookmarks:
 		return "bookmarks"
+	case FeedNotifications:
+		return "notifications"
 	case FeedSearch:
 		if m.cur().searchQuery == "" && len(m.cur().posts) == 0 {
 			return "quit"

--- a/internal/timeline/view.go
+++ b/internal/timeline/view.go
@@ -83,7 +83,8 @@ func (m Model) View() string {
 func (m Model) viewColumns() string {
 	first, count := m.visibleColumnRange()
 	width := columnContentWidth(m.width, count)
-	blocks := make([]string, 0, count)
+	blocks := make([]string, 0, count*2)
+	sepHeight := 0
 	for index := first; index < first+count; index++ {
 		c := &m.columns[index]
 		center := c.viewport.View()
@@ -97,10 +98,11 @@ func (m Model) viewColumns() string {
 					Render("the cat lost the timeline\n\n"+c.err.Error()))
 		}
 		block := m.columnHeader(c, width, index == m.focus) + "\n" + center
-		if index < first+count-1 {
-			block = lipgloss.NewStyle().PaddingRight(columnGutter).Render(block)
+		if index > first {
+			blocks = append(blocks, columnSeparator(sepHeight))
 		}
 		blocks = append(blocks, block)
+		sepHeight = max(sepHeight, lipgloss.Height(block))
 	}
 
 	joined := lipgloss.JoinHorizontal(lipgloss.Top, blocks...)
@@ -130,6 +132,17 @@ func (m Model) shell(center, footer string) string {
 }
 
 const columnGutter = 2
+
+// columnSeparator fills the gutter between two columns with a vertical bar
+// instead of blank padding, so the eye can tell where one column ends.
+func columnSeparator(height int) string {
+	bar := lipgloss.NewStyle().Foreground(muted).Render("│")
+	lines := make([]string, max(1, height))
+	for i := range lines {
+		lines[i] = bar
+	}
+	return lipgloss.NewStyle().Width(columnGutter).Render(strings.Join(lines, "\n"))
+}
 
 // columnContentWidth deliberately keeps all feed columns equal-width: the
 // post-ID-keyed previews map depends on that invariant. Unequal panes would
@@ -172,6 +185,9 @@ func (m Model) header(width int) string {
 
 func (m Model) columnHeader(c *column, width int, focused bool) string {
 	status := m.columnFeedLabel(c, width)
+	if account := m.columnAccountHandle(c); account != "" {
+		status = ansi.Truncate(account+" · "+status, max(9, width-2), "…")
+	}
 	if focused {
 		return lipgloss.NewStyle().
 			Foreground(bright).
@@ -184,6 +200,22 @@ func (m Model) columnHeader(c *column, width int, focused bool) string {
 		Foreground(muted).
 		Width(width).
 		Render("  " + status)
+}
+
+// columnAccountHandle names the account a column reads from, but only when
+// the user juggles more than one -- a single account would repeat what the
+// screen header already says.
+func (m Model) columnAccountHandle(c *column) string {
+	if len(m.accounts) <= 1 {
+		return ""
+	}
+	id := m.columnAccountID(c)
+	for _, account := range m.accounts {
+		if account.UserID == id {
+			return accountInfoLabel(account)
+		}
+	}
+	return ""
 }
 
 func (m Model) columnFeedLabel(c *column, width int) string {
@@ -424,7 +456,7 @@ func threadRail(depth int, selected bool) string {
 		own = "  "
 	}
 	if selected {
-		own = lipgloss.NewStyle().Foreground(selectionAccent(depth)).Render("▎") + " "
+		own = lipgloss.NewStyle().Foreground(selectionAccent(depth)).Bold(true).Render("▌") + " "
 	}
 	return strings.Repeat(railBar(), railLevels(depth)) + own
 }
@@ -525,7 +557,7 @@ func (m Model) renderPostForColumn(c *column, post api.TimelinePost, selected, n
 		textColor = dim
 		handleColor = muted
 		gutter = strings.Repeat(railBar(), railLevels(depth)) +
-			lipgloss.NewStyle().Foreground(muted).Render("▎") + " "
+			lipgloss.NewStyle().Foreground(muted).Bold(true).Render("▌") + " "
 	}
 	header := gutter +
 		lipgloss.NewStyle().Foreground(nameColor).Bold(true).Render(name) + "  " +
@@ -676,30 +708,36 @@ func highlightEntities(text string, base lipgloss.Color) string {
 	mention := lipgloss.NewStyle().Foreground(blue)
 	hashtag := lipgloss.NewStyle().Foreground(lavender)
 	link := lipgloss.NewStyle().Foreground(blue).Underline(true)
-	words := strings.Fields(text)
-	for i, word := range words {
-		switch {
-		case len(word) > 1 && word[0] == '@':
-			words[i] = mention.Render(word)
-		case len(word) > 1 && word[0] == '#':
-			words[i] = hashtag.Render(word)
-		case strings.HasPrefix(word, "https://") || strings.HasPrefix(word, "http://"):
-			trimmed := strings.TrimPrefix(strings.TrimPrefix(word, "https://"), "http://")
-			words[i] = link.Render(trimmed)
-		default:
-			words[i] = baseStyle.Render(word)
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		words := strings.Fields(line)
+		for j, word := range words {
+			switch {
+			case len(word) > 1 && word[0] == '@':
+				words[j] = mention.Render(word)
+			case len(word) > 1 && word[0] == '#':
+				words[j] = hashtag.Render(word)
+			case strings.HasPrefix(word, "https://") || strings.HasPrefix(word, "http://"):
+				trimmed := strings.TrimPrefix(strings.TrimPrefix(word, "https://"), "http://")
+				words[j] = link.Render(trimmed)
+			default:
+				words[j] = baseStyle.Render(word)
+			}
 		}
+		lines[i] = strings.Join(words, " ")
 	}
-	return strings.Join(words, " ")
+	return strings.Join(lines, "\n")
 }
 
 // stripTrailingMediaLink removes the t.co link X appends to a post's text
 // when its media is attached; the timeline renders the image itself instead.
+// The trailing check looks for newlines too: cleanText now preserves them,
+// and a link followed by another line is not the trailing media link.
 func stripTrailingMediaLink(text string) string {
-	if index := strings.LastIndex(text, " https://t.co/"); index >= 0 && !strings.Contains(text[index+1:], " ") {
+	if index := strings.LastIndex(text, " https://t.co/"); index >= 0 && !strings.ContainsAny(text[index+1:], " \n") {
 		return text[:index]
 	}
-	if strings.HasPrefix(text, "https://t.co/") && !strings.Contains(text, " ") {
+	if strings.HasPrefix(text, "https://t.co/") && !strings.ContainsAny(text, " \n") {
 		return ""
 	}
 	return text

--- a/internal/timeline/view.go
+++ b/internal/timeline/view.go
@@ -93,7 +93,7 @@ func (m Model) viewColumns() string {
 				lipgloss.NewStyle().Foreground(red).Width(max(20, width-8)).Align(lipgloss.Center).
 					Render("the cat lost the timeline\n\n"+c.err.Error()))
 		}
-		block := m.columnHeader(c, width, index == m.focus) + "\n\n" + center
+		block := m.columnHeader(c, width, index == m.focus) + "\n" + center
 		if index < first+count-1 {
 			block = lipgloss.NewStyle().PaddingRight(columnGutter).Render(block)
 		}
@@ -107,7 +107,7 @@ func (m Model) viewColumns() string {
 	if hidden > 0 {
 		footer = m.footerWithHiddenColumns(width, hidden, footer)
 	}
-	body := joined + "\n" +
+	body := m.screenHeader(totalWidth) + "\n" + joined + "\n" +
 		lipgloss.NewStyle().Foreground(muted).Width(totalWidth).Align(lipgloss.Center).Render(footer)
 	left := max(0, (m.width-totalWidth)/2)
 	return lipgloss.NewStyle().MarginLeft(left).Render(body)
@@ -159,10 +159,27 @@ func (m Model) visibleColumnWidth() int {
 }
 
 func (m Model) header(width int) string {
-	return m.columnHeader(m.cur(), width, true)
+	c := m.cur()
+	return m.catHeader(c, width, m.columnStatus(c, width))
 }
 
 func (m Model) columnHeader(c *column, width int, focused bool) string {
+	status := m.columnFeedLabel(c, width)
+	if focused {
+		return lipgloss.NewStyle().
+			Foreground(bright).
+			Background(blue).
+			Bold(true).
+			Width(width).
+			Render("▸ " + status)
+	}
+	return lipgloss.NewStyle().
+		Foreground(muted).
+		Width(width).
+		Render("  " + status)
+}
+
+func (m Model) columnFeedLabel(c *column, width int) string {
 	status := "for you"
 	switch c.feed {
 	case FeedForYou:
@@ -176,6 +193,11 @@ func (m Model) columnHeader(c *column, width int, focused bool) string {
 	case FeedList:
 		status = ansi.Truncate("list · "+c.listName, max(9, width-12), "…")
 	}
+	return status
+}
+
+func (m Model) columnStatus(c *column, width int) string {
+	status := m.columnFeedLabel(c, width)
 	if m.mode == modeThread {
 		status = "replies"
 		if root, ok := c.threadRootPost(); ok && root.Handle != "" {
@@ -189,20 +211,25 @@ func (m Model) columnHeader(c *column, width int, focused bool) string {
 	} else if c.loadingMore {
 		status = m.spinner.View() + " loading more"
 	}
+	return status
+}
+
+func (m Model) screenHeader(width int) string {
+	return m.catHeader(m.cur(), width, "")
+}
+
+func (m Model) catHeader(c *column, width int, status string) string {
 	face := "( o.o )"
 	if c.err != nil || (m.mode == modeThread && c.threadErr != nil) {
 		face = "( >.< )"
 	}
-	catColor := pink
-	titleColor := blue
-	if !focused {
-		catColor = muted
-		titleColor = muted
+	secondLine := lipgloss.NewStyle().Foreground(pink).Render(face)
+	if status != "" {
+		secondLine += lipgloss.NewStyle().Foreground(muted).Render("   " + status)
 	}
-	cat := lipgloss.NewStyle().Foreground(catColor).Render(" /\\_/\\") +
-		lipgloss.NewStyle().Foreground(titleColor).Bold(true).Render("   xeet") + "\n" +
-		lipgloss.NewStyle().Foreground(catColor).Render(face) +
-		lipgloss.NewStyle().Foreground(muted).Render("   "+status)
+	cat := lipgloss.NewStyle().Foreground(pink).Render(" /\\_/\\") +
+		lipgloss.NewStyle().Foreground(blue).Bold(true).Render("   xeet") + "\n" +
+		secondLine
 	return lipgloss.NewStyle().Width(width).Render(cat)
 }
 

--- a/internal/timeline/view.go
+++ b/internal/timeline/view.go
@@ -39,39 +39,39 @@ func (m Model) View() string {
 	}
 
 	footer := m.footer()
-	if m.loading && len(m.posts) == 0 {
+	if m.cur().loading && len(m.cur().posts) == 0 {
 		message := m.spinner.View() + " gathering xeets…"
 		loadingFooter := footer
-		if m.feed == FeedSearch {
-			query := ansi.Truncate(m.searchQuery, max(8, m.viewport.Width-20), "…")
+		if m.cur().feed == FeedSearch {
+			query := ansi.Truncate(m.cur().searchQuery, max(8, m.cur().viewport.Width-20), "…")
 			message = m.spinner.View() + " searching “" + query + "”…"
 			loadingFooter = "/ edit search  ·  q quit"
 		}
-		center := lipgloss.Place(m.viewport.Width, m.viewport.Height, lipgloss.Center, lipgloss.Center,
+		center := lipgloss.Place(m.cur().viewport.Width, m.cur().viewport.Height, lipgloss.Center, lipgloss.Center,
 			lipgloss.NewStyle().Foreground(lavender).Render(message))
 		return m.shell(center, loadingFooter)
 	}
-	if m.err != nil && len(m.posts) == 0 {
+	if m.cur().err != nil && len(m.cur().posts) == 0 {
 		title := "the cat lost the timeline"
 		errorFooter := m.errorFooter(true)
-		if m.feed == FeedSearch {
+		if m.cur().feed == FeedSearch {
 			title = "search couldn't reach X"
 			errorFooter = m.searchErrorFooter(true)
 		}
-		center := lipgloss.Place(m.viewport.Width, m.viewport.Height, lipgloss.Center, lipgloss.Center,
-			lipgloss.NewStyle().Foreground(red).Width(max(20, m.viewport.Width-8)).Align(lipgloss.Center).
-				Render(title+"\n\n"+m.err.Error()))
+		center := lipgloss.Place(m.cur().viewport.Width, m.cur().viewport.Height, lipgloss.Center, lipgloss.Center,
+			lipgloss.NewStyle().Foreground(red).Width(max(20, m.cur().viewport.Width-8)).Align(lipgloss.Center).
+				Render(title+"\n\n"+m.cur().err.Error()))
 		return m.shell(center, errorFooter)
 	}
-	if m.feed == FeedSearch && len(m.posts) == 0 {
-		query := ansi.Truncate(m.searchQuery, max(8, m.viewport.Width-24), "…")
+	if m.cur().feed == FeedSearch && len(m.cur().posts) == 0 {
+		query := ansi.Truncate(m.cur().searchQuery, max(8, m.cur().viewport.Width-24), "…")
 		message := lipgloss.NewStyle().Foreground(bright).Bold(true).Render("no posts found") + "\n\n" +
-			lipgloss.NewStyle().Foreground(muted).Width(max(20, m.viewport.Width-8)).Align(lipgloss.Center).
+			lipgloss.NewStyle().Foreground(muted).Width(max(20, m.cur().viewport.Width-8)).Align(lipgloss.Center).
 				Render("nothing matched “"+query+"”\ntry fewer words or remove a search operator")
-		center := lipgloss.Place(m.viewport.Width, m.viewport.Height, lipgloss.Center, lipgloss.Center, message)
+		center := lipgloss.Place(m.cur().viewport.Width, m.cur().viewport.Height, lipgloss.Center, lipgloss.Center, message)
 		return m.shell(center, m.searchEmptyFooter())
 	}
-	return m.shell(m.viewport.View(), footer)
+	return m.shell(m.cur().viewport.View(), footer)
 }
 
 func (m Model) shell(center, footer string) string {
@@ -97,7 +97,7 @@ func (m Model) contentWidth() int {
 
 func (m Model) header(width int) string {
 	status := "for you"
-	switch m.feed {
+	switch m.cur().feed {
 	case FeedForYou:
 		status = "for you"
 	case FeedFollowing:
@@ -105,25 +105,25 @@ func (m Model) header(width int) string {
 	case FeedBookmarks:
 		status = "bookmarks"
 	case FeedSearch:
-		status = ansi.Truncate("search · “"+m.searchQuery+"”", max(9, width-12), "…")
+		status = ansi.Truncate("search · “"+m.cur().searchQuery+"”", max(9, width-12), "…")
 	case FeedList:
-		status = ansi.Truncate("list · "+m.listName, max(9, width-12), "…")
+		status = ansi.Truncate("list · "+m.cur().listName, max(9, width-12), "…")
 	}
 	if m.mode == modeThread {
 		status = "replies"
-		if root, ok := m.threadRootPost(); ok && root.Handle != "" {
+		if root, ok := m.cur().threadRootPost(); ok && root.Handle != "" {
 			status = truncateRunes("replies to @"+root.Handle, max(9, width-12))
 		}
 	}
-	if m.mode == modeThread && (m.threadLoading || m.threadMore) {
+	if m.mode == modeThread && (m.cur().threadLoading || m.cur().threadMore) {
 		status = m.spinner.View() + " loading replies"
-	} else if m.refreshing {
+	} else if m.cur().refreshing {
 		status = m.spinner.View() + " refreshing"
-	} else if m.loadingMore {
+	} else if m.cur().loadingMore {
 		status = m.spinner.View() + " loading more"
 	}
 	face := "( o.o )"
-	if m.err != nil || (m.mode == modeThread && m.threadErr != nil) {
+	if m.cur().err != nil || (m.mode == modeThread && m.cur().threadErr != nil) {
 		face = "( >.< )"
 	}
 	cat := lipgloss.NewStyle().Foreground(pink).Render(" /\\_/\\") +
@@ -137,40 +137,40 @@ func (m Model) footer() string {
 	if m.toast != "" {
 		return m.toast
 	}
-	if m.err != nil {
-		if m.feed == FeedSearch {
+	if m.cur().err != nil {
+		if m.cur().feed == FeedSearch {
 			return m.searchErrorFooter(false)
 		}
 		return m.errorFooter(false)
 	}
 	position := 0
-	if len(m.posts) > 0 {
-		position = m.selected + 1
+	if len(m.cur().posts) > 0 {
+		position = m.cur().selected + 1
 	}
-	if m.feed == FeedSearch {
+	if m.cur().feed == FeedSearch {
 		var footer string
-		if m.expanded {
-			footer = fmt.Sprintf("%d/%d · / edit · e collapse · o browser · ? help", position, len(m.posts))
+		if m.cur().expanded {
+			footer = fmt.Sprintf("%d/%d · / edit · e collapse · o browser · ? help", position, len(m.cur().posts))
 		} else {
-			footer = fmt.Sprintf("%d/%d · / edit search · R refresh · enter replies · ? help", position, len(m.posts))
+			footer = fmt.Sprintf("%d/%d · / edit search · R refresh · enter replies · ? help", position, len(m.cur().posts))
 		}
 		if ansi.StringWidth(footer) > m.contentWidth() {
-			return fmt.Sprintf("%d/%d · / edit · ? help", position, len(m.posts))
+			return fmt.Sprintf("%d/%d · / edit · ? help", position, len(m.cur().posts))
 		}
 		return footer
 	}
-	if m.contentWidth() < 50 || len(m.posts) == 0 {
-		return fmt.Sprintf("%d/%d  ·  ? help", position, len(m.posts))
+	if m.contentWidth() < 50 || len(m.cur().posts) == 0 {
+		return fmt.Sprintf("%d/%d  ·  ? help", position, len(m.cur().posts))
 	}
-	if m.expanded {
-		return fmt.Sprintf("%d/%d · e collapse · o browser · ? help", position, len(m.posts))
+	if m.cur().expanded {
+		return fmt.Sprintf("%d/%d · e collapse · o browser · ? help", position, len(m.cur().posts))
 	}
-	return fmt.Sprintf("%d/%d · enter replies · e read · r reply · ? help", position, len(m.posts))
+	return fmt.Sprintf("%d/%d · enter replies · e read · r reply · ? help", position, len(m.cur().posts))
 }
 
 func (m Model) errorFooter(includeQuit bool) string {
 	parts := []string{"R retry"}
-	if errors.Is(m.err, api.ErrSessionExpired) {
+	if errors.Is(m.cur().err, api.ErrSessionExpired) {
 		parts = append([]string{"a reconnect"}, parts...)
 	}
 	if includeQuit {
@@ -204,62 +204,62 @@ func (m Model) searchEmptyFooter() string {
 
 func (m Model) viewThread() string {
 	footer := m.threadFooter()
-	if m.threadLoading && len(m.threadPosts) <= 1 {
-		center := lipgloss.Place(m.viewport.Width, m.viewport.Height, lipgloss.Center, lipgloss.Center,
+	if m.cur().threadLoading && len(m.cur().threadPosts) <= 1 {
+		center := lipgloss.Place(m.cur().viewport.Width, m.cur().viewport.Height, lipgloss.Center, lipgloss.Center,
 			lipgloss.NewStyle().Foreground(lavender).Render(m.spinner.View()+" gathering replies…"))
 		return m.shell(center, footer)
 	}
 	// The thread opens pre-seeded with the focal post, so a fetch failure
 	// almost never leaves the list empty. Show the error over the posts we
 	// have instead of hiding it behind a bare retry footer.
-	if m.threadErr != nil {
-		center := lipgloss.Place(m.viewport.Width, m.viewport.Height, lipgloss.Center, lipgloss.Center,
-			lipgloss.NewStyle().Foreground(red).Width(max(20, m.viewport.Width-8)).Align(lipgloss.Center).
-				Render("the cat lost the replies\n\n"+m.threadErr.Error()))
+	if m.cur().threadErr != nil {
+		center := lipgloss.Place(m.cur().viewport.Width, m.cur().viewport.Height, lipgloss.Center, lipgloss.Center,
+			lipgloss.NewStyle().Foreground(red).Width(max(20, m.cur().viewport.Width-8)).Align(lipgloss.Center).
+				Render("the cat lost the replies\n\n"+m.cur().threadErr.Error()))
 		return m.shell(center, footer)
 	}
-	return m.shell(m.viewport.View(), footer)
+	return m.shell(m.cur().viewport.View(), footer)
 }
 
 func (m Model) threadFooter() string {
 	if m.toast != "" {
 		return m.toast
 	}
-	if m.threadErr != nil {
+	if m.cur().threadErr != nil {
 		parts := []string{"R retry"}
-		if errors.Is(m.threadErr, api.ErrSessionExpired) {
+		if errors.Is(m.cur().threadErr, api.ErrSessionExpired) {
 			parts = append([]string{"a reconnect"}, parts...)
 		}
 		parts = append(parts, "esc back")
 		return strings.Join(parts, "  ·  ")
 	}
 	position := 0
-	if len(m.threadPosts) > 0 {
-		position = m.selected + 1
+	if len(m.cur().threadPosts) > 0 {
+		position = m.cur().selected + 1
 	}
-	return fmt.Sprintf("%d/%d · r reply · e read · esc back · ? help", position, len(m.threadPosts))
+	return fmt.Sprintf("%d/%d · r reply · e read · esc back · ? help", position, len(m.cur().threadPosts))
 }
 
 func (m Model) renderThreadContent() (string, []int, []int) {
-	if len(m.threadPosts) == 0 {
+	if len(m.cur().threadPosts) == 0 {
 		return lipgloss.NewStyle().Foreground(muted).Width(m.contentWidth()).Align(lipgloss.Center).Render("no replies yet · press r to start one"), nil, nil
 	}
-	handles := make(map[string]string, len(m.threadPosts))
-	for _, item := range m.threadPosts {
+	handles := make(map[string]string, len(m.cur().threadPosts))
+	for _, item := range m.cur().threadPosts {
 		handles[item.ID] = item.Handle
 	}
-	pieces := make([]string, 0, 2*len(m.threadPosts))
-	starts := make([]int, 0, len(m.threadPosts))
-	ends := make([]int, 0, len(m.threadPosts))
+	pieces := make([]string, 0, 2*len(m.cur().threadPosts))
+	starts := make([]int, 0, len(m.cur().threadPosts))
+	ends := make([]int, 0, len(m.cur().threadPosts))
 	line := 0
-	for i, item := range m.threadPosts {
+	for i, item := range m.cur().threadPosts {
 		// The gap between posts carries this post's ancestor rails so the
 		// conversation reads as one unbroken line down the left.
 		if i > 0 {
 			pieces = append(pieces, threadSpacer(item.Depth))
 			line++
 		}
-		block := m.renderPost(item.TimelinePost, i == m.selected, true, item.Depth)
+		block := m.renderPost(item.TimelinePost, i == m.cur().selected, true, item.Depth)
 		if context := m.replyContext(i, handles); context != "" {
 			block = context + "\n" + block
 		}
@@ -324,11 +324,11 @@ func selectionAccent(depth int) lipgloss.Color {
 // parent is not the post directly above it, or one nested past maxRailDepth,
 // where every further level draws at the same indent.
 func (m Model) replyContext(index int, handles map[string]string) string {
-	item := m.threadPosts[index]
+	item := m.cur().threadPosts[index]
 	if index == 0 || item.Depth <= 1 {
 		return ""
 	}
-	if item.InReplyToID == m.threadPosts[index-1].ID && item.Depth <= maxRailDepth {
+	if item.InReplyToID == m.cur().threadPosts[index-1].ID && item.Depth <= maxRailDepth {
 		return ""
 	}
 	handle := handles[item.InReplyToID]
@@ -340,28 +340,28 @@ func (m Model) replyContext(index int, handles map[string]string) string {
 }
 
 func (m Model) renderFeedContent() (string, []int, []int) {
-	if len(m.posts) == 0 {
+	if len(m.cur().posts) == 0 {
 		return lipgloss.NewStyle().Foreground(muted).Width(m.contentWidth()).Align(lipgloss.Center).Render("the timeline is quiet"), nil, nil
 	}
-	blocks := make([]string, 0, len(m.posts))
-	starts := make([]int, 0, len(m.posts))
-	ends := make([]int, 0, len(m.posts))
+	blocks := make([]string, 0, len(m.cur().posts))
+	starts := make([]int, 0, len(m.cur().posts))
+	ends := make([]int, 0, len(m.cur().posts))
 	line := 0
-	for i, post := range m.posts {
-		showImage := abs(i-m.selected) <= inlineImageRadius
+	for i, post := range m.cur().posts {
+		showImage := abs(i-m.cur().selected) <= inlineImageRadius
 		if m.imageMode == imageModeNative || m.imageMode == imageModeWezTerm {
 			// Native previews are cheap escape sequences rather than large ANSI
 			// mosaics. Keep cached images in the feed so they do not disappear as
 			// soon as the selection moves away from their post.
 			showImage = true
 		}
-		block := m.renderPost(post, i == m.selected, showImage, feedDepth)
+		block := m.renderPost(post, i == m.cur().selected, showImage, feedDepth)
 		height := lipgloss.Height(block)
 		starts = append(starts, line)
 		ends = append(ends, line+height-1)
 		blocks = append(blocks, block)
 		line += height
-		if i < len(m.posts)-1 {
+		if i < len(m.cur().posts)-1 {
 			line++
 		}
 	}
@@ -408,7 +408,7 @@ func (m Model) renderPost(post api.TimelinePost, selected, nearSelection bool, d
 	if body != "" {
 		wrapped := lipgloss.NewStyle().Width(max(12, width-pad)).Render(highlightEntities(body, textColor))
 		textLines := strings.Split(wrapped, "\n")
-		if !(selected && m.expanded) && len(textLines) > 4 {
+		if !(selected && m.cur().expanded) && len(textLines) > 4 {
 			textLines = textLines[:4]
 			textLines[3] = ansi.Truncate(textLines[3], max(2, width-pad-2), "…")
 		}

--- a/internal/timeline/view.go
+++ b/internal/timeline/view.go
@@ -160,7 +160,11 @@ func (m Model) visibleColumnWidth() int {
 
 func (m Model) header(width int) string {
 	c := m.cur()
-	return m.catHeader(c, width, m.columnStatus(c, width))
+	status := m.columnStatus(c, width)
+	if account := m.activeAccountLabel(); account != "" {
+		status = truncateRunes(account+" · "+status, max(9, width-12))
+	}
+	return m.catHeader(c, width, status)
 }
 
 func (m Model) columnHeader(c *column, width int, focused bool) string {
@@ -215,7 +219,7 @@ func (m Model) columnStatus(c *column, width int) string {
 }
 
 func (m Model) screenHeader(width int) string {
-	return m.catHeader(m.cur(), width, "")
+	return m.catHeader(m.cur(), width, m.activeAccountLabel())
 }
 
 func (m Model) catHeader(c *column, width int, status string) string {
@@ -996,12 +1000,12 @@ func (m Model) viewHelp() string {
 	if w > 54 {
 		w = 54
 	}
-	keys := "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nf           for you / following\nb           bookmarks / for you\n/           search\nL           lists\nl           like / unlike\nr           reply\nR           refresh\nenter       open replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\nP           new post\ng / G       top / bottom\nctrl+l      redraw screen\nq           quit"
+	keys := "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nf           for you / following\nb           bookmarks / for you\n@           next account\n/           search\nL           lists\nl           like / unlike\nr           reply\nR           refresh\nenter       open replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\nP           new post\ng / G       top / bottom\nctrl+l      redraw screen\nq           quit"
 	if m.mode == modeThread {
 		keys = "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\n/           search\nl           like / unlike\nr           reply to selected\nR           refresh replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\ng / G       top / bottom\nctrl+l      redraw screen\nesc         back to timeline\nq           quit"
 	}
 	if m.height < 25 {
-		keys = "\n\nj/k move · g/G ends · f feed\nl like · r reply · y copy\nenter replies · e read · i zoom · A alt text\nR refresh · o browser\nP new · / search · ^L redraw\nL lists · b saved · q quit"
+		keys = "\n\nj/k move · g/G ends · f feed\nl like · r reply · y copy\nenter replies · e read · i zoom · A alt text\nR refresh · o browser\nP new · / search · @ account\nL lists · b saved · q quit"
 		if m.mode == modeThread {
 			keys = "\n\nj/k move · g/G ends\nl like · r reply · y copy\ne read · i zoom · A alt text\nR refresh · o browser · / search\nesc back · q quit"
 		}

--- a/internal/timeline/view.go
+++ b/internal/timeline/view.go
@@ -233,6 +233,8 @@ func (m Model) columnFeedLabel(c *column, width int) string {
 		status = ansi.Truncate("search · “"+c.searchQuery+"”", max(9, width-12), "…")
 	case FeedList:
 		status = ansi.Truncate("list · "+c.listName, max(9, width-12), "…")
+	case FeedProfile:
+		status = ansi.Truncate("@"+c.profileHandle, max(9, width-12), "…")
 	}
 	return status
 }
@@ -873,6 +875,8 @@ func (m Model) searchBackLabel() string {
 			return "quit"
 		}
 		return "back to results"
+	case FeedProfile:
+		return "back to @" + m.cur().profileHandle
 	default:
 		return "back to for you"
 	}
@@ -897,6 +901,8 @@ func (m Model) searchBackShortLabel() string {
 			return "quit"
 		}
 		return "results"
+	case FeedProfile:
+		return "@" + m.cur().profileHandle
 	default:
 		return "for you"
 	}
@@ -1102,16 +1108,16 @@ func (m Model) viewHelp() string {
 	if w > 54 {
 		w = 54
 	}
-	keys := "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nf           for you / following\nb           bookmarks / for you\n@           next account\n/           search\nL           lists\nn           add column\nx           remove column\ns           column account\nI           image mode\nT           theme\nl           like / unlike\nt           repost / unrepost\nr           reply\nQ           quote post\nR           refresh\nenter       open replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\nP           new post\ng / G       top / bottom\nctrl+l      redraw screen\nq           quit"
+	keys := "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nf           for you / following\nb           bookmarks / for you\n@           next account\n/           search\nL           lists\nn           add column\nx           remove column\ns           column account\nI           image mode\nT           theme\nl           like / unlike\nt           repost / unrepost\nr           reply\nQ           quote post\nu           author profile\nR           refresh\nenter       open replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\nP           new post\ng / G       top / bottom\nctrl+l      redraw screen\nq           quit"
 	if m.mode == modeThread {
-		keys = "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\n/           search\nl           like / unlike\nt           repost / unrepost\nr           reply to selected\nQ           quote selected\nR           refresh replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\ng / G       top / bottom\nctrl+l      redraw screen\nesc         back to timeline\nq           quit"
+		keys = "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\n/           search\nl           like / unlike\nt           repost / unrepost\nr           reply to selected\nQ           quote selected\nu           author profile\nR           refresh replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\ng / G       top / bottom\nctrl+l      redraw screen\nesc         back to timeline\nq           quit"
 	}
 	if m.height < 25 {
 		// One leading newline, not two: the repost entry makes the longest line
 		// wrap, and the extra row would push the box's title off a short screen.
-		keys = "\nj/k move · g/G ends · f feed\nb saved · L lists · / search\nl like · t repost · r reply\nenter open · e read · i zoom\nA alt · o open · R reload\nQ quote · y copy · P post\n@ acct · q quit · n/x col±\ns acct · I/T img"
+		keys = "\nj/k move · g/G ends · f feed\nb saved · L lists · / search\nl like · t repost · r reply\nenter open · e read · i zoom\nA alt · o open · R reload\nQ quote · u prof · y copy\n@ acct · q quit · n/x col±\ns acct · I/T img · P post"
 		if m.mode == modeThread {
-			keys = "\n\nj/k move · g/G ends\nl like · t repost · r reply\nQ quote · y copy · e read\ni zoom · A alt text\nR refresh · o browser · / search\nesc back · q quit"
+			keys = "\n\nj/k move · g/G ends\nl like · t repost · r reply\nQ quote · u prof · e read\ni zoom · A alt text\nR refresh · o browser · / search\ny copy · esc back · q quit"
 		}
 	}
 	images := "images: " + string(m.imageMode)

--- a/internal/timeline/view.go
+++ b/internal/timeline/view.go
@@ -696,6 +696,11 @@ func (m Model) actionLine(post api.TimelinePost) string {
 			segments = append(segments, quiet.Render(repost))
 		}
 	}
+	// Bookmarks publish no count, so the marker only appears while set —
+	// unlike the heart and ⟳ it has nothing to show at zero.
+	if post.Bookmarked {
+		segments = append(segments, liked.Render("🔖"))
+	}
 	if views, err := strconv.Atoi(post.ViewCount); err == nil && views > 0 {
 		segments = append(segments, quiet.Render(formatCount(views)+" views"))
 	}
@@ -1108,16 +1113,18 @@ func (m Model) viewHelp() string {
 	if w > 54 {
 		w = 54
 	}
-	keys := "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nf           for you / following\nb           bookmarks / for you\n@           next account\n/           search\nL           lists\nn           add column\nx           remove column\ns           column account\nI           image mode\nT           theme\nl           like / unlike\nt           repost / unrepost\nr           reply\nQ           quote post\nu           author profile\nR           refresh\nenter       open replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\nP           new post\ng / G       top / bottom\nctrl+l      redraw screen\nq           quit"
+	keys := "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nf           for you / following\nb           bookmarks / for you\n@           next account\n/           search\nL           lists\nn           add column\nx           remove column\ns           column account\nI           image mode\nT           theme\nl           like / unlike\nt           repost / unrepost\nB           bookmark / unbookmark\nr           reply\nQ           quote post\nu           author profile\nR           refresh\nenter       open replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\nP           new post\ng / G       top / bottom\nctrl+l      redraw screen\nq           quit"
 	if m.mode == modeThread {
-		keys = "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\n/           search\nl           like / unlike\nt           repost / unrepost\nr           reply to selected\nQ           quote selected\nu           author profile\nR           refresh replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\ng / G       top / bottom\nctrl+l      redraw screen\nesc         back to timeline\nq           quit"
+		keys = "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\n/           search\nl           like / unlike\nt           repost / unrepost\nB           bookmark / unbookmark\nr           reply to selected\nQ           quote selected\nu           author profile\nR           refresh replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\ng / G       top / bottom\nctrl+l      redraw screen\nesc         back to timeline\nq           quit"
 	}
 	if m.height < 25 {
 		// One leading newline, not two: the repost entry makes the longest line
 		// wrap, and the extra row would push the box's title off a short screen.
-		keys = "\nj/k move · g/G ends · f feed\nb saved · L lists · / search\nl like · t repost · r reply\nenter open · e read · i zoom\nA alt · o open · R reload\nQ quote · u prof · y copy\n@ acct · q quit · n/x col±\ns acct · I/T img · P post"
+		// Content stays at eight lines for the same reason; g/G ends is the one
+		// full-help entry dropped to make room for B.
+		keys = "\nj/k move · f feed · b saved\nL lists · / search · @ acct\nl like · t repost · B save\nr reply · Q quote · u prof\nenter open · e read · i zoom\nA alt · o open · R reload\ny copy · n/x col± · s acct\nI/T img · P post · q quit"
 		if m.mode == modeThread {
-			keys = "\n\nj/k move · g/G ends\nl like · t repost · r reply\nQ quote · u prof · e read\ni zoom · A alt text\nR refresh · o browser · / search\ny copy · esc back · q quit"
+			keys = "\n\nj/k move · g/G ends\nl like · t repost · B save\nr reply · Q quote · u prof\ne read · i zoom · A alt\nR reload · o open · / search\ny copy · esc back · q quit"
 		}
 	}
 	images := "images: " + string(m.imageMode)

--- a/internal/timeline/view.go
+++ b/internal/timeline/view.go
@@ -128,8 +128,9 @@ func (m Model) shell(center, footer string) string {
 
 const columnGutter = 2
 
-// columnContentWidth keeps feed panes equal-width; the shared preview cache
-// relies on that invariant once multi-column previews arrive in C3.
+// columnContentWidth deliberately keeps all feed columns equal-width: the
+// post-ID-keyed previews map depends on that invariant. Unequal panes would
+// require per-column previews to avoid alternating width-based refetches.
 func columnContentWidth(totalWidth, ncols int) int {
 	ncols = max(1, ncols)
 	usable := totalWidth - 4

--- a/internal/timeline/view.go
+++ b/internal/timeline/view.go
@@ -28,6 +28,9 @@ func (m Model) View() string {
 	if m.mode == modeSearch {
 		return m.viewSearch()
 	}
+	if m.mode == modeListPicker {
+		return m.viewListPicker()
+	}
 	if m.mode == modeReply {
 		return m.viewReply()
 	}
@@ -103,6 +106,8 @@ func (m Model) header(width int) string {
 		status = "bookmarks"
 	case FeedSearch:
 		status = ansi.Truncate("search · “"+m.searchQuery+"”", max(9, width-12), "…")
+	case FeedList:
+		status = ansi.Truncate("list · "+m.listName, max(9, width-12), "…")
 	}
 	if m.mode == modeThread {
 		status = "replies"
@@ -697,6 +702,56 @@ func (m Model) searchBackShortLabel() string {
 	}
 }
 
+func (m Model) viewListPicker() string {
+	w := m.contentWidth()
+	title := lipgloss.NewStyle().Foreground(pink).Bold(true).Render("lists")
+	var body string
+	switch {
+	case m.listPickerLoading:
+		body = lipgloss.NewStyle().Foreground(lavender).Render(m.spinner.View() + " loading lists…")
+	case m.listPickerErr != nil:
+		body = lipgloss.NewStyle().Foreground(red).Width(max(20, w-8)).Align(lipgloss.Center).
+			Render("couldn't load lists\n\n" + m.listPickerErr.Error())
+	case len(m.listPicker) == 0:
+		body = lipgloss.NewStyle().Foreground(muted).Render("no lists found")
+	default:
+		visible := min(len(m.listPicker), max(1, m.height-9))
+		start := max(0, m.listPickerSel-visible/2)
+		start = min(start, len(m.listPicker)-visible)
+		rows := make([]string, 0, visible)
+		for index := start; index < start+visible; index++ {
+			list := m.listPicker[index]
+			marker := "  "
+			nameStyle := lipgloss.NewStyle().Foreground(bright)
+			if index == m.listPickerSel {
+				marker = "› "
+				nameStyle = nameStyle.Foreground(blue).Bold(true)
+			}
+			members := fmt.Sprintf("%d members", list.MemberCount)
+			if list.MemberCount == 1 {
+				members = "1 member"
+			}
+			privacy := "public"
+			if list.IsPrivate {
+				privacy = "private"
+			}
+			row := marker + nameStyle.Render(list.Name) +
+				lipgloss.NewStyle().Foreground(muted).Render(" · "+members+" · "+privacy)
+			rows = append(rows, ansi.Truncate(row, max(10, w-8), "…"))
+		}
+		body = strings.Join(rows, "\n")
+	}
+	panel := lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(blue).
+		Padding(0, 1).Width(w - 4).Render(body)
+	hintText := "j/k move · enter select · esc cancel"
+	if len(m.listPicker) > max(1, m.height-9) {
+		hintText = fmt.Sprintf("%d/%d · %s", m.listPickerSel+1, len(m.listPicker), hintText)
+	}
+	hint := lipgloss.NewStyle().Foreground(muted).Render(hintText)
+	content := title + "\n\n" + panel + "\n\n" + hint
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, content)
+}
+
 func (m Model) viewZoom() string {
 	post, ok := m.currentPost()
 	if !ok || len(post.Media) == 0 {
@@ -809,12 +864,12 @@ func (m Model) viewHelp() string {
 	if w > 54 {
 		w = 54
 	}
-	keys := "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nf           for you / following\nb           bookmarks / for you\n/           search\nl           like / unlike\nr           reply\nR           refresh\nenter       open replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\nP           new post\ng / G       top / bottom\nctrl+l      redraw screen\nq           quit"
+	keys := "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nf           for you / following\nb           bookmarks / for you\n/           search\nL           lists\nl           like / unlike\nr           reply\nR           refresh\nenter       open replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\nP           new post\ng / G       top / bottom\nctrl+l      redraw screen\nq           quit"
 	if m.mode == modeThread {
 		keys = "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\n/           search\nl           like / unlike\nr           reply to selected\nR           refresh replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\ng / G       top / bottom\nctrl+l      redraw screen\nesc         back to timeline\nq           quit"
 	}
 	if m.height < 25 {
-		keys = "\n\nj/k move · g/G ends · f feed\nl like · r reply · y copy\nenter replies · e read · i zoom · A alt text\nR refresh · o browser\nP new · / search · ^L redraw\nb bookmarks · q quit"
+		keys = "\n\nj/k move · g/G ends · f feed\nl like · r reply · y copy\nenter replies · e read · i zoom · A alt text\nR refresh · o browser\nP new · / search · ^L redraw\nL lists · b saved · q quit"
 		if m.mode == modeThread {
 			keys = "\n\nj/k move · g/G ends\nl like · r reply · y copy\ne read · i zoom · A alt text\nR refresh · o browser · / search\nesc back · q quit"
 		}

--- a/internal/timeline/view.go
+++ b/internal/timeline/view.go
@@ -37,6 +37,9 @@ func (m Model) View() string {
 	if m.mode == modeThread {
 		return m.viewThread()
 	}
+	if len(m.columns) > 1 {
+		return m.viewColumns()
+	}
 
 	footer := m.footer()
 	if m.cur().loading && len(m.cur().posts) == 0 {
@@ -74,8 +77,47 @@ func (m Model) View() string {
 	return m.shell(m.cur().viewport.View(), footer)
 }
 
+func (m Model) viewColumns() string {
+	first, count := m.visibleColumnRange()
+	width := columnContentWidth(m.width, count)
+	blocks := make([]string, 0, count)
+	for index := first; index < first+count; index++ {
+		c := &m.columns[index]
+		center := c.viewport.View()
+		switch {
+		case c.loading && len(c.posts) == 0:
+			center = lipgloss.Place(width, c.viewport.Height, lipgloss.Center, lipgloss.Center,
+				lipgloss.NewStyle().Foreground(lavender).Render(m.spinner.View()+" gathering xeets…"))
+		case c.err != nil && len(c.posts) == 0:
+			center = lipgloss.Place(width, c.viewport.Height, lipgloss.Center, lipgloss.Center,
+				lipgloss.NewStyle().Foreground(red).Width(max(20, width-8)).Align(lipgloss.Center).
+					Render("the cat lost the timeline\n\n"+c.err.Error()))
+		}
+		block := m.columnHeader(c, width, index == m.focus) + "\n\n" + center
+		if index < first+count-1 {
+			block = lipgloss.NewStyle().PaddingRight(columnGutter).Render(block)
+		}
+		blocks = append(blocks, block)
+	}
+
+	joined := lipgloss.JoinHorizontal(lipgloss.Top, blocks...)
+	totalWidth := width*count + columnGutter*(count-1)
+	hidden := len(m.columns) - count
+	footer := m.footerAtWidth(width)
+	if hidden > 0 {
+		footer = m.footerWithHiddenColumns(width, hidden, footer)
+	}
+	body := joined + "\n" +
+		lipgloss.NewStyle().Foreground(muted).Width(totalWidth).Align(lipgloss.Center).Render(footer)
+	left := max(0, (m.width-totalWidth)/2)
+	return lipgloss.NewStyle().MarginLeft(left).Render(body)
+}
+
 func (m Model) shell(center, footer string) string {
 	w := m.contentWidth()
+	if m.mode != modeFeed {
+		w = columnContentWidth(m.width, 1)
+	}
 	body := m.header(w) + "\n\n" + center + "\n" +
 		lipgloss.NewStyle().Foreground(muted).Width(w).Align(lipgloss.Center).Render(footer)
 	// Keep two columns clear on the right. Filling the terminal's final column
@@ -84,20 +126,44 @@ func (m Model) shell(center, footer string) string {
 	return lipgloss.NewStyle().MarginLeft(left).Render(body)
 }
 
+const columnGutter = 2
+
+// columnContentWidth keeps feed panes equal-width; the shared preview cache
+// relies on that invariant once multi-column previews arrive in C3.
+func columnContentWidth(totalWidth, ncols int) int {
+	ncols = max(1, ncols)
+	usable := totalWidth - 4
+	width := (usable - columnGutter*(ncols-1)) / ncols
+	return min(76, max(30, width))
+}
+
 func (m Model) contentWidth() int {
-	w := m.width - 4
-	if w > 76 {
-		w = 76
+	return columnContentWidth(m.width, len(m.columns))
+}
+
+func (m Model) visibleColumnRange() (int, int) {
+	configured := len(m.columns)
+	if configured == 0 {
+		return 0, 0
 	}
-	if w < 30 {
-		w = 30
-	}
-	return w
+	usable := max(0, m.width-4)
+	count := min(configured, max(1, usable/32))
+	first := min(max(0, m.focus-count+1), configured-count)
+	return first, count
+}
+
+func (m Model) visibleColumnWidth() int {
+	_, count := m.visibleColumnRange()
+	return columnContentWidth(m.width, count)
 }
 
 func (m Model) header(width int) string {
+	return m.columnHeader(m.cur(), width, true)
+}
+
+func (m Model) columnHeader(c *column, width int, focused bool) string {
 	status := "for you"
-	switch m.cur().feed {
+	switch c.feed {
 	case FeedForYou:
 		status = "for you"
 	case FeedFollowing:
@@ -105,35 +171,45 @@ func (m Model) header(width int) string {
 	case FeedBookmarks:
 		status = "bookmarks"
 	case FeedSearch:
-		status = ansi.Truncate("search · “"+m.cur().searchQuery+"”", max(9, width-12), "…")
+		status = ansi.Truncate("search · “"+c.searchQuery+"”", max(9, width-12), "…")
 	case FeedList:
-		status = ansi.Truncate("list · "+m.cur().listName, max(9, width-12), "…")
+		status = ansi.Truncate("list · "+c.listName, max(9, width-12), "…")
 	}
 	if m.mode == modeThread {
 		status = "replies"
-		if root, ok := m.cur().threadRootPost(); ok && root.Handle != "" {
+		if root, ok := c.threadRootPost(); ok && root.Handle != "" {
 			status = truncateRunes("replies to @"+root.Handle, max(9, width-12))
 		}
 	}
-	if m.mode == modeThread && (m.cur().threadLoading || m.cur().threadMore) {
+	if m.mode == modeThread && (c.threadLoading || c.threadMore) {
 		status = m.spinner.View() + " loading replies"
-	} else if m.cur().refreshing {
+	} else if c.refreshing {
 		status = m.spinner.View() + " refreshing"
-	} else if m.cur().loadingMore {
+	} else if c.loadingMore {
 		status = m.spinner.View() + " loading more"
 	}
 	face := "( o.o )"
-	if m.cur().err != nil || (m.mode == modeThread && m.cur().threadErr != nil) {
+	if c.err != nil || (m.mode == modeThread && c.threadErr != nil) {
 		face = "( >.< )"
 	}
-	cat := lipgloss.NewStyle().Foreground(pink).Render(" /\\_/\\") +
-		lipgloss.NewStyle().Foreground(blue).Bold(true).Render("   xeet") + "\n" +
-		lipgloss.NewStyle().Foreground(pink).Render(face) +
+	catColor := pink
+	titleColor := blue
+	if !focused {
+		catColor = muted
+		titleColor = muted
+	}
+	cat := lipgloss.NewStyle().Foreground(catColor).Render(" /\\_/\\") +
+		lipgloss.NewStyle().Foreground(titleColor).Bold(true).Render("   xeet") + "\n" +
+		lipgloss.NewStyle().Foreground(catColor).Render(face) +
 		lipgloss.NewStyle().Foreground(muted).Render("   "+status)
 	return lipgloss.NewStyle().Width(width).Render(cat)
 }
 
 func (m Model) footer() string {
+	return m.footerAtWidth(m.contentWidth())
+}
+
+func (m Model) footerAtWidth(width int) string {
 	if m.toast != "" {
 		return m.toast
 	}
@@ -154,18 +230,34 @@ func (m Model) footer() string {
 		} else {
 			footer = fmt.Sprintf("%d/%d · / edit search · R refresh · enter replies · ? help", position, len(m.cur().posts))
 		}
-		if ansi.StringWidth(footer) > m.contentWidth() {
+		if ansi.StringWidth(footer) > width {
 			return fmt.Sprintf("%d/%d · / edit · ? help", position, len(m.cur().posts))
 		}
 		return footer
 	}
-	if m.contentWidth() < 50 || len(m.cur().posts) == 0 {
+	if width < 50 || len(m.cur().posts) == 0 {
 		return fmt.Sprintf("%d/%d  ·  ? help", position, len(m.cur().posts))
 	}
 	if m.cur().expanded {
 		return fmt.Sprintf("%d/%d · e collapse · o browser · ? help", position, len(m.cur().posts))
 	}
 	return fmt.Sprintf("%d/%d · enter replies · e read · r reply · ? help", position, len(m.cur().posts))
+}
+
+func (m Model) footerWithHiddenColumns(width, hidden int, base string) string {
+	note := fmt.Sprintf("+%d more (widen terminal)", hidden)
+	if lipgloss.Width(base)+3+lipgloss.Width(note) <= width {
+		return base + " · " + note
+	}
+	position := 0
+	if len(m.cur().posts) > 0 {
+		position = m.cur().selected + 1
+	}
+	compact := fmt.Sprintf("%d/%d · %s", position, len(m.cur().posts), note)
+	if lipgloss.Width(compact) <= width {
+		return compact
+	}
+	return note
 }
 
 func (m Model) errorFooter(includeQuit bool) string {
@@ -241,8 +333,9 @@ func (m Model) threadFooter() string {
 }
 
 func (m Model) renderThreadContent() (string, []int, []int) {
+	width := columnContentWidth(m.width, 1)
 	if len(m.cur().threadPosts) == 0 {
-		return lipgloss.NewStyle().Foreground(muted).Width(m.contentWidth()).Align(lipgloss.Center).Render("no replies yet · press r to start one"), nil, nil
+		return lipgloss.NewStyle().Foreground(muted).Width(width).Align(lipgloss.Center).Render("no replies yet · press r to start one"), nil, nil
 	}
 	handles := make(map[string]string, len(m.cur().threadPosts))
 	for _, item := range m.cur().threadPosts {
@@ -259,7 +352,7 @@ func (m Model) renderThreadContent() (string, []int, []int) {
 			pieces = append(pieces, threadSpacer(item.Depth))
 			line++
 		}
-		block := m.renderPost(item.TimelinePost, i == m.cur().selected, true, item.Depth)
+		block := m.renderPostForColumn(m.cur(), item.TimelinePost, i == m.cur().selected, true, item.Depth, width, true)
 		if context := m.replyContext(i, handles); context != "" {
 			block = context + "\n" + block
 		}
@@ -340,39 +433,43 @@ func (m Model) replyContext(index int, handles map[string]string) string {
 }
 
 func (m Model) renderFeedContent() (string, []int, []int) {
-	if len(m.cur().posts) == 0 {
-		return lipgloss.NewStyle().Foreground(muted).Width(m.contentWidth()).Align(lipgloss.Center).Render("the timeline is quiet"), nil, nil
+	return m.renderFeedColumnContent(m.cur(), m.contentWidth(), true)
+}
+
+func (m Model) renderFeedColumnContent(c *column, width int, focused bool) (string, []int, []int) {
+	if len(c.posts) == 0 {
+		return lipgloss.NewStyle().Foreground(muted).Width(width).Align(lipgloss.Center).Render("the timeline is quiet"), nil, nil
 	}
-	blocks := make([]string, 0, len(m.cur().posts))
-	starts := make([]int, 0, len(m.cur().posts))
-	ends := make([]int, 0, len(m.cur().posts))
+	blocks := make([]string, 0, len(c.posts))
+	starts := make([]int, 0, len(c.posts))
+	ends := make([]int, 0, len(c.posts))
 	line := 0
-	for i, post := range m.cur().posts {
-		showImage := abs(i-m.cur().selected) <= inlineImageRadius
+	for i, post := range c.posts {
+		showImage := abs(i-c.selected) <= inlineImageRadius
 		if m.imageMode == imageModeNative || m.imageMode == imageModeWezTerm {
 			// Native previews are cheap escape sequences rather than large ANSI
 			// mosaics. Keep cached images in the feed so they do not disappear as
 			// soon as the selection moves away from their post.
 			showImage = true
 		}
-		block := m.renderPost(post, i == m.cur().selected, showImage, feedDepth)
+		block := m.renderPostForColumn(c, post, i == c.selected, showImage, feedDepth, width, focused)
 		height := lipgloss.Height(block)
 		starts = append(starts, line)
 		ends = append(ends, line+height-1)
 		blocks = append(blocks, block)
 		line += height
-		if i < len(m.cur().posts)-1 {
+		if i < len(c.posts)-1 {
 			line++
 		}
 	}
 	return strings.Join(blocks, "\n\n"), starts, ends
 }
 
-// renderPost draws one post. depth is its place in a conversation: feedDepth in
-// the timeline, zero for a thread's focal post, and deeper for each reply level,
-// which shifts the whole block right behind its rail.
-func (m Model) renderPost(post api.TimelinePost, selected, nearSelection bool, depth int) string {
-	width := m.contentWidth()
+// renderPostForColumn draws one post at the given width. depth is its place in a
+// conversation: feedDepth in the timeline, zero for a thread's focal post, and
+// deeper for each reply level, which shifts the whole block right behind its
+// rail. focused dims the post when it belongs to a column that is not in focus.
+func (m Model) renderPostForColumn(c *column, post api.TimelinePost, selected, nearSelection bool, depth, width int, focused bool) string {
 	name := post.AuthorName
 	if name == "" {
 		name = "someone"
@@ -387,6 +484,13 @@ func (m Model) renderPost(post api.TimelinePost, selected, nearSelection bool, d
 		nameColor = bright
 		textColor = bright
 		handleColor = selectionAccent(depth)
+	}
+	if selected && !focused {
+		nameColor = muted
+		textColor = dim
+		handleColor = muted
+		gutter = strings.Repeat(railBar(), railLevels(depth)) +
+			lipgloss.NewStyle().Foreground(muted).Render("▎") + " "
 	}
 	header := gutter +
 		lipgloss.NewStyle().Foreground(nameColor).Bold(true).Render(name) + "  " +
@@ -408,7 +512,7 @@ func (m Model) renderPost(post api.TimelinePost, selected, nearSelection bool, d
 	if body != "" {
 		wrapped := lipgloss.NewStyle().Width(max(12, width-pad)).Render(highlightEntities(body, textColor))
 		textLines := strings.Split(wrapped, "\n")
-		if !(selected && m.cur().expanded) && len(textLines) > 4 {
+		if !(selected && c.expanded) && len(textLines) > 4 {
 			textLines = textLines[:4]
 			textLines[3] = ansi.Truncate(textLines[3], max(2, width-pad-2), "…")
 		}
@@ -587,7 +691,7 @@ func compactCount(value, unit int, suffix string) string {
 }
 
 func (m Model) viewReply() string {
-	w := m.contentWidth()
+	w := columnContentWidth(m.width, 1)
 	title := "replying to @" + m.replyPost.Handle
 	original := lipgloss.NewStyle().Foreground(muted).Width(max(20, w-8)).Render(cleanText(m.replyPost.Text))
 	originalLines := strings.Split(original, "\n")
@@ -635,7 +739,7 @@ func (m Model) viewReply() string {
 }
 
 func (m Model) viewSearch() string {
-	w := m.contentWidth()
+	w := columnContentWidth(m.width, 1)
 	title := lipgloss.NewStyle().Foreground(pink).Bold(true).Render("search posts")
 	description := "find words, accounts, or exact phrases"
 	if m.width < 48 {
@@ -703,7 +807,7 @@ func (m Model) searchBackShortLabel() string {
 }
 
 func (m Model) viewListPicker() string {
-	w := m.contentWidth()
+	w := columnContentWidth(m.width, 1)
 	title := lipgloss.NewStyle().Foreground(pink).Bold(true).Render("lists")
 	var body string
 	switch {
@@ -860,7 +964,7 @@ func (m Model) viewAltText() string {
 }
 
 func (m Model) viewHelp() string {
-	w := m.contentWidth()
+	w := columnContentWidth(m.width, 1)
 	if w > 54 {
 		w = 54
 	}

--- a/internal/timeline/view.go
+++ b/internal/timeline/view.go
@@ -309,7 +309,7 @@ func (m Model) searchErrorFooter(includeQuit bool) string {
 		edit = "/ edit"
 	}
 	parts := []string{"R retry", edit}
-	if errors.Is(m.err, api.ErrSessionExpired) {
+	if errors.Is(m.cur().err, api.ErrSessionExpired) {
 		parts = append([]string{"a reconnect"}, parts...)
 	}
 	if includeQuit {
@@ -804,13 +804,13 @@ func (m Model) searchBackLabel() string {
 	if m.searchReturn == modeThread {
 		return "back to replies"
 	}
-	switch m.feed {
+	switch m.cur().feed {
 	case FeedFollowing:
 		return "back to following"
 	case FeedBookmarks:
 		return "back to bookmarks"
 	case FeedSearch:
-		if m.searchQuery == "" && len(m.posts) == 0 {
+		if m.cur().searchQuery == "" && len(m.cur().posts) == 0 {
 			return "quit"
 		}
 		return "back to results"
@@ -823,13 +823,13 @@ func (m Model) searchBackShortLabel() string {
 	if m.searchReturn == modeThread {
 		return "replies"
 	}
-	switch m.feed {
+	switch m.cur().feed {
 	case FeedFollowing:
 		return "following"
 	case FeedBookmarks:
 		return "bookmarks"
 	case FeedSearch:
-		if m.searchQuery == "" && len(m.posts) == 0 {
+		if m.cur().searchQuery == "" && len(m.cur().posts) == 0 {
 			return "quit"
 		}
 		return "results"

--- a/internal/timeline/view.go
+++ b/internal/timeline/view.go
@@ -34,7 +34,7 @@ func (m Model) View() string {
 	if m.mode == modeChoicePicker {
 		return m.viewChoicePicker()
 	}
-	if m.mode == modeReply {
+	if m.mode == modeReply || m.mode == modeQuote {
 		return m.viewReply()
 	}
 	if m.mode == modeThread {
@@ -776,6 +776,9 @@ func compactCount(value, unit int, suffix string) string {
 func (m Model) viewReply() string {
 	w := columnContentWidth(m.width, 1)
 	title := "replying to @" + m.replyPost.Handle
+	if m.mode == modeQuote {
+		title = "quoting @" + m.replyPost.Handle
+	}
 	original := lipgloss.NewStyle().Foreground(muted).Width(max(20, w-8)).Render(cleanText(m.replyPost.Text))
 	originalLines := strings.Split(original, "\n")
 	if len(originalLines) > 2 {
@@ -1099,16 +1102,16 @@ func (m Model) viewHelp() string {
 	if w > 54 {
 		w = 54
 	}
-	keys := "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nf           for you / following\nb           bookmarks / for you\n@           next account\n/           search\nL           lists\nn           add column\nx           remove column\ns           column account\nI           image mode\nT           theme\nl           like / unlike\nt           repost / unrepost\nr           reply\nR           refresh\nenter       open replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\nP           new post\ng / G       top / bottom\nctrl+l      redraw screen\nq           quit"
+	keys := "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nf           for you / following\nb           bookmarks / for you\n@           next account\n/           search\nL           lists\nn           add column\nx           remove column\ns           column account\nI           image mode\nT           theme\nl           like / unlike\nt           repost / unrepost\nr           reply\nQ           quote post\nR           refresh\nenter       open replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\nP           new post\ng / G       top / bottom\nctrl+l      redraw screen\nq           quit"
 	if m.mode == modeThread {
-		keys = "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\n/           search\nl           like / unlike\nt           repost / unrepost\nr           reply to selected\nR           refresh replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\ng / G       top / bottom\nctrl+l      redraw screen\nesc         back to timeline\nq           quit"
+		keys = "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\n/           search\nl           like / unlike\nt           repost / unrepost\nr           reply to selected\nQ           quote selected\nR           refresh replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\ng / G       top / bottom\nctrl+l      redraw screen\nesc         back to timeline\nq           quit"
 	}
 	if m.height < 25 {
 		// One leading newline, not two: the repost entry makes the longest line
 		// wrap, and the extra row would push the box's title off a short screen.
-		keys = "\nj/k move · g/G ends · f feed\nb saved · L lists · / search\nl like · t repost · r reply · y copy\nenter open · e read · i zoom\nA alt · o open · R reload\nP post · @ acct · q quit\nn/x col± · s acct · I/T img"
+		keys = "\nj/k move · g/G ends · f feed\nb saved · L lists · / search\nl like · t repost · r reply\nenter open · e read · i zoom\nA alt · o open · R reload\nQ quote · y copy · P post\n@ acct · q quit · n/x col±\ns acct · I/T img"
 		if m.mode == modeThread {
-			keys = "\n\nj/k move · g/G ends\nl like · t repost · r reply · y copy\ne read · i zoom · A alt text\nR refresh · o browser · / search\nesc back · q quit"
+			keys = "\n\nj/k move · g/G ends\nl like · t repost · r reply\nQ quote · y copy · e read\ni zoom · A alt text\nR refresh · o browser · / search\nesc back · q quit"
 		}
 	}
 	images := "images: " + string(m.imageMode)

--- a/internal/timeline/view.go
+++ b/internal/timeline/view.go
@@ -683,8 +683,16 @@ func (m Model) actionLine(post api.TimelinePost) string {
 	if post.ReplyCount > 0 {
 		segments = append(segments, quiet.Render("↩ "+formatCount(post.ReplyCount)))
 	}
-	if post.RepostCount > 0 {
-		segments = append(segments, quiet.Render("⟳ "+formatCount(post.RepostCount)))
+	// A reposted post shows its ⟳ in green even at zero reposts, mirroring how
+	// the like heart switches color instead of hiding.
+	repostedStyle := lipgloss.NewStyle().Foreground(green)
+	if post.RepostCount > 0 || post.Reposted {
+		repost := "⟳ " + formatCount(post.RepostCount)
+		if post.Reposted {
+			segments = append(segments, repostedStyle.Render(repost))
+		} else {
+			segments = append(segments, quiet.Render(repost))
+		}
 	}
 	if views, err := strconv.Atoi(post.ViewCount); err == nil && views > 0 {
 		segments = append(segments, quiet.Render(formatCount(views)+" views"))
@@ -1091,14 +1099,16 @@ func (m Model) viewHelp() string {
 	if w > 54 {
 		w = 54
 	}
-	keys := "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nf           for you / following\nb           bookmarks / for you\n@           next account\n/           search\nL           lists\nn           add column\nx           remove column\ns           column account\nI           image mode\nT           theme\nl           like / unlike\nr           reply\nR           refresh\nenter       open replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\nP           new post\ng / G       top / bottom\nctrl+l      redraw screen\nq           quit"
+	keys := "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nf           for you / following\nb           bookmarks / for you\n@           next account\n/           search\nL           lists\nn           add column\nx           remove column\ns           column account\nI           image mode\nT           theme\nl           like / unlike\nt           repost / unrepost\nr           reply\nR           refresh\nenter       open replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\nP           new post\ng / G       top / bottom\nctrl+l      redraw screen\nq           quit"
 	if m.mode == modeThread {
-		keys = "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\n/           search\nl           like / unlike\nr           reply to selected\nR           refresh replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\ng / G       top / bottom\nctrl+l      redraw screen\nesc         back to timeline\nq           quit"
+		keys = "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\n/           search\nl           like / unlike\nt           repost / unrepost\nr           reply to selected\nR           refresh replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\ng / G       top / bottom\nctrl+l      redraw screen\nesc         back to timeline\nq           quit"
 	}
 	if m.height < 25 {
-		keys = "\n\nj/k move · g/G ends · f feed\nb saved · L lists · / search\nl like · r reply · y copy\nenter open · e read · i zoom\nA alt · o open · R reload\nP post · @ acct · q quit\nn/x col± · s acct · I/T img"
+		// One leading newline, not two: the repost entry makes the longest line
+		// wrap, and the extra row would push the box's title off a short screen.
+		keys = "\nj/k move · g/G ends · f feed\nb saved · L lists · / search\nl like · t repost · r reply · y copy\nenter open · e read · i zoom\nA alt · o open · R reload\nP post · @ acct · q quit\nn/x col± · s acct · I/T img"
 		if m.mode == modeThread {
-			keys = "\n\nj/k move · g/G ends\nl like · r reply · y copy\ne read · i zoom · A alt text\nR refresh · o browser · / search\nesc back · q quit"
+			keys = "\n\nj/k move · g/G ends\nl like · t repost · r reply · y copy\ne read · i zoom · A alt text\nR refresh · o browser · / search\nesc back · q quit"
 		}
 	}
 	images := "images: " + string(m.imageMode)

--- a/internal/timeline/view_test.go
+++ b/internal/timeline/view_test.go
@@ -106,7 +106,7 @@ func TestSelectedImageRowsCarryGutter(t *testing.T) {
 	m.syncViewport()
 	content, _, _ := m.renderFeedContent()
 	for _, line := range strings.Split(content, "\n") {
-		if strings.Contains(line, "IMGROW") && !strings.Contains(line, "▎") {
+		if strings.Contains(line, "IMGROW") && !strings.Contains(line, "▌") {
 			t.Fatalf("image row lost the selection gutter: %q", line)
 		}
 	}
@@ -154,7 +154,7 @@ func TestImageBlockIsPaddedWithGutterLines(t *testing.T) {
 		}
 		above, below := lines[i-1], lines[i+1]
 		for _, spacer := range []string{above, below} {
-			if !strings.Contains(spacer, "▎") || strings.TrimSpace(strings.ReplaceAll(spacer, "▎", "")) != "" {
+			if !strings.Contains(spacer, "▌") || strings.TrimSpace(strings.ReplaceAll(spacer, "▌", "")) != "" {
 				t.Fatalf("image is not framed by blank gutter lines:\n%s", content)
 			}
 		}
@@ -203,7 +203,7 @@ func headerIndent(t *testing.T, lines []string, handle string) int {
 		if !strings.Contains(stripped, handle) {
 			continue
 		}
-		return lipgloss.Width(stripped) - lipgloss.Width(strings.TrimLeft(stripped, "│▎ "))
+		return lipgloss.Width(stripped) - lipgloss.Width(strings.TrimLeft(stripped, "│▌ "))
 	}
 	t.Fatalf("no header for %s in:\n%s", handle, strings.Join(lines, "\n"))
 	return 0
@@ -270,7 +270,7 @@ func TestSelectedReplyUsesTheReplyAccent(t *testing.T) {
 		}
 	}
 	for i, line := range lines {
-		if strings.Contains(ansi.Strip(line), "▎") != (i >= header) {
+		if strings.Contains(ansi.Strip(line), "▌") != (i >= header) {
 			t.Fatalf("line %d does not agree with the selection (header at %d):\n%s",
 				i, header, strings.Join(lines, "\n"))
 		}

--- a/internal/timeline/view_test.go
+++ b/internal/timeline/view_test.go
@@ -79,9 +79,9 @@ func TestMediaChip(t *testing.T) {
 
 func TestUnselectedPostNearSelectionRendersCachedImage(t *testing.T) {
 	m := New()
-	m.loading = false
-	m.posts = mediaPosts(10)
-	m.selected = 0
+	m.cur().loading = false
+	m.cur().posts = mediaPosts(10)
+	m.cur().selected = 0
 	m.previews["p1"] = previewState{content: "CACHED-IMAGE-BLOCK"}
 	m.previews["p9"] = previewState{content: "FAR-IMAGE-BLOCK"}
 	m.syncViewport()
@@ -99,9 +99,9 @@ func TestUnselectedPostNearSelectionRendersCachedImage(t *testing.T) {
 
 func TestSelectedImageRowsCarryGutter(t *testing.T) {
 	m := New()
-	m.loading = false
-	m.posts = mediaPosts(1)
-	m.selected = 0
+	m.cur().loading = false
+	m.cur().posts = mediaPosts(1)
+	m.cur().selected = 0
 	m.previews["p0"] = previewState{content: "IMGROW1\nIMGROW2\nIMGROW3"}
 	m.syncViewport()
 	content, _, _ := m.renderFeedContent()
@@ -114,11 +114,11 @@ func TestSelectedImageRowsCarryGutter(t *testing.T) {
 
 func TestMultiImagePostShowsCountUnderPreview(t *testing.T) {
 	m := New()
-	m.loading = false
+	m.cur().loading = false
 	posts := mediaPosts(1)
 	posts[0].Media = append(posts[0].Media, posts[0].Media[0], posts[0].Media[0])
-	m.posts = posts
-	m.selected = 0
+	m.cur().posts = posts
+	m.cur().selected = 0
 	m.previews["p0"] = previewState{content: "IMGROW"}
 	m.syncViewport()
 	content, _, _ := m.renderFeedContent()
@@ -126,8 +126,8 @@ func TestMultiImagePostShowsCountUnderPreview(t *testing.T) {
 		t.Fatalf("selected multi-image post is missing its count caption:\n%s", content)
 	}
 
-	m.posts = append(mediaPosts(1), posts[0])
-	m.posts[1].ID = "p1"
+	m.cur().posts = append(mediaPosts(1), posts[0])
+	m.cur().posts[1].ID = "p1"
 	m.previews["p1"] = previewState{content: "IMGROW"}
 	m.syncViewport()
 	content, _, _ = m.renderFeedContent()
@@ -138,9 +138,9 @@ func TestMultiImagePostShowsCountUnderPreview(t *testing.T) {
 
 func TestImageBlockIsPaddedWithGutterLines(t *testing.T) {
 	m := New()
-	m.loading = false
-	m.posts = mediaPosts(1)
-	m.selected = 0
+	m.cur().loading = false
+	m.cur().posts = mediaPosts(1)
+	m.cur().selected = 0
 	m.previews["p0"] = previewState{content: "IMGROW"}
 	m.syncViewport()
 	content, _, _ := m.renderFeedContent()
@@ -164,15 +164,15 @@ func TestImageBlockIsPaddedWithGutterLines(t *testing.T) {
 // threadModel builds a conversation whose replies nest one level per post.
 func threadModel(depths ...int) Model {
 	m := NewWithImageMode("off")
-	m.loading = false
+	m.cur().loading = false
 	m.mode = modeThread
-	m.threadRootID = "root"
-	m.threadPosts = []api.ConversationPost{
+	m.cur().threadRootID = "root"
+	m.cur().threadPosts = []api.ConversationPost{
 		{TimelinePost: api.TimelinePost{ID: "root", AuthorName: "Alice", Handle: "alice", Text: "the first word"}},
 	}
 	for i, depth := range depths {
-		parent := m.threadPosts[len(m.threadPosts)-1].ID
-		m.threadPosts = append(m.threadPosts, api.ConversationPost{
+		parent := m.cur().threadPosts[len(m.cur().threadPosts)-1].ID
+		m.cur().threadPosts = append(m.cur().threadPosts, api.ConversationPost{
 			TimelinePost: api.TimelinePost{
 				ID: fmt.Sprintf("r%d", i), AuthorName: "Bob", Handle: fmt.Sprintf("bob%d", i),
 				Text: "a reply", InReplyToID: parent,
@@ -220,8 +220,8 @@ func TestThreadRepliesIndentBehindTheRail(t *testing.T) {
 
 	// The feed is untouched by any of this.
 	feed := NewWithImageMode("off")
-	feed.loading = false
-	feed.posts = []api.TimelinePost{{ID: "1", AuthorName: "Alice", Handle: "alice", Text: "the first word"}}
+	feed.cur().loading = false
+	feed.cur().posts = []api.TimelinePost{{ID: "1", AuthorName: "Alice", Handle: "alice", Text: "the first word"}}
 	content, _, _ := feed.renderFeedContent()
 	if got := headerIndent(t, strings.Split(content, "\n"), "@alice"); got != 2 {
 		t.Errorf("feed post indents %d columns, want 2:\n%s", got, content)
@@ -257,7 +257,7 @@ func TestSelectedReplyUsesTheReplyAccent(t *testing.T) {
 
 	// The bar itself lands on the selected post at its own indent.
 	m := threadModel(1)
-	m.selected = 1
+	m.cur().selected = 1
 	lines := threadLines(t, m)
 	if got := headerIndent(t, lines, "@bob0"); got != 4 {
 		t.Errorf("selected reply indents %d columns, want 4", got)
@@ -279,11 +279,11 @@ func TestSelectedReplyUsesTheReplyAccent(t *testing.T) {
 
 func TestDeepRepliesStayInsideTheFrame(t *testing.T) {
 	m := threadModel(1, 2, 3, 4, 5)
-	for i := range m.threadPosts {
-		m.threadPosts[i].Text = strings.Repeat("wordy ", 40)
+	for i := range m.cur().threadPosts {
+		m.cur().threadPosts[i].Text = strings.Repeat("wordy ", 40)
 	}
-	m.selected = len(m.threadPosts) - 1
-	m.expanded = true
+	m.cur().selected = len(m.cur().threadPosts) - 1
+	m.cur().expanded = true
 	for _, line := range threadLines(t, m) {
 		if width := lipgloss.Width(line); width > m.contentWidth() {
 			t.Fatalf("line is %d columns wide, frame is %d: %q", width, m.contentWidth(), ansi.Strip(line))
@@ -308,7 +308,7 @@ func TestReplyNamesTheParentTheRailCannotPlace(t *testing.T) {
 
 	// A reply that arrives out of order does not sit under its parent.
 	m = threadModel(1, 2, 2)
-	m.threadPosts[3].InReplyToID = "r0"
+	m.cur().threadPosts[3].InReplyToID = "r0"
 	if content := threadContent(t, m); !strings.Contains(content, "↳ @bob0") {
 		t.Fatalf("an out-of-order reply did not name its parent:\n%s", content)
 	}
@@ -317,11 +317,11 @@ func TestReplyNamesTheParentTheRailCannotPlace(t *testing.T) {
 func TestIndentedReplyKeepsAWideCachedImageInsideTheFrame(t *testing.T) {
 	m := threadModel(1, 2)
 	m.imageMode = imageModeANSI
-	last := len(m.threadPosts) - 1
-	m.threadPosts[last].Media = []api.TimelineMedia{{URL: "https://pbs.twimg.com/media/abc", Type: "photo"}}
+	last := len(m.cur().threadPosts) - 1
+	m.cur().threadPosts[last].Media = []api.TimelineMedia{{URL: "https://pbs.twimg.com/media/abc", Type: "photo"}}
 	// A preview cached while its post sat in the feed fills the whole frame.
-	m.previews[m.threadPosts[last].ID] = previewState{content: strings.Repeat("X", m.contentWidth()-4)}
-	m.selected = last
+	m.previews[m.cur().threadPosts[last].ID] = previewState{content: strings.Repeat("X", m.contentWidth()-4)}
+	m.cur().selected = last
 	for _, line := range threadLines(t, m) {
 		if width := lipgloss.Width(line); width > m.contentWidth() {
 			t.Fatalf("image row is %d columns wide, frame is %d: %q", width, m.contentWidth(), ansi.Strip(line))
@@ -357,14 +357,14 @@ func TestHelpShowsImageModeNote(t *testing.T) {
 
 func TestUnselectedMediaPostShowsChip(t *testing.T) {
 	m := New()
-	m.loading = false
-	m.posts = []api.TimelinePost{
+	m.cur().loading = false
+	m.cur().posts = []api.TimelinePost{
 		{ID: "1", AuthorName: "Alice", Handle: "alice", Text: "words"},
 		{ID: "2", AuthorName: "Bob", Handle: "bob", Text: "pic https://t.co/x",
 			Media: []api.TimelineMedia{{URL: "https://pbs.twimg.com/a", Type: "photo"}}},
 	}
 	m.syncViewport()
-	view := m.viewport.View()
+	view := m.cur().viewport.View()
 	if !strings.Contains(view, "▣ image") {
 		t.Fatalf("unselected media post has no chip:\n%s", view)
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -234,7 +234,7 @@ func beginPost(parent context.Context, text string, attachments []media.Attachme
 				events <- postProgressMsg{event: event}
 			})
 			if client.ApplyRefreshedQueryIDs(cfg) {
-				_ = mgr.Save(cfg)
+				_ = mgr.SaveQueryIDs(cfg)
 			}
 			events <- postResultMsg{id: id, err: err, diagnostic: client.LastDiagnostic()}
 			close(events)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -230,7 +230,7 @@ func beginPost(parent context.Context, text string, attachments []media.Attachme
 				uploads = append(uploads, upload)
 			}
 			client := api.NewWebClient(cfg)
-			id, err := client.PostTweet(ctx, text, "", uploads, func(event api.PostEvent) {
+			id, err := client.PostTweet(ctx, text, "", "", uploads, func(event api.PostEvent) {
 				events <- postProgressMsg{event: event}
 			})
 			if client.ApplyRefreshedQueryIDs(cfg) {

--- a/pkg/api/article_live_test.go
+++ b/pkg/api/article_live_test.go
@@ -1,0 +1,50 @@
+package api
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/melqtx/xeet/pkg/config"
+)
+
+// Article parsing rests on X's response shape (article.article_results.result
+// .plain_text), which a fixture can only guess at. Given a real article post
+// id, this proves both the withArticlePlainText opt-in and the field path.
+func TestFetchArticleLive(t *testing.T) {
+	if os.Getenv("XEET_LIVE_ARTICLE") != "1" {
+		t.Skip("set XEET_LIVE_ARTICLE=1 to run")
+	}
+	tweetID := os.Getenv("XEET_LIVE_ARTICLE_TWEET_ID")
+	if tweetID == "" {
+		t.Skip("set XEET_LIVE_ARTICLE_TWEET_ID to a post that carries an X article")
+	}
+	mgr, err := config.NewConfigManager()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := mgr.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+	defer cancel()
+	client := NewWebClient(cfg)
+
+	page, err := client.FetchTweetDetail(ctx, tweetID, "", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Posts) == 0 || page.Posts[0].ID != tweetID {
+		t.Fatalf("focal post %s missing from its own detail page", tweetID)
+	}
+	post := page.Posts[0]
+	if post.Article == nil {
+		t.Fatalf("post %s parsed without an article body; the opt-in or the field path drifted", tweetID)
+	}
+	if post.Article.Text == "" {
+		t.Fatal("article parsed but plain_text is empty")
+	}
+	t.Logf("article title=%q body=%d chars", post.Article.Title, len(post.Article.Text))
+}

--- a/pkg/api/bookmarks.go
+++ b/pkg/api/bookmarks.go
@@ -1,8 +1,22 @@
 package api
 
-import "context"
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
 
-const bookmarksOperation = "Bookmarks"
+const (
+	bookmarksOperation      = "Bookmarks"
+	createBookmarkOperation = "CreateBookmark"
+	deleteBookmarkOperation = "DeleteBookmark"
+	// The first live run answered a bodyless 404 without the transaction
+	// header — the same shape search.go and retweet.go document — so every
+	// attempt mints a fresh one, exactly like the retweet mutations.
+	bookmarkWithTransactionID = true
+)
 
 // FetchBookmarks returns a page of the authenticated user's bookmarks.
 func (c *WebClient) FetchBookmarks(ctx context.Context, cursor string, count int) (*TimelinePage, error) {
@@ -17,4 +31,94 @@ func (c *WebClient) FetchBookmarks(ctx context.Context, cursor string, count int
 			}
 			return variables
 		})
+}
+
+// SetTweetBookmarked bookmarks or un-bookmarks a post using X's web GraphQL
+// mutations. Like the retweet pair there is no shipped fallback query id: the
+// id is discovered from X's live bundles (or supplied via
+// XEET_CREATEBOOKMARK_QID / XEET_DELETEBOOKMARK_QID) and cached in the config.
+func (c *WebClient) SetTweetBookmarked(ctx context.Context, tweetID string, bookmarked bool) error {
+	if c.authToken == "" || c.ct0 == "" {
+		return fmt.Errorf("no session; run 'xeet auth' first")
+	}
+	if tweetID == "" {
+		return fmt.Errorf("tweet id is empty")
+	}
+	operation, environment := createBookmarkOperation, "XEET_CREATEBOOKMARK_QID"
+	if !bookmarked {
+		operation, environment = deleteBookmarkOperation, "XEET_DELETEBOOKMARK_QID"
+	}
+	qid := c.operationQueryID(operation, "", environment)
+	if qid == "" {
+		fresh, discoverErr := c.discoverOperation(ctx, operation)
+		if discoverErr != nil {
+			return fmt.Errorf("discover %s endpoint: %w", operation, discoverErr)
+		}
+		qid = fresh
+	}
+	res, err := c.doTweetBookmark(ctx, operation, qid, tweetID)
+	if err != nil {
+		return err
+	}
+	if needsQueryIDRefresh(res) {
+		fresh, discoverErr := c.discoverOperation(ctx, operation)
+		if discoverErr != nil {
+			return fmt.Errorf("%s endpoint changed and discovery failed: %w", operation, discoverErr)
+		}
+		res, err = c.doTweetBookmark(ctx, operation, fresh, tweetID)
+		if err != nil {
+			return err
+		}
+	}
+	if err := statusToError(res.status, res.header); err != nil {
+		return err
+	}
+	if isTransientStatus(res.status) {
+		return &ServiceUnavailableError{Status: res.status}
+	}
+	if res.status != http.StatusOK {
+		return fmt.Errorf("bookmark API error %d: %s", res.status, truncate(res.body))
+	}
+	var payload any
+	if err := json.Unmarshal(res.body, &payload); err != nil {
+		return fmt.Errorf("decode bookmark response: %w", err)
+	}
+	if err := graphQLError(payload); err != nil {
+		return err
+	}
+	return nil
+}
+
+// doTweetBookmark retries only CreateBookmark: re-adding a bookmark is a
+// no-op, but the live endpoint answers a replayed delete with a GraphQL
+// "_Missing: not found in actor's favorites" error. A timed-out delete that
+// actually landed must not be re-fired, so DeleteBookmark gets a single
+// attempt — the same call CreateRetweet makes.
+func (c *WebClient) doTweetBookmark(ctx context.Context, operation, qid, tweetID string) (*httpResult, error) {
+	payload := map[string]any{
+		"variables": map[string]string{"tweet_id": tweetID},
+		"queryId":   qid,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	endpoint := fmt.Sprintf("https://x.com/i/api/graphql/%s/%s", qid, operation)
+	return c.send(ctx, func() (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		c.setHeaders(req)
+		// Minted per attempt (see doTimelineOp): a replayed id is rejected
+		// exactly like an omitted one.
+		if bookmarkWithTransactionID && c.transactionID != nil {
+			transactionID, err := c.transactionID(ctx, req.Method, req.URL.Path)
+			if err != nil {
+				return nil, fmt.Errorf("generate X transaction id: %w", err)
+			}
+			req.Header.Set("X-Client-Transaction-Id", transactionID)
+		}
+		return req, nil
+	}, operation == createBookmarkOperation, 2<<20)
 }

--- a/pkg/api/bookmarks_live_test.go
+++ b/pkg/api/bookmarks_live_test.go
@@ -57,3 +57,100 @@ func TestBookmarksLive(t *testing.T) {
 		t.Logf("discovered bookmarks query id staged for persistence (len=%d)", len(cfg.BookmarksQID))
 	}
 }
+
+// The bookmark round trip cannot be proven by mocks: only a live
+// Create/Delete pair against a known post shows both the mutation shape and
+// the legacy.bookmarked flag flipping back.
+func TestBookmarkMutationLive(t *testing.T) {
+	if os.Getenv("XEET_LIVE_BOOKMARK") != "1" {
+		t.Skip("set XEET_LIVE_BOOKMARK=1 to run")
+	}
+	mgr, err := config.NewConfigManager()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := mgr.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	client := NewWebClient(cfg)
+
+	tweetID := os.Getenv("XEET_LIVE_BOOKMARK_TWEET_ID")
+	if tweetID == "" {
+		// Hands-free default: bookmark one of the account's own posts.
+		if cfg.Handle == "" {
+			t.Skip("set XEET_LIVE_BOOKMARK_TWEET_ID to one of your own older posts")
+		}
+		found, err := client.FetchSearchTimeline(ctx, "from:"+cfg.Handle, "", 10)
+		if err != nil {
+			t.Fatalf("search own posts: %v", err)
+		}
+		for _, post := range found.Posts {
+			if post.Handle == cfg.Handle {
+				tweetID = post.ID
+				break
+			}
+		}
+		if tweetID == "" {
+			t.Skip("no own posts found to bookmark; set XEET_LIVE_BOOKMARK_TWEET_ID")
+		}
+		t.Logf("bookmark target: own post %s", tweetID)
+	}
+
+	bookmarked := func(want bool) {
+		t.Helper()
+		page, err := client.FetchTweetDetail(ctx, tweetID, "", 5)
+		if err != nil {
+			t.Fatalf("read back tweet detail: %v", err)
+		}
+		for _, post := range page.Posts {
+			if post.ID == tweetID {
+				if post.Bookmarked != want {
+					t.Fatalf("bookmarked flag = %v, want %v", post.Bookmarked, want)
+				}
+				return
+			}
+		}
+		t.Fatalf("tweet %s missing from its own detail page", tweetID)
+	}
+
+	if err := client.SetTweetBookmarked(ctx, tweetID, true); err != nil {
+		t.Fatalf("CreateBookmark: %v", err)
+	}
+	// Even a failed verify below must attempt to undo the bookmark; leave
+	// nothing behind on the account.
+	t.Cleanup(func() {
+		uctx, ucancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer ucancel()
+		if err := client.SetTweetBookmarked(uctx, tweetID, false); err != nil {
+			t.Logf("cleanup un-bookmark failed (remove it by hand): %v", err)
+		}
+	})
+	bookmarked(true)
+
+	if err := client.SetTweetBookmarked(ctx, tweetID, false); err != nil {
+		t.Fatalf("DeleteBookmark: %v", err)
+	}
+	bookmarked(false)
+
+	for operation, qid := range map[string]string{
+		"CreateBookmark": cfg.CreateBookmarkQID,
+		"DeleteBookmark": cfg.DeleteBookmarkQID,
+	} {
+		if qid != "" {
+			continue
+		}
+		if !client.ApplyRefreshedQueryIDs(cfg) {
+			t.Fatalf("discovered a %s id but nothing was staged for persistence", operation)
+		}
+		t.Logf("discovered %s query id staged for persistence", operation)
+	}
+	if cfg.CreateBookmarkQID == "" || cfg.DeleteBookmarkQID == "" {
+		t.Fatalf("staged ids incomplete: create=%q delete=%q", cfg.CreateBookmarkQID, cfg.DeleteBookmarkQID)
+	}
+	if err := mgr.SaveQueryIDs(cfg); err != nil {
+		t.Fatalf("persist refreshed query ids: %v", err)
+	}
+}

--- a/pkg/api/bookmarks_test.go
+++ b/pkg/api/bookmarks_test.go
@@ -3,10 +3,13 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/melqtx/xeet/pkg/config"
 )
@@ -210,4 +213,206 @@ func decodeBookmarkVariables(t *testing.T, req *http.Request) map[string]any {
 		t.Fatalf("decode variables %q: %v", raw, err)
 	}
 	return variables
+}
+
+func configuredBookmarkMutationClient(t *testing.T, cfg *config.Config, handler func(*http.Request) (*http.Response, error)) *WebClient {
+	t.Helper()
+	cfg.AuthToken, cfg.CT0 = "auth", "csrf"
+	client := NewWebClient(cfg)
+	client.httpClient = &http.Client{Transport: roundTripFunc(handler)}
+	client.retryDelay = time.Millisecond
+	// The generator scrapes X's transaction page; tests stub the minting step
+	// and assert on the header it produces instead.
+	client.transactionID = func(context.Context, string, string) (string, error) {
+		return "tx-id", nil
+	}
+	return client
+}
+
+func TestSetTweetBookmarkedPostsTweetIDToCreateBookmark(t *testing.T) {
+	var path, body string
+	client := configuredBookmarkMutationClient(t, &config.Config{CreateBookmarkQID: "cb-qid"}, func(req *http.Request) (*http.Response, error) {
+		path = req.URL.Path
+		data, _ := io.ReadAll(req.Body)
+		body = string(data)
+		return response(http.StatusOK, `{"data":{"tweet_bookmark_put":"Done"}}`), nil
+	})
+
+	if err := client.SetTweetBookmarked(context.Background(), "123", true); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(path, "/cb-qid/CreateBookmark") || !strings.Contains(body, `"tweet_id":"123"`) {
+		t.Fatalf("path=%q body=%s", path, body)
+	}
+}
+
+func TestSetTweetUnbookmarkedPostsTweetIDToDeleteBookmark(t *testing.T) {
+	var path, body string
+	client := configuredBookmarkMutationClient(t, &config.Config{DeleteBookmarkQID: "db-qid"}, func(req *http.Request) (*http.Response, error) {
+		path = req.URL.Path
+		data, _ := io.ReadAll(req.Body)
+		body = string(data)
+		return response(http.StatusOK, `{"data":{"tweet_bookmark_delete":"Done"}}`), nil
+	})
+
+	if err := client.SetTweetBookmarked(context.Background(), "123", false); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(path, "/db-qid/DeleteBookmark") || !strings.Contains(body, `"tweet_id":"123"`) {
+		t.Fatalf("path=%q body=%s", path, body)
+	}
+}
+
+// The bookmark mutations answer a bodyless 404 without the transaction
+// header — confirmed on the first live run — so every attempt must carry the
+// minted id, exactly like the retweet pair.
+func TestSetTweetBookmarkedSendsTransactionHeader(t *testing.T) {
+	var header string
+	client := configuredBookmarkMutationClient(t, &config.Config{CreateBookmarkQID: "cb-qid"}, func(req *http.Request) (*http.Response, error) {
+		header = req.Header.Get("X-Client-Transaction-Id")
+		return response(http.StatusOK, `{"data":{"tweet_bookmark_put":"Done"}}`), nil
+	})
+
+	if err := client.SetTweetBookmarked(context.Background(), "123", true); err != nil {
+		t.Fatal(err)
+	}
+	if header != "tx-id" {
+		t.Fatalf("X-Client-Transaction-Id = %q, want tx-id", header)
+	}
+}
+
+func TestSetTweetBookmarkedDiscoversMissingQueryIDBeforeFirstRequestAndExposesItForPersistence(t *testing.T) {
+	var path string
+	client := configuredBookmarkMutationClient(t, &config.Config{}, func(req *http.Request) (*http.Response, error) {
+		path = req.URL.Path
+		return response(http.StatusOK, `{"data":{"tweet_bookmark_put":"Done"}}`), nil
+	})
+	client.discover = func(_ context.Context, auth, ct0, operation string) (string, error) {
+		if auth != "auth" || ct0 != "csrf" || operation != createBookmarkOperation {
+			t.Fatalf("discovery args = auth:%q ct0:%q operation:%q", auth, ct0, operation)
+		}
+		return "fresh-cb", nil
+	}
+
+	if err := client.SetTweetBookmarked(context.Background(), "123", true); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(path, "/fresh-cb/CreateBookmark") {
+		t.Fatalf("path=%q", path)
+	}
+	cfg := &config.Config{}
+	if !client.ApplyRefreshedQueryIDs(cfg) || cfg.CreateBookmarkQID != "fresh-cb" {
+		t.Fatalf("config=%+v", cfg)
+	}
+}
+
+func TestSetTweetBookmarkedRotatesQueryIDOnceOnPersistedQueryMiss(t *testing.T) {
+	var paths []string
+	client := configuredBookmarkMutationClient(t, &config.Config{DeleteBookmarkQID: "stale"}, func(req *http.Request) (*http.Response, error) {
+		paths = append(paths, req.URL.Path)
+		if len(paths) == 1 {
+			return response(http.StatusNotFound, ``), nil
+		}
+		return response(http.StatusOK, `{"data":{"tweet_bookmark_delete":"Done"}}`), nil
+	})
+	discoveries := 0
+	client.discover = func(_ context.Context, _, _, operation string) (string, error) {
+		discoveries++
+		return "fresh-db", nil
+	}
+
+	if err := client.SetTweetBookmarked(context.Background(), "123", false); err != nil {
+		t.Fatal(err)
+	}
+	if discoveries != 1 || len(paths) != 2 ||
+		!strings.Contains(paths[0], "/stale/DeleteBookmark") || !strings.Contains(paths[1], "/fresh-db/DeleteBookmark") {
+		t.Fatalf("discoveries=%d paths=%v", discoveries, paths)
+	}
+}
+
+// Bookmarks are only half idempotent: re-adding one is a no-op, but the live
+// endpoint errors on a replayed delete ("_Missing: not found in actor's
+// favorites"). So a create rides out a transient 503 while a delete surfaces
+// after exactly one attempt and leaves the retry to the user.
+func TestSetTweetBookmarkedRetriesTransientStatus(t *testing.T) {
+	attempts := 0
+	client := configuredBookmarkMutationClient(t, &config.Config{CreateBookmarkQID: "cb-qid"}, func(req *http.Request) (*http.Response, error) {
+		attempts++
+		if attempts == 1 {
+			return response(http.StatusServiceUnavailable, ``), nil
+		}
+		return response(http.StatusOK, `{"data":{"tweet_bookmark_put":"Done"}}`), nil
+	})
+
+	if err := client.SetTweetBookmarked(context.Background(), "123", true); err != nil {
+		t.Fatal(err)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2 (transient retry for idempotent bookmarks)", attempts)
+	}
+}
+
+func TestSetTweetBookmarkedSurfacesPersistentTransientStatus(t *testing.T) {
+	client := configuredBookmarkMutationClient(t, &config.Config{CreateBookmarkQID: "cb-qid"}, func(req *http.Request) (*http.Response, error) {
+		return response(http.StatusServiceUnavailable, ``), nil
+	})
+
+	err := client.SetTweetBookmarked(context.Background(), "123", true)
+	var unavailable *ServiceUnavailableError
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("err = %v, want ServiceUnavailableError", err)
+	}
+}
+
+func TestSetTweetUnbookmarkedDoesNotRetryTransientStatus(t *testing.T) {
+	attempts := 0
+	client := configuredBookmarkMutationClient(t, &config.Config{DeleteBookmarkQID: "db-qid"}, func(req *http.Request) (*http.Response, error) {
+		attempts++
+		return response(http.StatusServiceUnavailable, ``), nil
+	})
+
+	err := client.SetTweetBookmarked(context.Background(), "123", false)
+	var unavailable *ServiceUnavailableError
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("err = %v, want ServiceUnavailableError", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1 (no transient retry for bookmark delete)", attempts)
+	}
+}
+
+func TestSetTweetBookmarkedHonorsEnvironmentQueryIDOverride(t *testing.T) {
+	t.Setenv("XEET_CREATEBOOKMARK_QID", "env-cb")
+	var path string
+	client := configuredBookmarkMutationClient(t, &config.Config{CreateBookmarkQID: "cfg-cb"}, func(req *http.Request) (*http.Response, error) {
+		path = req.URL.Path
+		return response(http.StatusOK, `{"data":{"tweet_bookmark_put":"Done"}}`), nil
+	})
+
+	if err := client.SetTweetBookmarked(context.Background(), "123", true); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(path, "/env-cb/CreateBookmark") {
+		t.Fatalf("path=%q", path)
+	}
+}
+
+func TestSetTweetBookmarkedRejectsMissingSessionAndEmptyIDBeforeAnyRequest(t *testing.T) {
+	requests := 0
+	client := configuredBookmarkMutationClient(t, &config.Config{CreateBookmarkQID: "cb-qid"}, func(req *http.Request) (*http.Response, error) {
+		requests++
+		return response(http.StatusOK, `{}`), nil
+	})
+	client.authToken, client.ct0 = "", ""
+
+	if err := client.SetTweetBookmarked(context.Background(), "123", true); err == nil {
+		t.Fatal("SetTweetBookmarked succeeded without a session")
+	}
+	client.authToken, client.ct0 = "auth", "csrf"
+	if err := client.SetTweetBookmarked(context.Background(), "", true); err == nil {
+		t.Fatal("SetTweetBookmarked succeeded with an empty tweet id")
+	}
+	if requests != 0 {
+		t.Fatalf("requests = %d, want 0", requests)
+	}
 }

--- a/pkg/api/browsers_test.go
+++ b/pkg/api/browsers_test.go
@@ -25,3 +25,31 @@ func TestBetterLoginResultPrefersXDomainThenRecency(t *testing.T) {
 		t.Fatal("newer session was not preferred within the same domain")
 	}
 }
+
+func TestScanCollapsesOnlyByteIdenticalCookiePairs(t *testing.T) {
+	now := time.Now()
+	results := sortAndDeduplicateLoginResults([]LoginResult{
+		{
+			AuthToken: "same-auth", CT0: "same-ct0", Profile: "Copied",
+			CookieDomain: "x.com", LastUsedAt: now.Add(-time.Hour),
+		},
+		{
+			AuthToken: "same-auth", CT0: "same-ct0", Profile: "Fresh",
+			CookieDomain: "x.com", LastUsedAt: now,
+		},
+		{
+			AuthToken: "rotated-auth", CT0: "rotated-ct0", Profile: "Older cookies",
+			CookieDomain: "x.com", LastUsedAt: now.Add(-2 * time.Hour),
+		},
+	})
+
+	if len(results) != 2 {
+		t.Fatalf("scan returned %d sessions, want 2 distinct cookie pairs", len(results))
+	}
+	if results[0].Profile != "Fresh" {
+		t.Fatalf("first profile = %q, want freshest identical-cookie copy", results[0].Profile)
+	}
+	if results[1].Profile != "Older cookies" {
+		t.Fatalf("second profile = %q, want rotated cookie pair to remain selectable", results[1].Profile)
+	}
+}

--- a/pkg/api/conversation.go
+++ b/pkg/api/conversation.go
@@ -9,6 +9,20 @@ import (
 	"strings"
 )
 
+// tweetDetailFieldToggles opts only TweetDetail into article plain text.
+// Flipping the shared timelineFieldToggles instead would reshape every
+// timeline request, while article bodies only matter when reading a single
+// post. withArticleRichContentState stays off: the ProseMirror JSON is heavy
+// and the plain text covers the read use case.
+var tweetDetailFieldToggles = func() map[string]bool {
+	toggles := make(map[string]bool, len(timelineFieldToggles)+1)
+	for key, value := range timelineFieldToggles {
+		toggles[key] = value
+	}
+	toggles["withArticlePlainText"] = true
+	return toggles
+}()
+
 // ConversationPost is one post in a TweetDetail conversation. Depth is
 // relative to the focal post (the focal post itself has depth zero).
 type ConversationPost struct {
@@ -103,7 +117,7 @@ func (c *WebClient) doTweetDetail(ctx context.Context, qid, tweetID, cursor stri
 	variables["count"] = count
 	variablesJSON, _ := json.Marshal(variables)
 	featuresJSON, _ := json.Marshal(timelineFeatures)
-	fieldTogglesJSON, _ := json.Marshal(timelineFieldToggles)
+	fieldTogglesJSON, _ := json.Marshal(tweetDetailFieldToggles)
 
 	params := url.Values{}
 	params.Set("variables", string(variablesJSON))

--- a/pkg/api/conversation_test.go
+++ b/pkg/api/conversation_test.go
@@ -76,6 +76,9 @@ func TestFetchTweetDetailUsesConfiguredQueryIDAndVariables(t *testing.T) {
 				t.Fatalf("variables %s missing %s", variables, want)
 			}
 		}
+		if toggles := req.URL.Query().Get("fieldToggles"); !strings.Contains(toggles, `"withArticlePlainText":true`) {
+			t.Fatalf("fieldToggles %s missing article opt-in", toggles)
+		}
 		return response(http.StatusOK, `{"data":{"threaded_conversation_with_injections_v2":{"instructions":[]}}}`), nil
 	})}
 	page, err := client.FetchTweetDetail(context.Background(), "123", "next", 25)

--- a/pkg/api/cookies_darwin.go
+++ b/pkg/api/cookies_darwin.go
@@ -102,16 +102,25 @@ func (b chromiumBrowser) hasXSession() bool {
 	return false
 }
 
-// ImportBrowserSession reads and decrypts the x.com session from a single named
-// browser (as returned by DetectBrowsers). It only touches that browser's
-// Keychain item, so the user sees at most one permission prompt.
+// ImportBrowserSession returns the best session from one browser.
 func ImportBrowserSession(name string) (*LoginResult, string, error) {
+	results, resolved, err := ImportBrowserSessions(name)
+	if err != nil {
+		return nil, "", err
+	}
+	return &results[0], resolved, nil
+}
+
+// ImportBrowserSessions reads every distinct x.com session from one browser.
+// It only touches that browser's Keychain item, so the user sees at most one
+// permission prompt.
+func ImportBrowserSessions(name string) ([]LoginResult, string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil, "", err
 	}
 	if browser, ok := findGeckoBrowser(name, geckoBrowsers(home)); ok {
-		return importGeckoSession(browser)
+		return importGeckoSessions(browser)
 	}
 	if _, err := exec.LookPath("sqlite3"); err != nil {
 		return nil, "", fmt.Errorf("the 'sqlite3' command isn't available (needed to read the cookie database)")
@@ -132,9 +141,20 @@ func ImportBrowserSession(name string) (*LoginResult, string, error) {
 		return nil, "", fmt.Errorf("couldn't read %s's Keychain key: %v", browser.name, err)
 	}
 
-	var best *LoginResult
+	results := scanChromiumSessions(browser, key, extractXCookies)
+	if len(results) > 0 {
+		return results, browser.name, nil
+	}
+	return nil, "", fmt.Errorf("no logged-in x.com session found in %s. Open x.com in it, log in, then try again", browser.name)
+}
+
+type chromiumCookieExtractor func(string, []byte) (*LoginResult, error)
+
+func scanChromiumSessions(browser chromiumBrowser, key []byte, extract chromiumCookieExtractor) []LoginResult {
+	var results []LoginResult
+	dbs := browser.cookieDBs()
 	for _, db := range dbs {
-		result, err := extractXCookies(db, key)
+		result, err := extract(db, key)
 		if err != nil {
 			continue
 		}
@@ -145,15 +165,10 @@ func ImportBrowserSession(name string) (*LoginResult, string, error) {
 					result.LastUsedAt = info.ModTime()
 				}
 			}
-			if betterLoginResult(result, best) {
-				best = result
-			}
+			results = append(results, *result)
 		}
 	}
-	if best != nil {
-		return best, browser.name, nil
-	}
-	return nil, "", fmt.Errorf("no logged-in x.com session found in %s. Open x.com in it, log in, then try again", browser.name)
+	return sortAndDeduplicateLoginResults(results)
 }
 
 func findChromiumBrowser(name string, browsers []chromiumBrowser) (chromiumBrowser, bool) {

--- a/pkg/api/cookies_darwin_test.go
+++ b/pkg/api/cookies_darwin_test.go
@@ -6,6 +6,8 @@ import (
 	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -86,5 +88,37 @@ func TestChromeCookieTime(t *testing.T) {
 	}
 	if got := chromeCookieTime(0); !got.IsZero() {
 		t.Fatalf("zero Chrome time converted to %v", got)
+	}
+}
+
+func TestDarwinScanReturnsAllLoggedInProfiles(t *testing.T) {
+	root := t.TempDir()
+	for _, profile := range []string{"Default", "Profile 8"} {
+		dir := filepath.Join(root, profile, "Network")
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "Cookies"), []byte("db"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	now := time.Now()
+	browser := chromiumBrowser{name: "Chrome", topDir: root}
+	results := scanChromiumSessions(browser, nil, func(path string, key []byte) (*LoginResult, error) {
+		profile := cookieProfile(path)
+		return &LoginResult{
+			AuthToken:    "auth-" + profile,
+			CT0:          "ct0-" + profile,
+			CookieDomain: "x.com",
+			LastUsedAt:   map[string]time.Time{"Default": now, "Profile 8": now.Add(time.Minute)}[profile],
+		}, nil
+	})
+
+	if len(results) != 2 {
+		t.Fatalf("scan returned %d profiles, want 2", len(results))
+	}
+	if results[0].Profile != "Profile 8" || results[1].Profile != "Default" {
+		t.Fatalf("profiles = %q, %q; want best-first Profile 8, Default", results[0].Profile, results[1].Profile)
 	}
 }

--- a/pkg/api/cookies_gecko.go
+++ b/pkg/api/cookies_gecko.go
@@ -73,21 +73,27 @@ func readGeckoXCookies(path string) ([]*kooky.Cookie, error) {
 	)
 }
 
-func importGeckoSession(b geckoBrowser) (*LoginResult, string, error) {
+type geckoCookieReader func(string) ([]*kooky.Cookie, error)
+
+func importGeckoSessions(b geckoBrowser) ([]LoginResult, string, error) {
+	return scanGeckoSessions(b, readGeckoXCookies)
+}
+
+func scanGeckoSessions(b geckoBrowser, read geckoCookieReader) ([]LoginResult, string, error) {
 	dbs := b.cookieDBs()
 	if len(dbs) == 0 {
 		return nil, "", fmt.Errorf("%s has no cookie database; is it installed and set up?", b.name)
 	}
 
 	var lastErr error
-	var best *LoginResult
+	var results []LoginResult
 	for _, db := range dbs {
 		tmp, copied, err := copyDBAs(db, "cookies.sqlite")
 		if err != nil {
 			lastErr = err
 			continue
 		}
-		cookies, readErr := readGeckoXCookies(copied)
+		cookies, readErr := read(copied)
 		os.RemoveAll(tmp)
 		if readErr != nil {
 			lastErr = readErr
@@ -100,13 +106,12 @@ func importGeckoSession(b geckoBrowser) (*LoginResult, string, error) {
 					result.LastUsedAt = info.ModTime()
 				}
 			}
-			if betterLoginResult(result, best) {
-				best = result
-			}
+			results = append(results, *result)
 		}
 	}
-	if best != nil {
-		return best, b.name, nil
+	results = sortAndDeduplicateLoginResults(results)
+	if len(results) > 0 {
+		return results, b.name, nil
 	}
 
 	if lastErr != nil {
@@ -170,23 +175,24 @@ func selectLoginResult(values []sessionCookieValue, now time.Time) *LoginResult 
 			}
 		}
 	}
-	var best *LoginResult
+	results := make([]LoginResult, 0, len(pairs))
 	for _, candidate := range pairs {
 		if candidate.auth == nil || candidate.ct0 == nil {
 			continue
 		}
-		result := &LoginResult{
+		results = append(results, LoginResult{
 			AuthToken:    candidate.auth.value,
 			CT0:          candidate.ct0.value,
 			CookieDomain: candidate.domain,
 			ExpiresAt:    earliestExpiry(candidate.auth.expires, candidate.ct0.expires),
 			LastUsedAt:   latestTime(candidate.auth.lastUsed, candidate.ct0.lastUsed),
-		}
-		if betterLoginResult(result, best) {
-			best = result
-		}
+		})
 	}
-	return best
+	results = sortAndDeduplicateLoginResults(results)
+	if len(results) == 0 {
+		return nil
+	}
+	return &results[0]
 }
 
 func usableSessionCookie(cookie *kooky.Cookie, now time.Time) bool {
@@ -258,6 +264,28 @@ func betterLoginResult(candidate, current *LoginResult) bool {
 		return candidate.ExpiresAt.After(current.ExpiresAt)
 	}
 	return candidate.Profile < current.Profile
+}
+
+func sortAndDeduplicateLoginResults(results []LoginResult) []LoginResult {
+	sort.SliceStable(results, func(i, j int) bool {
+		return betterLoginResult(&results[i], &results[j])
+	})
+
+	type cookiePair struct {
+		authToken string
+		ct0       string
+	}
+	seen := make(map[cookiePair]struct{}, len(results))
+	unique := results[:0]
+	for _, result := range results {
+		pair := cookiePair{authToken: result.AuthToken, ct0: result.CT0}
+		if _, exists := seen[pair]; exists {
+			continue
+		}
+		seen[pair] = struct{}{}
+		unique = append(unique, result)
+	}
+	return unique
 }
 
 func earliestExpiry(first, second time.Time) time.Time {

--- a/pkg/api/cookies_gecko_test.go
+++ b/pkg/api/cookies_gecko_test.go
@@ -77,6 +77,40 @@ func TestGeckoBrowserFindsMultipleProfilesAndRoots(t *testing.T) {
 	}
 }
 
+func TestGeckoScanReturnsAllLoggedInProfiles(t *testing.T) {
+	root := t.TempDir()
+	for _, profile := range []string{"a.default", "b.work"} {
+		dir := filepath.Join(root, profile)
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "cookies.sqlite"), []byte("db"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	read := 0
+	browser := geckoBrowser{name: "Firefox", roots: []string{root}}
+	results, _, err := scanGeckoSessions(browser, func(string) ([]*kooky.Cookie, error) {
+		read++
+		suffix := string(rune('0' + read))
+		return []*kooky.Cookie{
+			{Cookie: http.Cookie{Name: "auth_token", Value: "auth-" + suffix, Domain: ".x.com"}},
+			{Cookie: http.Cookie{Name: "ct0", Value: "ct0-" + suffix, Domain: ".x.com"}},
+		}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("scan returned %d profiles, want 2", len(results))
+	}
+	profiles := map[string]bool{results[0].Profile: true, results[1].Profile: true}
+	if !profiles["a.default"] || !profiles["b.work"] {
+		t.Fatalf("profiles = %v, want both Firefox profiles", profiles)
+	}
+}
+
 func TestCopyDBAsCopiesWAL(t *testing.T) {
 	dir := t.TempDir()
 	source := filepath.Join(dir, "cookies.sqlite")

--- a/pkg/api/cookies_linux.go
+++ b/pkg/api/cookies_linux.go
@@ -83,15 +83,24 @@ func DetectBrowsers() []string {
 }
 
 func ImportBrowserSession(name string) (*LoginResult, string, error) {
+	results, resolved, err := ImportBrowserSessions(name)
+	if err != nil {
+		return nil, "", err
+	}
+	return &results[0], resolved, nil
+}
+
+// ImportBrowserSessions reads every distinct x.com session from one browser.
+func ImportBrowserSessions(name string) ([]LoginResult, string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil, "", err
 	}
 	if browser, ok := findGeckoBrowser(name, geckoBrowsers(home)); ok {
-		return importGeckoSession(browser)
+		return importGeckoSessions(browser)
 	}
 	if browser, ok := findChromiumBrowser(name, chromiumBrowsers(home)); ok {
-		return importChromiumSession(browser)
+		return importChromiumSessions(browser)
 	}
 	return nil, "", fmt.Errorf("unknown browser %q", name)
 }
@@ -138,7 +147,7 @@ func (b chromiumBrowser) cookieDBs() []string {
 	return out
 }
 
-func importChromiumSession(browser chromiumBrowser) (*LoginResult, string, error) {
+func importChromiumSessions(browser chromiumBrowser) ([]LoginResult, string, error) {
 	dbs := browser.cookieDBs()
 	if len(dbs) == 0 {
 		return nil, "", fmt.Errorf("%s has no cookie database; is it installed and set up?", browser.name)
@@ -156,7 +165,7 @@ func importChromiumSession(browser chromiumBrowser) (*LoginResult, string, error
 	}
 
 	var lastErr error
-	var best *LoginResult
+	var results []LoginResult
 	for _, db := range dbs {
 		tmp, copied, err := copyDB(db)
 		if err != nil {
@@ -176,13 +185,12 @@ func importChromiumSession(browser chromiumBrowser) (*LoginResult, string, error
 					result.LastUsedAt = info.ModTime()
 				}
 			}
-			if betterLoginResult(result, best) {
-				best = result
-			}
+			results = append(results, *result)
 		}
 	}
-	if best != nil {
-		return best, browser.name, nil
+	results = sortAndDeduplicateLoginResults(results)
+	if len(results) > 0 {
+		return results, browser.name, nil
 	}
 
 	if lastErr != nil {

--- a/pkg/api/cookies_linux_test.go
+++ b/pkg/api/cookies_linux_test.go
@@ -53,10 +53,11 @@ func TestLinuxChromiumImportUsesCopiedDatabase(t *testing.T) {
 			}, nil
 		},
 	}
-	result, name, err := importChromiumSession(browser)
+	results, name, err := importChromiumSessions(browser)
 	if err != nil {
 		t.Fatal(err)
 	}
+	result := results[0]
 	if result.AuthToken != "token" || result.CT0 != "csrf" || name != "Chromium" {
 		t.Fatalf("result=%+v name=%q", result, name)
 	}
@@ -83,8 +84,46 @@ func TestLinuxLockedKeyringErrorIsActionable(t *testing.T) {
 			return nil, errors.New("collection is locked")
 		},
 	}
-	_, _, err := importChromiumSession(browser)
+	_, _, err := importChromiumSessions(browser)
 	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "unlock") {
 		t.Fatalf("error = %v, want unlock guidance", err)
+	}
+}
+
+func TestLinuxScanReturnsAllLoggedInProfiles(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "chrome")
+	for _, profile := range []string{"Default", "Profile 8"} {
+		dir := filepath.Join(root, profile, "Network")
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "Cookies"), []byte("db"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	read := 0
+	browser := chromiumBrowser{
+		name:  "Chrome",
+		roots: []string{root},
+		reader: func(context.Context, string, ...kooky.Filter) ([]*kooky.Cookie, error) {
+			read++
+			suffix := string(rune('0' + read))
+			return []*kooky.Cookie{
+				{Cookie: http.Cookie{Name: "auth_token", Value: "auth-" + suffix, Domain: ".x.com"}},
+				{Cookie: http.Cookie{Name: "ct0", Value: "ct0-" + suffix, Domain: ".x.com"}},
+			}, nil
+		},
+	}
+	results, _, err := importChromiumSessions(browser)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("scan returned %d profiles, want 2", len(results))
+	}
+	profiles := map[string]bool{results[0].Profile: true, results[1].Profile: true}
+	if !profiles["Default"] || !profiles["Profile 8"] {
+		t.Fatalf("profiles = %v, want Default and Profile 8", profiles)
 	}
 }

--- a/pkg/api/cookies_other.go
+++ b/pkg/api/cookies_other.go
@@ -9,5 +9,11 @@ func DetectBrowsers() []string { return nil }
 
 // ImportBrowserSession is not implemented on this platform yet.
 func ImportBrowserSession(name string) (*LoginResult, string, error) {
+	_, _, err := ImportBrowserSessions(name)
+	return nil, "", err
+}
+
+// ImportBrowserSessions is not implemented on this platform yet.
+func ImportBrowserSessions(name string) ([]LoginResult, string, error) {
 	return nil, "", fmt.Errorf("importing browser cookies is currently supported on macOS and Linux")
 }

--- a/pkg/api/discover.go
+++ b/pkg/api/discover.go
@@ -106,6 +106,11 @@ func operationHint(operation string) string {
 	if operation == "TweetDetail" {
 		return "TweetDetail"
 	}
+	// The notifications page ships its timeline operation in the route chunk,
+	// which is named for the page (Notifications), not the operation.
+	if operation == notificationsTimelineOperation {
+		return "Notifications"
+	}
 	if strings.Contains(operation, "Home") {
 		return "HomeTimeline"
 	}

--- a/pkg/api/discover.go
+++ b/pkg/api/discover.go
@@ -112,6 +112,13 @@ func operationHint(operation string) string {
 	if operation == "SearchTimeline" {
 		return "SearchTimeline"
 	}
+	// The list read operations ship in the shared timeline chunk, which is named
+	// for the bundles that pull it — Bookmarks, Explore, HomeTimeline — and never
+	// for List. Hinting "List" only finds the list *management* bundles
+	// (UserLists, ListHandler), none of which carry these operations.
+	if operation == listLatestTweetsOperation || operation == listsManagementPageOperation {
+		return "HomeTimeline"
+	}
 	if strings.Contains(operation, "Tweet") {
 		return "Compose"
 	}

--- a/pkg/api/discover_test.go
+++ b/pkg/api/discover_test.go
@@ -55,6 +55,14 @@ func TestOperationHintSelectsTheBundleForEachOperationFamily(t *testing.T) {
 		{operation: "CreateTweet", want: "Compose"},
 		{operation: "SearchTimeline", want: "SearchTimeline"},
 		{operation: "Bookmarks", want: "Bookmarks"},
+		// Both list read operations ship in the shared timeline chunk, observed
+		// live as shared~loader.Dock~bundle.BookmarkFolders~bundle.Bookmarks~
+		// bundle.Explore~bundle.HomeTimeline~bundle.Notifica.<hash>.js. Its name
+		// never contains "List", so hinting "List" reaches only the list
+		// management bundles (UserLists, ListHandler) and discovery finds
+		// nothing — the failure this table exists to prevent.
+		{operation: "ListLatestTweetsTimeline", want: "HomeTimeline"},
+		{operation: "ListsManagementPageTimeline", want: "HomeTimeline"},
 	}
 	for _, test := range tests {
 		t.Run(test.operation, func(t *testing.T) {

--- a/pkg/api/errors_test.go
+++ b/pkg/api/errors_test.go
@@ -89,7 +89,7 @@ func TestPostTweetSessionExpired(t *testing.T) {
 		client := newTestClient(func(req *http.Request) (*http.Response, error) {
 			return response(status, `{"errors":[{"message":"nope"}]}`), nil
 		})
-		_, err := client.PostTweet(context.Background(), "hi", "", nil, nil)
+		_, err := client.PostTweet(context.Background(), "hi", "", "", nil, nil)
 		if !errors.Is(err, ErrSessionExpired) {
 			t.Errorf("HTTP %d: got %v, want ErrSessionExpired", status, err)
 		}
@@ -103,7 +103,7 @@ func TestPostTweetRateLimited(t *testing.T) {
 		resp.Header.Set("x-rate-limit-reset", strconv.FormatInt(reset, 10))
 		return resp, nil
 	})
-	_, err := client.PostTweet(context.Background(), "hi", "", nil, nil)
+	_, err := client.PostTweet(context.Background(), "hi", "", "", nil, nil)
 	var rle *RateLimitError
 	if !errors.As(err, &rle) {
 		t.Fatalf("got %v, want RateLimitError", err)
@@ -122,7 +122,7 @@ func TestPostTweetGraphQLAuthError(t *testing.T) {
 	client := newTestClient(func(req *http.Request) (*http.Response, error) {
 		return response(http.StatusOK, `{"errors":[{"message":"Could not authenticate you","code":32}]}`), nil
 	})
-	_, err := client.PostTweet(context.Background(), "hi", "", nil, nil)
+	_, err := client.PostTweet(context.Background(), "hi", "", "", nil, nil)
 	if !errors.Is(err, ErrSessionExpired) {
 		t.Fatalf("got %v, want ErrSessionExpired", err)
 	}
@@ -132,7 +132,7 @@ func TestPostTweetDuplicateIsActionable(t *testing.T) {
 	client := newTestClient(func(req *http.Request) (*http.Response, error) {
 		return response(http.StatusOK, `{"errors":[{"message":"Status is a duplicate.","code":187}]}`), nil
 	})
-	_, err := client.PostTweet(context.Background(), "same text", "", nil, nil)
+	_, err := client.PostTweet(context.Background(), "same text", "", "", nil, nil)
 	var recent *RecentlyPostedError
 	if !errors.As(err, &recent) {
 		t.Fatalf("got %v, want RecentlyPostedError", err)
@@ -144,7 +144,7 @@ func TestPostTweetAutomationBlockIsActionable(t *testing.T) {
 		// X sometimes omits code 226 and only returns the automation text.
 		return response(http.StatusOK, `{"errors":[{"message":"Authorization: This request looks like it might be automated"}]}`), nil
 	})
-	_, err := client.PostTweet(context.Background(), "hi", "", nil, nil)
+	_, err := client.PostTweet(context.Background(), "hi", "", "", nil, nil)
 	var blocked *AutomationBlockedError
 	if !errors.As(err, &blocked) || !strings.Contains(err.Error(), "try the exact text in X") {
 		t.Fatalf("got %v, want automation-block guidance", err)
@@ -188,7 +188,7 @@ func TestPostTweetNotRetriedOnTransientFailure(t *testing.T) {
 		}
 		return response(http.StatusOK, `{"data":{"home":{"instructions":[]}}}`), nil
 	})
-	_, err := client.PostTweet(context.Background(), "hi", "", nil, nil)
+	_, err := client.PostTweet(context.Background(), "hi", "", "", nil, nil)
 	var ambiguous *AmbiguousPostError
 	if !errors.As(err, &ambiguous) {
 		t.Fatalf("got %v, want AmbiguousPostError", err)
@@ -210,7 +210,7 @@ func TestUploadRetriesTransientFailures(t *testing.T) {
 		}
 		return response(http.StatusOK, `{"data":{"create_tweet":{"tweet_results":{"result":{"rest_id":"1"}}}}}`), nil
 	})
-	id, err := client.PostTweet(context.Background(), "pic", "",
+	id, err := client.PostTweet(context.Background(), "pic", "", "",
 		[]Upload{{Filename: "a.png", ContentType: "image/png", Data: []byte("x")}}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -226,7 +226,7 @@ func TestUploadGivesUpAfterMaxAttempts(t *testing.T) {
 		attempts++
 		return response(http.StatusBadGateway, `down`), nil
 	})
-	_, err := client.PostTweet(context.Background(), "pic", "",
+	_, err := client.PostTweet(context.Background(), "pic", "", "",
 		[]Upload{{Filename: "a.png", ContentType: "image/png", Data: []byte("x")}}, nil)
 	if err == nil {
 		t.Fatal("expected error")
@@ -331,7 +331,7 @@ func TestErrorsNeverLeakCookies(t *testing.T) {
 	})
 	client.authToken = "tok_hunter2_secret"
 	client.ct0 = "csrf_hunter2_secret"
-	_, err := client.PostTweet(context.Background(), "hi", "", nil, nil)
+	_, err := client.PostTweet(context.Background(), "hi", "", "", nil, nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -407,7 +407,7 @@ func TestPostTweetRefreshesRotatedQueryID(t *testing.T) {
 		return "fresh", nil
 	}
 
-	id, err := client.PostTweet(context.Background(), "hello", "", nil, nil)
+	id, err := client.PostTweet(context.Background(), "hello", "", "", nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -427,7 +427,7 @@ func TestPostTweetRejectsMissingCreatedID(t *testing.T) {
 	client := newTestClient(func(req *http.Request) (*http.Response, error) {
 		return response(http.StatusOK, `{"data":{"create_tweet":{"tweet_results":{"result":{}}}}}`), nil
 	})
-	if _, err := client.PostTweet(context.Background(), "hello", "", nil, nil); err == nil {
+	if _, err := client.PostTweet(context.Background(), "hello", "", "", nil, nil); err == nil {
 		t.Fatal("missing created post id was reported as success")
 	}
 }

--- a/pkg/api/lists.go
+++ b/pkg/api/lists.go
@@ -1,0 +1,254 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+const (
+	listLatestTweetsOperation    = "ListLatestTweetsTimeline"
+	listsManagementPageOperation = "ListsManagementPageTimeline"
+)
+
+// ListInfo is one list the authenticated user owns or follows.
+type ListInfo struct {
+	ID          string
+	Name        string
+	MemberCount int
+	IsPrivate   bool
+}
+
+// FetchListTimeline retrieves one page of the given X List's feed.
+func (c *WebClient) FetchListTimeline(ctx context.Context, listID, cursor string, count int) (*TimelinePage, error) {
+	return c.fetchTimelineOp(ctx, listLatestTweetsOperation, "", "XEET_LISTLATESTTWEETSTIMELINE_QID", count, false,
+		func(count int) map[string]any {
+			variables := map[string]any{
+				"listId": listID,
+				"count":  count,
+			}
+			if cursor != "" {
+				variables["cursor"] = cursor
+			}
+			return variables
+		})
+}
+
+// FetchOwnedLists enumerates the user's lists for the picker.
+func (c *WebClient) FetchOwnedLists(ctx context.Context) ([]ListInfo, error) {
+	return c.fetchListsOp(ctx, listsManagementPageOperation, "", "XEET_LISTSMANAGEMENTPAGETIMELINE_QID", 100, false,
+		func(count int) map[string]any {
+			return map[string]any{"count": count}
+		})
+}
+
+func (c *WebClient) fetchListsOp(
+	ctx context.Context,
+	operation, fallback, environment string,
+	count int,
+	withTransactionID bool,
+	buildVars func(count int) map[string]any,
+) ([]ListInfo, error) {
+	if c.authToken == "" || c.ct0 == "" {
+		return nil, fmt.Errorf("no session; run 'xeet auth' first")
+	}
+	if count <= 0 || count > 100 {
+		count = 30
+	}
+	qid := c.operationQueryID(operation, fallback, environment)
+	if qid == "" {
+		fresh, discoverErr := c.discoverOperation(ctx, operation)
+		if discoverErr != nil {
+			return nil, fmt.Errorf("discover %s endpoint: %w", operation, discoverErr)
+		}
+		qid = fresh
+	}
+
+	res, err := c.doTimelineOp(ctx, operation, qid, buildVars(count), withTransactionID)
+	if err != nil {
+		return nil, err
+	}
+	if needsQueryIDRefresh(res) {
+		fresh, discoverErr := c.discoverOperation(ctx, operation)
+		if discoverErr != nil {
+			return nil, fmt.Errorf("home timeline endpoint changed and discovery failed: %w", discoverErr)
+		}
+		res, err = c.doTimelineOp(ctx, operation, fresh, buildVars(count), withTransactionID)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if err := statusToError(res.status, res.header); err != nil {
+		return nil, err
+	}
+	if isTransientStatus(res.status) {
+		return nil, &ServiceUnavailableError{Status: res.status}
+	}
+	if res.status != http.StatusOK {
+		return nil, fmt.Errorf("timeline API error %d: %s", res.status, truncate(res.body))
+	}
+
+	var payload any
+	if err := json.Unmarshal(res.body, &payload); err != nil {
+		return nil, fmt.Errorf("decode timeline: %w", err)
+	}
+	root, ok := payload.(map[string]any)
+	if !ok || root["data"] == nil {
+		return nil, fmt.Errorf("x returned a malformed lists response")
+	}
+	// X answers this operation 200 with the list entries intact *and* a partial
+	// serialization error beside them, so the error is only fatal when nothing
+	// parsed — which is also the shape an auth or rate-limit rejection takes,
+	// leaving those classified as before.
+	lists := parseListsPage(payload)
+	if len(lists) > 0 {
+		return lists, nil
+	}
+	if err := graphQLError(payload); err != nil {
+		return nil, err
+	}
+	return lists, nil
+}
+
+func parseListsPage(payload any) []ListInfo {
+	var lists []ListInfo
+	seen := map[string]bool{}
+
+	parseItemContent := func(raw any) {
+		item, ok := raw.(map[string]any)
+		if !ok {
+			return
+		}
+		list, ok := parseListItem(item)
+		if !ok || seen[list.ID] {
+			return
+		}
+		seen[list.ID] = true
+		lists = append(lists, list)
+	}
+
+	parseEntry := func(raw any) {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			return
+		}
+		content, _ := entry["content"].(map[string]any)
+		if content == nil {
+			content = entry
+		}
+		if item, ok := content["itemContent"].(map[string]any); ok {
+			parseItemContent(item)
+		}
+		if items, ok := content["items"].([]any); ok {
+			for _, rawItem := range items {
+				moduleItem, _ := rawItem.(map[string]any)
+				item, _ := moduleItem["item"].(map[string]any)
+				if item == nil {
+					item = moduleItem
+				}
+				if itemContent, ok := item["itemContent"].(map[string]any); ok {
+					parseItemContent(itemContent)
+				}
+			}
+		}
+	}
+
+	var walk func(any)
+	walk = func(node any) {
+		switch value := node.(type) {
+		case map[string]any:
+			if entries, ok := value["entries"].([]any); ok {
+				for _, entry := range entries {
+					parseEntry(entry)
+				}
+				return
+			}
+			for _, child := range value {
+				walk(child)
+			}
+		case []any:
+			for _, child := range value {
+				walk(child)
+			}
+		}
+	}
+	walk(payload)
+	return lists
+}
+
+func parseListItem(item map[string]any) (ListInfo, bool) {
+	for _, key := range []string{"twitter_list", "list", "list_results"} {
+		if list, ok := parseListNode(item[key], 0); ok {
+			return list, true
+		}
+	}
+	itemType := firstString(item, "itemType", "__typename", "entryType")
+	if strings.Contains(strings.ToLower(itemType), "list") {
+		return parseListNode(item, 0)
+	}
+	return ListInfo{}, false
+}
+
+func parseListNode(node any, depth int) (ListInfo, bool) {
+	if depth > 4 {
+		return ListInfo{}, false
+	}
+	object, ok := node.(map[string]any)
+	if !ok {
+		return ListInfo{}, false
+	}
+	if list, ok := listInfoFromObject(object); ok {
+		return list, true
+	}
+	for _, key := range []string{"result", "twitter_list", "list", "list_results"} {
+		if list, ok := parseListNode(object[key], depth+1); ok {
+			return list, true
+		}
+	}
+	return ListInfo{}, false
+}
+
+func listInfoFromObject(object map[string]any) (ListInfo, bool) {
+	legacy, _ := object["legacy"].(map[string]any)
+	id := firstString(object, "id_str", "rest_id", "id")
+	if id == "" {
+		id = firstString(legacy, "id_str", "rest_id", "id")
+	}
+	name := firstString(object, "name")
+	if name == "" {
+		name = firstString(legacy, "name")
+	}
+	if id == "" || name == "" {
+		return ListInfo{}, false
+	}
+
+	memberCount := intValue(object["member_count"])
+	if memberCount == 0 {
+		memberCount = intValue(legacy["member_count"])
+	}
+	isPrivate := boolValue(object, "is_private", "private")
+	if !isPrivate {
+		isPrivate = boolValue(legacy, "is_private", "private")
+	}
+	mode := firstString(object, "mode", "privacy")
+	if mode == "" {
+		mode = firstString(legacy, "mode", "privacy")
+	}
+	return ListInfo{
+		ID:          id,
+		Name:        name,
+		MemberCount: memberCount,
+		IsPrivate:   isPrivate || strings.EqualFold(mode, "private"),
+	}, true
+}
+
+func boolValue(object map[string]any, keys ...string) bool {
+	for _, key := range keys {
+		if value, ok := object[key].(bool); ok {
+			return value
+		}
+	}
+	return false
+}

--- a/pkg/api/lists_live_test.go
+++ b/pkg/api/lists_live_test.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/melqtx/xeet/pkg/config"
+)
+
+func TestListsLive(t *testing.T) {
+	if os.Getenv("XEET_LIVE_LISTS") != "1" {
+		t.Skip("set XEET_LIVE_LISTS=1 to run")
+	}
+	mgr, err := config.NewConfigManager()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := mgr.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+	defer cancel()
+	client := NewWebClient(cfg)
+
+	lists, err := client.FetchOwnedLists(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("lists: %d", len(lists))
+	if len(lists) == 0 {
+		t.Skip("the authenticated account owns or follows no lists")
+	}
+	if lists[0].ID == "" || lists[0].Name == "" {
+		t.Fatalf("first list has incomplete identity: %+v", lists[0])
+	}
+
+	page, err := client.FetchListTimeline(ctx, lists[0].ID, "", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("first list page: %d posts; cursor=%t", len(page.Posts), page.Cursor != "")
+
+	if cfg.ListLatestTweetsTimelineQID == "" || cfg.ListsManagementPageTimelineQID == "" {
+		if !client.ApplyRefreshedQueryIDs(cfg) {
+			t.Fatal("reached the lists endpoints but staged no query ids for persistence")
+		}
+		if cfg.ListLatestTweetsTimelineQID == "" || cfg.ListsManagementPageTimelineQID == "" {
+			t.Fatalf("ApplyRefreshedQueryIDs left a lists query id empty: %+v", cfg)
+		}
+	}
+}

--- a/pkg/api/lists_test.go
+++ b/pkg/api/lists_test.go
@@ -1,0 +1,257 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/melqtx/xeet/pkg/config"
+)
+
+const listTimelineFixture = `{
+  "data": {
+    "list": {
+      "tweets_timeline": {
+        "timeline": {
+          "instructions": [{
+            "type": "TimelineAddEntries",
+            "entries": [
+              {
+                "entryId": "tweet-1",
+                "content": {
+                  "entryType": "TimelineTimelineItem",
+                  "itemContent": {
+                    "tweet_results": {
+                      "result": {
+                        "rest_id": "1",
+                        "legacy": {"full_text": "list post"},
+                        "core": {
+                          "user_results": {
+                            "result": {
+                              "core": {"name": "Alice", "screen_name": "alice"}
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "entryId": "cursor-bottom-1",
+                "content": {
+                  "entryType": "TimelineTimelineCursor",
+                  "cursorType": "Bottom",
+                  "value": "CURSOR_L1"
+                }
+              }
+            ]
+          }]
+        }
+      }
+    }
+  }
+}`
+
+const listsManagementFixture = `{
+  "data": {
+    "viewer": {
+      "list_management_timeline": {
+        "timeline": {
+          "instructions": [{
+            "type": "TimelineAddEntries",
+            "entries": [
+              {
+                "entryId": "list-100",
+                "content": {
+                  "entryType": "TimelineTimelineItem",
+                  "itemContent": {
+                    "itemType": "TimelineTwitterList",
+                    "twitter_list": {
+                      "rest_id": "100",
+                      "legacy": {
+                        "name": "Private team",
+                        "member_count": 12,
+                        "mode": "Private"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "entryId": "lists-module",
+                "content": {
+                  "entryType": "TimelineTimelineModule",
+                  "items": [{
+                    "entryId": "list-200",
+                    "item": {
+                      "itemContent": {
+                        "itemType": "TimelineTwitterList",
+                        "list": {
+                          "id_str": "200",
+                          "name": "Public news",
+                          "member_count": 34,
+                          "mode": "Public"
+                        }
+                      }
+                    }
+                  }]
+                }
+              }
+            ]
+          }]
+        }
+      }
+    }
+  }
+}`
+
+func TestFetchListTimelineParsesPostsAndCursor(t *testing.T) {
+	client := configuredListsTestClient(t, func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/i/api/graphql/list-timeline-qid/ListLatestTweetsTimeline" {
+			t.Fatalf("path = %q, want ListLatestTweetsTimeline GraphQL path", req.URL.Path)
+		}
+		variables := decodeListVariables(t, req)
+		if variables["count"] != float64(25) {
+			t.Fatalf("variables.count = %#v, want 25", variables["count"])
+		}
+		if _, ok := variables["cursor"]; ok {
+			t.Fatalf("first-page variables unexpectedly contain cursor: %#v", variables)
+		}
+		return response(http.StatusOK, listTimelineFixture), nil
+	})
+
+	page, err := client.FetchListTimeline(context.Background(), "42", "", 25)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Posts) != 1 || page.Posts[0].ID != "1" || page.Posts[0].Text != "list post" {
+		t.Fatalf("posts = %+v", page.Posts)
+	}
+	if page.Cursor != "CURSOR_L1" {
+		t.Fatalf("cursor = %q, want CURSOR_L1", page.Cursor)
+	}
+}
+
+func TestFetchListTimelineSendsListIDVariable(t *testing.T) {
+	client := configuredListsTestClient(t, func(req *http.Request) (*http.Response, error) {
+		variables := decodeListVariables(t, req)
+		if variables["listId"] != "1234567890" {
+			t.Fatalf("variables.listId = %#v, want 1234567890", variables["listId"])
+		}
+		if variables["cursor"] != "next-page" {
+			t.Fatalf("variables.cursor = %#v, want next-page", variables["cursor"])
+		}
+		return response(http.StatusOK, listTimelineFixture), nil
+	})
+
+	if _, err := client.FetchListTimeline(context.Background(), "1234567890", "next-page", 30); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFetchOwnedListsParsesIDNameAndPrivacy(t *testing.T) {
+	client := configuredListsTestClient(t, func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/i/api/graphql/lists-management-qid/ListsManagementPageTimeline" {
+			t.Fatalf("path = %q, want ListsManagementPageTimeline GraphQL path", req.URL.Path)
+		}
+		variables := decodeListVariables(t, req)
+		if !reflect.DeepEqual(variables, map[string]any{"count": float64(100)}) {
+			t.Fatalf("variables = %#v, want count=100 only", variables)
+		}
+		return response(http.StatusOK, listsManagementFixture), nil
+	})
+
+	lists, err := client.FetchOwnedLists(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []ListInfo{
+		{ID: "100", Name: "Private team", MemberCount: 12, IsPrivate: true},
+		{ID: "200", Name: "Public news", MemberCount: 34, IsPrivate: false},
+	}
+	if !reflect.DeepEqual(lists, want) {
+		t.Fatalf("lists = %+v, want %+v", lists, want)
+	}
+}
+
+func TestFetchListTimelineDiscoversQueryIDWhenUnset(t *testing.T) {
+	requests := 0
+	client := NewWebClient(&config.Config{AuthToken: "auth", CT0: "csrf"})
+	client.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if !strings.Contains(req.URL.Path, "/fresh-list-timeline/ListLatestTweetsTimeline") {
+			t.Fatalf("path = %q", req.URL.Path)
+		}
+		return response(http.StatusOK, listTimelineFixture), nil
+	})}
+	client.discover = func(_ context.Context, auth, ct0, operation string) (string, error) {
+		if auth != "auth" || ct0 != "csrf" || operation != listLatestTweetsOperation {
+			t.Fatalf("discovery args = auth:%q ct0:%q operation:%q", auth, ct0, operation)
+		}
+		return "fresh-list-timeline", nil
+	}
+
+	if _, err := client.FetchListTimeline(context.Background(), "42", "", 30); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{}
+	if requests != 1 || !client.ApplyRefreshedQueryIDs(cfg) || cfg.ListLatestTweetsTimelineQID != "fresh-list-timeline" {
+		t.Fatalf("requests=%d config=%+v", requests, cfg)
+	}
+}
+
+func TestFetchOwnedListsDiscoversQueryIDWhenUnset(t *testing.T) {
+	requests := 0
+	client := NewWebClient(&config.Config{AuthToken: "auth", CT0: "csrf"})
+	client.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if !strings.Contains(req.URL.Path, "/fresh-lists-management/ListsManagementPageTimeline") {
+			t.Fatalf("path = %q", req.URL.Path)
+		}
+		return response(http.StatusOK, listsManagementFixture), nil
+	})}
+	client.discover = func(_ context.Context, auth, ct0, operation string) (string, error) {
+		if auth != "auth" || ct0 != "csrf" || operation != listsManagementPageOperation {
+			t.Fatalf("discovery args = auth:%q ct0:%q operation:%q", auth, ct0, operation)
+		}
+		return "fresh-lists-management", nil
+	}
+
+	if _, err := client.FetchOwnedLists(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{}
+	if requests != 1 || !client.ApplyRefreshedQueryIDs(cfg) ||
+		cfg.ListsManagementPageTimelineQID != "fresh-lists-management" {
+		t.Fatalf("requests=%d config=%+v", requests, cfg)
+	}
+}
+
+func configuredListsTestClient(t *testing.T, handler func(*http.Request) (*http.Response, error)) *WebClient {
+	t.Helper()
+	client := NewWebClient(&config.Config{
+		AuthToken:                      "auth",
+		CT0:                            "csrf",
+		ListLatestTweetsTimelineQID:    "list-timeline-qid",
+		ListsManagementPageTimelineQID: "lists-management-qid",
+	})
+	client.httpClient = &http.Client{Transport: roundTripFunc(handler)}
+	return client
+}
+
+func decodeListVariables(t *testing.T, req *http.Request) map[string]any {
+	t.Helper()
+	raw := req.URL.Query().Get("variables")
+	if raw == "" {
+		t.Fatal("request has no variables parameter")
+	}
+	var variables map[string]any
+	if err := json.Unmarshal([]byte(raw), &variables); err != nil {
+		t.Fatalf("decode variables %q: %v", raw, err)
+	}
+	return variables
+}

--- a/pkg/api/notifications.go
+++ b/pkg/api/notifications.go
@@ -1,0 +1,283 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"html"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const notificationsTimelineOperation = "NotificationsTimeline"
+
+// FetchNotificationsTimeline retrieves one page of the authenticated user's
+// notifications. Each notification is shaped into a TimelinePost for the feed
+// it points at so the usual actions (enter, like, reply) work unchanged.
+func (c *WebClient) FetchNotificationsTimeline(ctx context.Context, cursor string, count int) (*TimelinePage, error) {
+	return c.fetchNotificationsOp(ctx, notificationsTimelineOperation, "", "XEET_NOTIFICATIONSTIMELINE_QID", count, false,
+		func(count int) map[string]any {
+			variables := map[string]any{
+				"count": count,
+				// GRAPHQL_VALIDATION_FAILED names this when it is missing; the
+				// web client's notifications page sends "All".
+				"timeline_type": "All",
+			}
+			if cursor != "" {
+				variables["cursor"] = cursor
+			}
+			return variables
+		})
+}
+
+// fetchTimelineOp hard-calls parseTimeline, which silently drops items without
+// a top-level tweet_results — exactly what notification entries look like. So
+// this runs the same ladder (resolve, discover, refresh, classify, decode) and
+// diverges only at the final parse, mirroring fetchListsOp.
+func (c *WebClient) fetchNotificationsOp(
+	ctx context.Context,
+	operation, fallback, environment string,
+	count int,
+	withTransactionID bool,
+	buildVars func(count int) map[string]any,
+) (*TimelinePage, error) {
+	if c.authToken == "" || c.ct0 == "" {
+		return nil, fmt.Errorf("no session; run 'xeet auth' first")
+	}
+	if count <= 0 || count > 100 {
+		count = 30
+	}
+	qid := c.operationQueryID(operation, fallback, environment)
+	if qid == "" {
+		fresh, discoverErr := c.discoverOperation(ctx, operation)
+		if discoverErr != nil {
+			return nil, fmt.Errorf("discover %s endpoint: %w", operation, discoverErr)
+		}
+		qid = fresh
+	}
+
+	res, err := c.doTimelineOp(ctx, operation, qid, buildVars(count), withTransactionID)
+	if err != nil {
+		return nil, err
+	}
+	if needsQueryIDRefresh(res) {
+		fresh, discoverErr := c.discoverOperation(ctx, operation)
+		if discoverErr != nil {
+			return nil, fmt.Errorf("notifications endpoint changed and discovery failed: %w", discoverErr)
+		}
+		res, err = c.doTimelineOp(ctx, operation, fresh, buildVars(count), withTransactionID)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if err := statusToError(res.status, res.header); err != nil {
+		return nil, err
+	}
+	if isTransientStatus(res.status) {
+		return nil, &ServiceUnavailableError{Status: res.status}
+	}
+	if res.status != http.StatusOK {
+		return nil, fmt.Errorf("notifications API error %d: %s", res.status, truncate(res.body))
+	}
+
+	var payload any
+	if err := json.Unmarshal(res.body, &payload); err != nil {
+		return nil, fmt.Errorf("decode notifications: %w", err)
+	}
+	root, ok := payload.(map[string]any)
+	if !ok || root["data"] == nil {
+		return nil, fmt.Errorf("x returned a malformed notifications response")
+	}
+	if err := graphQLError(payload); err != nil {
+		return nil, err
+	}
+	page := parseNotificationsPage(payload)
+	return &page, nil
+}
+
+// The walker deliberately duplicates parseEntries' shape instead of sharing
+// it, for the same reason parseEntries duplicates parseConversation's:
+// timeline.go tracks upstream closely, and coupling the two would make
+// rebases costlier without changing notification behavior.
+func parseNotificationsPage(payload any) TimelinePage {
+	var posts []TimelinePost
+	var bottomCursor string
+	seen := map[string]bool{}
+
+	parseItemContent := func(raw any) {
+		item, ok := raw.(map[string]any)
+		if !ok {
+			return
+		}
+		if post, ok := parseNotificationItem(item); ok && !seen[post.ID] {
+			seen[post.ID] = true
+			posts = append(posts, post)
+		}
+	}
+
+	parseCursor := func(item map[string]any) {
+		cursorType, _ := item["cursorType"].(string)
+		kind := strings.ToLower(cursorType)
+		if kind == "bottom" || strings.Contains(kind, "showmore") {
+			if value, _ := item["value"].(string); value != "" {
+				bottomCursor = value
+			}
+		}
+	}
+
+	parseEntry := func(raw any) {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			return
+		}
+		content, _ := entry["content"].(map[string]any)
+		if content == nil {
+			content = entry
+		}
+		parseCursor(content)
+		if item, ok := content["itemContent"].(map[string]any); ok {
+			parseCursor(item)
+			parseItemContent(item)
+		}
+		if items, ok := content["items"].([]any); ok {
+			for _, rawItem := range items {
+				moduleItem, _ := rawItem.(map[string]any)
+				item, _ := moduleItem["item"].(map[string]any)
+				if item == nil {
+					item = moduleItem
+				}
+				if itemContent, ok := item["itemContent"].(map[string]any); ok {
+					parseCursor(itemContent)
+					parseItemContent(itemContent)
+				}
+			}
+		}
+	}
+
+	var walk func(any)
+	walk = func(node any) {
+		switch value := node.(type) {
+		case map[string]any:
+			if entries, ok := value["entries"].([]any); ok {
+				for _, entry := range entries {
+					parseEntry(entry)
+				}
+				return
+			}
+			for _, child := range value {
+				walk(child)
+			}
+		case []any:
+			for _, child := range value {
+				walk(child)
+			}
+		}
+	}
+	walk(payload)
+	return TimelinePage{Posts: posts, Cursor: bottomCursor}
+}
+
+// parseNotificationItem maps one notification onto the post it targets. The
+// post's own id and author go into ID/Handle (not the notification's) because
+// every downstream action — enter, like, reply, postURL — keys off those
+// fields. Notifications with no resolvable target post (follows, digests) are
+// skipped rather than shown as dead rows no action works on.
+func parseNotificationItem(item map[string]any) (TimelinePost, bool) {
+	notification, _ := item["notification"].(map[string]any)
+	if notification == nil {
+		notification = item
+	}
+	kind := firstString(item, "notificationType", "notification_type")
+	if kind == "" {
+		kind = firstString(notification, "notification_type", "__typename")
+	}
+	message := notificationMessage(notification)
+	if message == "" {
+		message = notificationMessage(item)
+	}
+
+	// An embedded tweet result carries the real post state (counts, liked,
+	// media), which keeps the like button honest; the url fallback only ever
+	// yields an id and a handle.
+	var post TimelinePost
+	if embedded, ok := notificationEmbeddedPost(item, notification); ok {
+		post = embedded
+	} else {
+		id, handle := notificationTargetRef(notification)
+		if id == "" {
+			return TimelinePost{}, false
+		}
+		post = TimelinePost{ID: id, Handle: handle, AuthorName: handle}
+	}
+
+	// A plain TimelineTweet entry (how mentions arrive) has no message; its
+	// typename must not become a text prefix. The kind only fills in when
+	// neither a message nor a post text exists.
+	text := message
+	if text == "" && post.Text == "" {
+		text = kind
+	}
+	if post.Text != "" && text != "" {
+		post.Text = text + "\n\n" + post.Text
+	} else if post.Text == "" {
+		post.Text = text
+	}
+	if post.ID == "" || post.Text == "" {
+		return TimelinePost{}, false
+	}
+	if timestamp, _ := notification["timestamp_ms"].(string); timestamp != "" {
+		if millis, err := strconv.ParseInt(timestamp, 10, 64); err == nil {
+			post.CreatedAt = time.UnixMilli(millis)
+		}
+	}
+	return post, true
+}
+
+func notificationMessage(notification map[string]any) string {
+	for _, key := range []string{"message", "richMessage", "rich_message"} {
+		rich, _ := notification[key].(map[string]any)
+		if text, _ := rich["text"].(string); text != "" {
+			return html.UnescapeString(text)
+		}
+	}
+	return ""
+}
+
+func notificationEmbeddedPost(item, notification map[string]any) (TimelinePost, bool) {
+	for _, node := range []any{item["tweet_results"], notification["tweet_results"]} {
+		tweetResults, _ := node.(map[string]any)
+		if tweetResults == nil {
+			continue
+		}
+		if post, ok := parseTimelineItem(map[string]any{"tweet_results": tweetResults}); ok {
+			return post, true
+		}
+	}
+	return TimelinePost{}, false
+}
+
+// notificationTargetRef digs the target post id (and its author's handle) out
+// of the notification's deeplink, shaped like
+// "https://x.com/<handle>/status/<id>".
+func notificationTargetRef(notification map[string]any) (id, handle string) {
+	for _, key := range []string{"notification_url", "url"} {
+		link, _ := notification[key].(map[string]any)
+		raw := firstString(link, "url", "expanded_url")
+		if raw == "" {
+			continue
+		}
+		parts := strings.Split(strings.Trim(raw, "/"), "/")
+		for i, part := range parts {
+			if part != "status" || i+1 >= len(parts) || i == 0 {
+				continue
+			}
+			candidate := strings.SplitN(parts[i+1], "?", 2)[0]
+			if _, err := strconv.ParseInt(candidate, 10, 64); err == nil {
+				return candidate, parts[i-1]
+			}
+		}
+	}
+	return "", ""
+}

--- a/pkg/api/notifications_live_test.go
+++ b/pkg/api/notifications_live_test.go
@@ -1,0 +1,62 @@
+package api
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/melqtx/xeet/pkg/config"
+)
+
+func TestNotificationsLive(t *testing.T) {
+	if os.Getenv("XEET_LIVE_NOTIFICATIONS") != "1" {
+		t.Skip("set XEET_LIVE_NOTIFICATIONS=1 to run")
+	}
+	mgr, err := config.NewConfigManager()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := mgr.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+	defer cancel()
+	client := NewWebClient(cfg)
+	first, err := client.FetchNotificationsTimeline(ctx, "", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("first page: %d notifications; cursor=%t", len(first.Posts), first.Cursor != "")
+	if len(first.Posts) == 0 {
+		t.Fatal("notifications returned no posts; the account has notifications, so an empty page means the variables or the parser are wrong")
+	}
+	for i, post := range first.Posts {
+		t.Logf("  [%d] id=%s handle=%q text=%q", i, post.ID, post.Handle, post.Text)
+	}
+	if first.Cursor == "" {
+		t.Fatal("no bottom cursor; pagination would dead-end after the first page")
+	}
+
+	second, err := client.FetchNotificationsTimeline(ctx, first.Cursor, 10)
+	if err != nil {
+		t.Fatalf("second page with cursor %q: %v", first.Cursor, err)
+	}
+	t.Logf("second page: %d notifications", len(second.Posts))
+	if len(second.Posts) > 0 && second.Posts[0].ID == first.Posts[0].ID {
+		t.Fatal("cursor did not advance; the second page repeats the first")
+	}
+
+	// A discovered id that never reaches the config is not an error the caller
+	// can see: it just silently re-discovers on every launch.
+	if cfg.NotificationsTimelineQID == "" {
+		if !client.ApplyRefreshedQueryIDs(cfg) {
+			t.Fatal("discovered a query id to reach the endpoint but nothing was staged for persistence")
+		}
+		if cfg.NotificationsTimelineQID == "" {
+			t.Fatal("ApplyRefreshedQueryIDs reported work but left NotificationsTimelineQID empty")
+		}
+		t.Logf("discovered notifications query id staged for persistence (len=%d)", len(cfg.NotificationsTimelineQID))
+	}
+}

--- a/pkg/api/notifications_test.go
+++ b/pkg/api/notifications_test.go
@@ -1,0 +1,302 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/melqtx/xeet/pkg/config"
+)
+
+// This fixture is a best-effort guess at the NotificationsTimeline shape; the
+// XEET_LIVE_NOTIFICATIONS run is what proves it, and structural corrections
+// land here from that response, never from invention.
+const notificationsFixture = `{
+  "data": {
+    "notifications_timeline": {
+      "timeline": {
+        "instructions": [{
+          "type": "TimelineAddEntries",
+          "entries": [
+            {
+              "entryId": "notification-1",
+              "content": {
+                "entryType": "TimelineTimelineItem",
+                "itemContent": {
+                  "__typename": "TimelineNotification",
+                  "notificationType": "Like",
+                  "notification": {
+                    "id": "notif-1",
+                    "timestamp_ms": "1753700000000",
+                    "message": {"text": "@alice liked your post"},
+                    "notification_url": {"url": "https://x.com/bob/status/111222333"}
+                  }
+                }
+              }
+            },
+            {
+              "entryId": "notification-2",
+              "content": {
+                "entryType": "TimelineTimelineItem",
+                "itemContent": {
+                  "__typename": "TimelineNotification",
+                  "notificationType": "Reply",
+                  "notification": {
+                    "id": "notif-2",
+                    "timestamp_ms": "1753700100000",
+                    "message": {"text": "@carol replied to your post"}
+                  },
+                  "tweet_results": {
+                    "result": {
+                      "rest_id": "999",
+                      "legacy": {
+                        "full_text": "reply text",
+                        "favorite_count": 4,
+                        "favorited": true
+                      },
+                      "core": {
+                        "user_results": {
+                          "result": {
+                            "core": {"name": "Carol", "screen_name": "carol"}
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "entryId": "notification-3",
+              "content": {
+                "entryType": "TimelineTimelineItem",
+                "itemContent": {
+                  "__typename": "TimelineNotification",
+                  "notificationType": "Follow",
+                  "notification": {
+                    "id": "notif-3",
+                    "timestamp_ms": "1753700200000",
+                    "message": {"text": "@dave followed you"}
+                  }
+                }
+              }
+            },
+            {
+              "entryId": "tweet-mention-1",
+              "content": {
+                "entryType": "TimelineTimelineItem",
+                "itemContent": {
+                  "__typename": "TimelineTweet",
+                  "tweet_results": {
+                    "result": {
+                      "rest_id": "555",
+                      "legacy": {"full_text": "@me hello there"},
+                      "core": {
+                        "user_results": {
+                          "result": {
+                            "core": {"name": "Eve", "screen_name": "eve"}
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "entryId": "cursor-bottom-1",
+              "content": {
+                "entryType": "TimelineTimelineCursor",
+                "cursorType": "Bottom",
+                "value": "CURSOR_N1"
+              }
+            }
+          ]
+        }]
+      }
+    }
+  }
+}`
+
+func TestFetchNotificationsTimelineParsesPostsAndBottomCursorWithSpecifiedFirstPageVariables(t *testing.T) {
+	client := configuredNotificationsTestClient(t, func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/i/api/graphql/notif-qid/NotificationsTimeline" {
+			t.Fatalf("path = %q, want NotificationsTimeline GraphQL path", req.URL.Path)
+		}
+		variables := decodeNotificationVariables(t, req)
+		if variables["count"] != float64(25) {
+			t.Fatalf("variables.count = %#v, want 25", variables["count"])
+		}
+		if _, ok := variables["cursor"]; ok {
+			t.Fatalf("first-page variables unexpectedly contain cursor: %#v", variables)
+		}
+		return response(http.StatusOK, notificationsFixture), nil
+	})
+
+	page, err := client.FetchNotificationsTimeline(context.Background(), "", 25)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Posts) != 3 {
+		t.Fatalf("posts = %+v, want 3 (the follow notification has no target post)", page.Posts)
+	}
+	like := page.Posts[0]
+	if like.ID != "111222333" || like.Handle != "bob" || like.Text != "@alice liked your post" {
+		t.Fatalf("like notification = %+v", like)
+	}
+	if like.CreatedAt != time.UnixMilli(1753700000000) {
+		t.Fatalf("like timestamp = %v", like.CreatedAt)
+	}
+	reply := page.Posts[1]
+	if reply.ID != "999" || reply.Handle != "carol" {
+		t.Fatalf("reply notification = %+v", reply)
+	}
+	if reply.Text != "@carol replied to your post\n\nreply text" {
+		t.Fatalf("reply text = %q", reply.Text)
+	}
+	if !reply.Liked || reply.LikeCount != 4 {
+		t.Fatalf("embedded tweet state lost: %+v", reply)
+	}
+	mention := page.Posts[2]
+	if mention.ID != "555" || mention.Handle != "eve" || mention.Text != "@me hello there" {
+		// Mentions arrive as plain TimelineTweet entries; the typename must not
+		// leak into the text as a fake prefix.
+		t.Fatalf("mention entry = %+v", mention)
+	}
+	if page.Cursor != "CURSOR_N1" {
+		t.Fatalf("cursor = %q, want CURSOR_N1", page.Cursor)
+	}
+}
+
+func TestFetchNotificationsTimelinePassesCursorThroughToGraphQLVariables(t *testing.T) {
+	client := configuredNotificationsTestClient(t, func(req *http.Request) (*http.Response, error) {
+		variables := decodeNotificationVariables(t, req)
+		if variables["cursor"] != "abc" {
+			t.Fatalf("variables.cursor = %#v, want abc", variables["cursor"])
+		}
+		return response(http.StatusOK, notificationsFixture), nil
+	})
+
+	if _, err := client.FetchNotificationsTimeline(context.Background(), "abc", 30); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFetchNotificationsTimelineDiscoversMissingQueryIDBeforeFirstRequestAndExposesItForPersistence(t *testing.T) {
+	requests := 0
+	client := NewWebClient(&config.Config{AuthToken: "auth", CT0: "csrf"})
+	client.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if !strings.Contains(req.URL.Path, "/fresh-notif/NotificationsTimeline") {
+			t.Fatalf("path = %q", req.URL.Path)
+		}
+		return response(http.StatusOK, notificationsFixture), nil
+	})}
+	client.discover = func(_ context.Context, auth, ct0, operation string) (string, error) {
+		if auth != "auth" || ct0 != "csrf" || operation != notificationsTimelineOperation {
+			t.Fatalf("discovery args = auth:%q ct0:%q operation:%q", auth, ct0, operation)
+		}
+		return "fresh-notif", nil
+	}
+
+	if _, err := client.FetchNotificationsTimeline(context.Background(), "", 30); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{}
+	if requests != 1 || !client.ApplyRefreshedQueryIDs(cfg) || cfg.NotificationsTimelineQID != "fresh-notif" {
+		t.Fatalf("requests=%d config=%+v", requests, cfg)
+	}
+}
+
+func TestFetchNotificationsTimelineRejectsMissingSessionBeforeAnyRequest(t *testing.T) {
+	requests := 0
+	client := NewWebClient(&config.Config{NotificationsTimelineQID: "notif-qid"})
+	client.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		return response(http.StatusOK, notificationsFixture), nil
+	})}
+
+	if _, err := client.FetchNotificationsTimeline(context.Background(), "", 30); err == nil {
+		t.Fatal("FetchNotificationsTimeline succeeded without a session")
+	}
+	if requests != 0 {
+		t.Fatalf("requests = %d, want 0", requests)
+	}
+}
+
+func TestParseNotificationsPageCollapsesRepeatedNotificationsForOnePost(t *testing.T) {
+	payload := decodeFixture(t, `{
+	  "data": {"timeline": {"instructions": [{"entries": [
+	    {"content": {"itemContent": {
+	      "notificationType": "Like",
+	      "notification": {"message": {"text": "@alice liked your post"},
+	        "notification_url": {"url": "https://x.com/bob/status/42"}}}}},
+	    {"content": {"itemContent": {
+	      "notificationType": "Retweet",
+	      "notification": {"message": {"text": "@carol reposted your post"},
+	        "notification_url": {"url": "https://x.com/bob/status/42"}}}}}
+	  ]}]}}
+	}`)
+
+	page := parseNotificationsPage(payload)
+	// The post id is the dedup key everywhere downstream (merge, like, image
+	// cache), so a second notification for the same post cannot survive.
+	if len(page.Posts) != 1 || page.Posts[0].ID != "42" {
+		t.Fatalf("posts = %+v", page.Posts)
+	}
+}
+
+func TestParseNotificationsPageSkipsMalformedEntries(t *testing.T) {
+	payload := decodeFixture(t, `{
+	  "data": {"timeline": {"instructions": [{"entries": [
+	    {"content": {"itemContent": {"__typename": "TimelineNotification"}}},
+	    {"content": {"itemContent": {"notificationType": "Like", "notification": {}}}},
+	    "not-even-an-object",
+	    {"content": {"itemContent": {
+	      "notificationType": "Mention",
+	      "notification": {"message": {"text": "@eve mentioned you"},
+	        "notification_url": {"url": "https://x.com/eve/status/7"}}}}}
+	  ]}]}}
+	}`)
+
+	page := parseNotificationsPage(payload)
+	if len(page.Posts) != 1 || page.Posts[0].ID != "7" {
+		t.Fatalf("posts = %+v", page.Posts)
+	}
+}
+
+func decodeFixture(t *testing.T, raw string) any {
+	t.Helper()
+	var payload any
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		t.Fatal(err)
+	}
+	return payload
+}
+
+func configuredNotificationsTestClient(t *testing.T, handler func(*http.Request) (*http.Response, error)) *WebClient {
+	t.Helper()
+	client := NewWebClient(&config.Config{
+		AuthToken:                "auth",
+		CT0:                      "csrf",
+		NotificationsTimelineQID: "notif-qid",
+	})
+	client.httpClient = &http.Client{Transport: roundTripFunc(handler)}
+	return client
+}
+
+func decodeNotificationVariables(t *testing.T, req *http.Request) map[string]any {
+	t.Helper()
+	raw := req.URL.Query().Get("variables")
+	if raw == "" {
+		t.Fatal("request has no variables parameter")
+	}
+	var variables map[string]any
+	if err := json.Unmarshal([]byte(raw), &variables); err != nil {
+		t.Fatalf("decode variables %q: %v", raw, err)
+	}
+	return variables
+}

--- a/pkg/api/post_response_test.go
+++ b/pkg/api/post_response_test.go
@@ -146,7 +146,7 @@ func TestAmbiguousCreateReconcilesWithOneReadAndNoMutationRetry(t *testing.T) {
 	})
 
 	var events []PostStage
-	id, err := client.PostTweet(context.Background(), "hello from reconciliation", "", nil, func(event PostEvent) {
+	id, err := client.PostTweet(context.Background(), "hello from reconciliation", "", "", nil, func(event PostEvent) {
 		events = append(events, event.Stage)
 	})
 	if err != nil {
@@ -170,7 +170,7 @@ func TestAmbiguousCreateRemainsAmbiguousWhenReadCannotConfirm(t *testing.T) {
 		return response(http.StatusOK, `{"data":{"home":{"instructions":[]}}}`), nil
 	})
 
-	_, err := client.PostTweet(context.Background(), "not in timeline", "", nil, nil)
+	_, err := client.PostTweet(context.Background(), "not in timeline", "", "", nil, nil)
 	var ambiguous *AmbiguousPostError
 	if !errors.As(err, &ambiguous) {
 		t.Fatalf("error=%v, want AmbiguousPostError", err)
@@ -201,7 +201,7 @@ func TestTransportFailureReconcilesWithoutMutationRetry(t *testing.T) {
 		return response(http.StatusOK, body), nil
 	})
 
-	id, err := client.PostTweet(context.Background(), "possibly landed", "", nil, nil)
+	id, err := client.PostTweet(context.Background(), "possibly landed", "", "", nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +223,7 @@ func TestMalformedSuccessResponseIsAmbiguous(t *testing.T) {
 		return response(http.StatusOK, `{"data":{"home":{"instructions":[]}}}`), nil
 	})
 
-	_, err := client.PostTweet(context.Background(), "maybe", "", nil, nil)
+	_, err := client.PostTweet(context.Background(), "maybe", "", "", nil, nil)
 	var ambiguous *AmbiguousPostError
 	if !errors.As(err, &ambiguous) {
 		t.Fatalf("error=%v, want AmbiguousPostError", err)

--- a/pkg/api/profile.go
+++ b/pkg/api/profile.go
@@ -1,0 +1,133 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const (
+	userByScreenNameOperation = "UserByScreenName"
+	userTweetsOperation       = "UserTweets"
+)
+
+var userByScreenNameFeatures = map[string]bool{
+	"responsive_web_graphql_exclude_directive_enabled":                  true,
+	"responsive_web_graphql_skip_user_profile_image_extensions_enabled": false,
+	"responsive_web_graphql_timeline_navigation_enabled":                true,
+	"responsive_web_twitter_article_notes_tab_enabled":                  true,
+	"verified_phone_label_enabled":                                      false,
+}
+
+// FetchUserByScreenName resolves a handle to the numeric user id UserTweets
+// expects. The id is not derivable from timeline posts (they carry only the
+// handle), so profile browsing pays one extra request per user switch and
+// caches the result in the column.
+func (c *WebClient) FetchUserByScreenName(ctx context.Context, handle string) (string, error) {
+	handle = strings.TrimPrefix(strings.TrimSpace(handle), "@")
+	if handle == "" {
+		return "", errors.New("profile handle is empty")
+	}
+	if c.authToken == "" || c.ct0 == "" {
+		return "", fmt.Errorf("no session; run 'xeet auth' first")
+	}
+	qid := c.operationQueryID(userByScreenNameOperation, "", "XEET_USERBYSCREENNAME_QID")
+	if qid == "" {
+		fresh, discoverErr := c.discoverOperation(ctx, userByScreenNameOperation)
+		if discoverErr != nil {
+			return "", fmt.Errorf("discover %s endpoint: %w", userByScreenNameOperation, discoverErr)
+		}
+		qid = fresh
+	}
+	res, err := c.doUserByScreenName(ctx, qid, handle)
+	if err != nil {
+		return "", err
+	}
+	if needsQueryIDRefresh(res) {
+		fresh, discoverErr := c.discoverOperation(ctx, userByScreenNameOperation)
+		if discoverErr != nil {
+			return "", fmt.Errorf("user lookup endpoint changed and discovery failed: %w", discoverErr)
+		}
+		res, err = c.doUserByScreenName(ctx, fresh, handle)
+		if err != nil {
+			return "", err
+		}
+	}
+	if err := statusToError(res.status, res.header); err != nil {
+		return "", err
+	}
+	if isTransientStatus(res.status) {
+		return "", &ServiceUnavailableError{Status: res.status}
+	}
+	if res.status != http.StatusOK {
+		return "", fmt.Errorf("user lookup API error %d: %s", res.status, truncate(res.body))
+	}
+
+	var payload any
+	if err := json.Unmarshal(res.body, &payload); err != nil {
+		return "", fmt.Errorf("decode user lookup: %w", err)
+	}
+	if err := graphQLError(payload); err != nil {
+		return "", err
+	}
+	if id := userIDFromLookup(payload); id != "" {
+		return id, nil
+	}
+	return "", fmt.Errorf("x returned no user for @%s", handle)
+}
+
+func (c *WebClient) doUserByScreenName(ctx context.Context, qid, handle string) (*httpResult, error) {
+	variables, _ := json.Marshal(map[string]any{
+		"screen_name":              handle,
+		"withSafetyModeUserFields": true,
+	})
+	features, _ := json.Marshal(userByScreenNameFeatures)
+	params := url.Values{}
+	params.Set("variables", string(variables))
+	params.Set("features", string(features))
+	endpoint := fmt.Sprintf("https://x.com/i/api/graphql/%s/UserByScreenName?%s", qid, params.Encode())
+	return c.send(ctx, func() (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+		if err != nil {
+			return nil, err
+		}
+		c.setHeaders(req)
+		return req, nil
+	}, true, 4<<20)
+}
+
+func userIDFromLookup(payload any) string {
+	root, _ := payload.(map[string]any)
+	data, _ := root["data"].(map[string]any)
+	user, _ := data["user"].(map[string]any)
+	result, _ := user["result"].(map[string]any)
+	id, _ := result["rest_id"].(string)
+	return id
+}
+
+// FetchUserTweets returns one page of a user's posts (and their reposts —
+// the endpoint mixes them, so callers must not assume every post belongs to
+// the profile owner).
+func (c *WebClient) FetchUserTweets(ctx context.Context, userID, cursor string, count int) (*TimelinePage, error) {
+	if strings.TrimSpace(userID) == "" {
+		return nil, errors.New("profile user id is empty")
+	}
+	return c.fetchTimelineOp(ctx, userTweetsOperation, "", "XEET_USERTWEETS_QID", count, false,
+		func(count int) map[string]any {
+			variables := map[string]any{
+				"userId":                 userID,
+				"count":                  count,
+				"includePromotedContent": false,
+				"withVoice":              true,
+				"withV2Timeline":         true,
+			}
+			if cursor != "" {
+				variables["cursor"] = cursor
+			}
+			return variables
+		})
+}

--- a/pkg/api/profile_live_test.go
+++ b/pkg/api/profile_live_test.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/melqtx/xeet/pkg/config"
+)
+
+// Resolving the session's own handle keeps the live run read-only against
+// other accounts, and UserTweets mixes in the user's reposts, so the check
+// asserts a non-empty page rather than authorship.
+func TestProfileLive(t *testing.T) {
+	if os.Getenv("XEET_LIVE_PROFILE") != "1" {
+		t.Skip("set XEET_LIVE_PROFILE=1 to run")
+	}
+	mgr, err := config.NewConfigManager()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := mgr.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Handle == "" {
+		t.Skip("config has no handle; run 'xeet auth' first")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	client := NewWebClient(cfg)
+
+	userID, err := client.FetchUserByScreenName(ctx, cfg.Handle)
+	if err != nil {
+		t.Fatalf("resolve @%s: %v", cfg.Handle, err)
+	}
+	if userID == "" {
+		t.Fatal("lookup returned an empty user id")
+	}
+	t.Logf("@%s resolved to %s", cfg.Handle, userID)
+
+	page, err := client.FetchUserTweets(ctx, userID, "", 20)
+	if err != nil {
+		t.Fatalf("fetch user tweets: %v", err)
+	}
+	if len(page.Posts) == 0 {
+		t.Fatal("profile page came back empty")
+	}
+	t.Logf("got %d posts, cursor=%q", len(page.Posts), page.Cursor)
+
+	if client.ApplyRefreshedQueryIDs(cfg) {
+		if err := mgr.SaveQueryIDs(cfg); err != nil {
+			t.Fatalf("persist refreshed query ids: %v", err)
+		}
+	}
+}

--- a/pkg/api/profile_test.go
+++ b/pkg/api/profile_test.go
@@ -1,0 +1,266 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/melqtx/xeet/pkg/config"
+)
+
+const userTweetsFixture = `{
+  "data": {
+    "user": {
+      "result": {
+        "timeline_v2": {
+          "timeline": {
+            "instructions": [{
+              "type": "TimelineAddEntries",
+              "entries": [
+                {
+                  "entryId": "tweet-p1",
+                  "content": {
+                    "entryType": "TimelineTimelineItem",
+                    "itemContent": {
+                      "tweet_results": {
+                        "result": {
+                          "rest_id": "p1",
+                          "legacy": {"full_text": "first profile post"}
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "entryId": "cursor-bottom",
+                  "content": {
+                    "entryType": "TimelineTimelineCursor",
+                    "cursorType": "Bottom",
+                    "value": "CURSOR_U1"
+                  }
+                }
+              ]
+            }]
+          }
+        }
+      }
+    }
+  }
+}`
+
+func configuredProfileTestClient(t *testing.T, handler func(*http.Request) (*http.Response, error)) *WebClient {
+	t.Helper()
+	client := NewWebClient(&config.Config{
+		AuthToken:           "auth",
+		CT0:                 "csrf",
+		UserByScreenNameQID: "lookup-qid",
+		UserTweetsQID:       "usertweets-qid",
+	})
+	client.httpClient = &http.Client{Transport: roundTripFunc(handler)}
+	client.transactionID = func(context.Context, string, string) (string, error) {
+		return "stub-transaction-id", nil
+	}
+	return client
+}
+
+func decodeProfileVariables(t *testing.T, req *http.Request) map[string]any {
+	t.Helper()
+	raw := req.URL.Query().Get("variables")
+	if raw == "" {
+		t.Fatal("request has no variables parameter")
+	}
+	var variables map[string]any
+	if err := json.Unmarshal([]byte(raw), &variables); err != nil {
+		t.Fatalf("decode variables %q: %v", raw, err)
+	}
+	return variables
+}
+
+func TestFetchUserByScreenNameResolvesID(t *testing.T) {
+	client := configuredProfileTestClient(t, func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/i/api/graphql/lookup-qid/UserByScreenName" {
+			t.Fatalf("path = %q, want UserByScreenName GraphQL path", req.URL.Path)
+		}
+		variables := decodeProfileVariables(t, req)
+		if variables["screen_name"] != "someone" {
+			t.Fatalf("variables.screen_name = %#v, want someone", variables["screen_name"])
+		}
+		return response(http.StatusOK, `{"data":{"user":{"result":{"rest_id":"12345"}}}}`), nil
+	})
+
+	id, err := client.FetchUserByScreenName(context.Background(), "@someone")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != "12345" {
+		t.Fatalf("id = %q, want 12345", id)
+	}
+}
+
+func TestFetchUserByScreenNameRejectsEmptyHandleBeforeAnyRequest(t *testing.T) {
+	requests := 0
+	client := configuredProfileTestClient(t, func(req *http.Request) (*http.Response, error) {
+		requests++
+		return response(http.StatusOK, `{}`), nil
+	})
+
+	if _, err := client.FetchUserByScreenName(context.Background(), " @ "); err == nil {
+		t.Fatal("blank handle should fail")
+	}
+	if requests != 0 {
+		t.Fatalf("requests = %d, want 0", requests)
+	}
+}
+
+func TestFetchUserByScreenNameErrorsWhenUserMissing(t *testing.T) {
+	client := configuredProfileTestClient(t, func(req *http.Request) (*http.Response, error) {
+		return response(http.StatusOK, `{"data":{"user":{}}}`), nil
+	})
+
+	_, err := client.FetchUserByScreenName(context.Background(), "nobody")
+	if err == nil || !strings.Contains(err.Error(), "no user for @nobody") {
+		t.Fatalf("error = %v, want a no-user error naming the handle", err)
+	}
+}
+
+func TestFetchUserByScreenNameDiscoversAndStagesMissingQueryID(t *testing.T) {
+	requests := 0
+	client := NewWebClient(&config.Config{AuthToken: "auth", CT0: "csrf"})
+	client.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if !strings.Contains(req.URL.Path, "/fresh-lookup/UserByScreenName") {
+			t.Fatalf("path = %q", req.URL.Path)
+		}
+		return response(http.StatusOK, `{"data":{"user":{"result":{"rest_id":"12345"}}}}`), nil
+	})}
+	client.discover = func(_ context.Context, auth, ct0, operation string) (string, error) {
+		if operation != userByScreenNameOperation {
+			t.Fatalf("discovery operation = %q", operation)
+		}
+		return "fresh-lookup", nil
+	}
+
+	if _, err := client.FetchUserByScreenName(context.Background(), "someone"); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{}
+	if requests != 1 || !client.ApplyRefreshedQueryIDs(cfg) || cfg.UserByScreenNameQID != "fresh-lookup" {
+		t.Fatalf("requests=%d config=%+v", requests, cfg)
+	}
+}
+
+func TestFetchUserByScreenNameEnvOverridesQueryID(t *testing.T) {
+	t.Setenv("XEET_USERBYSCREENNAME_QID", "env-lookup")
+	client := NewWebClient(&config.Config{AuthToken: "auth", CT0: "csrf", UserByScreenNameQID: "cfg-lookup"})
+	client.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if !strings.Contains(req.URL.Path, "/env-lookup/UserByScreenName") {
+			t.Fatalf("path = %q, want the env override qid", req.URL.Path)
+		}
+		return response(http.StatusOK, `{"data":{"user":{"result":{"rest_id":"1"}}}}`), nil
+	})}
+
+	if _, err := client.FetchUserByScreenName(context.Background(), "someone"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFetchUserTweetsSendsUserIDAndParsesPage(t *testing.T) {
+	client := configuredProfileTestClient(t, func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/i/api/graphql/usertweets-qid/UserTweets" {
+			t.Fatalf("path = %q, want UserTweets GraphQL path", req.URL.Path)
+		}
+		variables := decodeProfileVariables(t, req)
+		for name, want := range map[string]any{
+			"userId":                 "12345",
+			"count":                  float64(20),
+			"includePromotedContent": false,
+			"withV2Timeline":         true,
+		} {
+			if got := variables[name]; got != want {
+				t.Fatalf("variables.%s = %#v, want %#v", name, got, want)
+			}
+		}
+		if _, ok := variables["cursor"]; ok {
+			t.Fatalf("first-page variables unexpectedly contain cursor: %#v", variables)
+		}
+		return response(http.StatusOK, userTweetsFixture), nil
+	})
+
+	page, err := client.FetchUserTweets(context.Background(), "12345", "", 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Posts) != 1 || page.Posts[0].ID != "p1" || page.Posts[0].Text != "first profile post" {
+		t.Fatalf("posts = %+v", page.Posts)
+	}
+	if page.Cursor != "CURSOR_U1" {
+		t.Fatalf("cursor = %q, want CURSOR_U1", page.Cursor)
+	}
+}
+
+func TestFetchUserTweetsPassesCursorThrough(t *testing.T) {
+	client := configuredProfileTestClient(t, func(req *http.Request) (*http.Response, error) {
+		variables := decodeProfileVariables(t, req)
+		if variables["cursor"] != "next-page" {
+			t.Fatalf("variables.cursor = %#v, want next-page", variables["cursor"])
+		}
+		return response(http.StatusOK, userTweetsFixture), nil
+	})
+
+	if _, err := client.FetchUserTweets(context.Background(), "12345", "next-page", 30); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFetchUserTweetsRejectsEmptyUserIDBeforeAnyRequest(t *testing.T) {
+	requests := 0
+	client := configuredProfileTestClient(t, func(req *http.Request) (*http.Response, error) {
+		requests++
+		return response(http.StatusOK, userTweetsFixture), nil
+	})
+
+	if _, err := client.FetchUserTweets(context.Background(), "  ", "", 30); err == nil {
+		t.Fatal("blank user id should fail")
+	}
+	if requests != 0 {
+		t.Fatalf("requests = %d, want 0", requests)
+	}
+}
+
+func TestFetchUserTweetsDiscoversAndStagesMissingQueryID(t *testing.T) {
+	requests := 0
+	client := NewWebClient(&config.Config{AuthToken: "auth", CT0: "csrf"})
+	client.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if !strings.Contains(req.URL.Path, "/fresh-usertweets/UserTweets") {
+			t.Fatalf("path = %q", req.URL.Path)
+		}
+		return response(http.StatusOK, userTweetsFixture), nil
+	})}
+	client.discover = func(_ context.Context, auth, ct0, operation string) (string, error) {
+		if operation != userTweetsOperation {
+			t.Fatalf("discovery operation = %q", operation)
+		}
+		return "fresh-usertweets", nil
+	}
+
+	if _, err := client.FetchUserTweets(context.Background(), "12345", "", 30); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{}
+	if requests != 1 || !client.ApplyRefreshedQueryIDs(cfg) || cfg.UserTweetsQID != "fresh-usertweets" {
+		t.Fatalf("requests=%d config=%+v", requests, cfg)
+	}
+}
+
+func TestProfileOperationsRequireSession(t *testing.T) {
+	client := &WebClient{}
+	if _, err := client.FetchUserByScreenName(context.Background(), "someone"); err == nil {
+		t.Fatal("lookup without a session should fail")
+	}
+	if _, err := client.FetchUserTweets(context.Background(), "12345", "", 30); err == nil {
+		t.Fatal("user tweets without a session should fail")
+	}
+}

--- a/pkg/api/quote_live_test.go
+++ b/pkg/api/quote_live_test.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/melqtx/xeet/pkg/config"
+)
+
+// A quote only counts as working when the posted tweet carries quoted_status;
+// CreateTweet returns 200 with the text alone if the attachment_url shape is
+// wrong, which a mock can never catch. The posted quote is left for manual
+// deletion (there is no delete API in scope).
+func TestQuoteLive(t *testing.T) {
+	if os.Getenv("XEET_LIVE_QUOTE") != "1" {
+		t.Skip("set XEET_LIVE_QUOTE=1 to run")
+	}
+	quoteID := os.Getenv("XEET_LIVE_QUOTE_TWEET_ID")
+	if quoteID == "" {
+		t.Skip("set XEET_LIVE_QUOTE_TWEET_ID to a post worth quoting")
+	}
+	mgr, err := config.NewConfigManager()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := mgr.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	client := NewWebClient(cfg)
+
+	id, err := client.PostTweet(ctx, "xeet quote live test (delete me)", "", quoteID, nil, nil)
+	if err != nil {
+		t.Fatalf("PostTweet with quote: %v", err)
+	}
+	if id == "" {
+		t.Fatal("CreateTweet returned no id")
+	}
+	t.Logf("posted quote %s of %s — delete it by hand", id, quoteID)
+
+	page, err := client.FetchTweetDetail(ctx, id, "", 5)
+	if err != nil {
+		t.Fatalf("read back the quote: %v", err)
+	}
+	if len(page.Posts) == 0 || page.Posts[0].ID != id {
+		t.Fatalf("posted quote missing from its detail page: %+v", page.Posts)
+	}
+	// The quoted post rides inside the tweet's own payload as
+	// legacy.quoted_status_id_str, which the parser deliberately does not
+	// surface — so the check scans the raw detail body. If the attachment_url
+	// shape were wrong the text would post with nothing quoted, and this scan
+	// is the only thing that catches it.
+	qid := client.operationQueryID("TweetDetail", "", "XEET_TWEETDETAIL_QID")
+	if qid == "" {
+		fresh, derr := client.discoverOperation(ctx, "TweetDetail")
+		if derr != nil {
+			t.Fatalf("discover TweetDetail: %v", derr)
+		}
+		qid = fresh
+	}
+	res, err := client.doTweetDetail(ctx, qid, id, "", 5)
+	if err != nil {
+		t.Fatalf("raw detail fetch: %v", err)
+	}
+	if !strings.Contains(string(res.body), `"quoted_status_id_str":"`+quoteID+`"`) {
+		t.Fatalf("posted tweet does not quote %s; attachment_url shape is wrong", quoteID)
+	}
+}

--- a/pkg/api/retweet.go
+++ b/pkg/api/retweet.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+const (
+	createRetweetOperation = "CreateRetweet"
+	deleteRetweetOperation = "DeleteRetweet"
+	// The retweet mutations answer a bodyless 404 when the transaction header
+	// is missing — the same shape search.go documents for SearchTimeline, and
+	// what the first live run returned. Like CreateTweet, every attempt mints
+	// a fresh one.
+	retweetWithTransactionID = true
+)
+
+// SetTweetReposted reposts or un-reposts a post using X's web GraphQL
+// mutations. Unlike likes there is no shipped fallback query id: the id is
+// discovered from X's live bundles (or supplied via XEET_CREATERETWEET_QID /
+// XEET_DELETERETWEET_QID) and cached in the config.
+func (c *WebClient) SetTweetReposted(ctx context.Context, tweetID string, reposted bool) error {
+	if c.authToken == "" || c.ct0 == "" {
+		return fmt.Errorf("no session; run 'xeet auth' first")
+	}
+	if tweetID == "" {
+		return fmt.Errorf("tweet id is empty")
+	}
+	operation, environment := createRetweetOperation, "XEET_CREATERETWEET_QID"
+	if !reposted {
+		operation, environment = deleteRetweetOperation, "XEET_DELETERETWEET_QID"
+	}
+	qid := c.operationQueryID(operation, "", environment)
+	if qid == "" {
+		fresh, discoverErr := c.discoverOperation(ctx, operation)
+		if discoverErr != nil {
+			return fmt.Errorf("discover %s endpoint: %w", operation, discoverErr)
+		}
+		qid = fresh
+	}
+	res, err := c.doTweetRetweet(ctx, operation, qid, tweetID)
+	if err != nil {
+		return err
+	}
+	if needsQueryIDRefresh(res) {
+		fresh, discoverErr := c.discoverOperation(ctx, operation)
+		if discoverErr != nil {
+			return fmt.Errorf("%s endpoint changed and discovery failed: %w", operation, discoverErr)
+		}
+		res, err = c.doTweetRetweet(ctx, operation, fresh, tweetID)
+		if err != nil {
+			return err
+		}
+	}
+	if err := statusToError(res.status, res.header); err != nil {
+		return err
+	}
+	if isTransientStatus(res.status) {
+		return &ServiceUnavailableError{Status: res.status}
+	}
+	if res.status != http.StatusOK {
+		return fmt.Errorf("repost API error %d: %s", res.status, truncate(res.body))
+	}
+	var payload any
+	if err := json.Unmarshal(res.body, &payload); err != nil {
+		return fmt.Errorf("decode repost response: %w", err)
+	}
+	if err := graphQLError(payload); err != nil {
+		return err
+	}
+	return nil
+}
+
+// doTweetRetweet never retries transient failures: CreateRetweet is not
+// idempotent (a replayed request errors as "already retweeted"), so a timed-out
+// request that actually landed must not be re-fired. The TUI rolls its
+// optimistic state back and lets the user press the key again.
+func (c *WebClient) doTweetRetweet(ctx context.Context, operation, qid, tweetID string) (*httpResult, error) {
+	variable := "tweet_id"
+	if operation == deleteRetweetOperation {
+		variable = retweetDeleteVariable()
+	}
+	payload := map[string]any{
+		"variables": map[string]string{variable: tweetID},
+		"queryId":   qid,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	endpoint := fmt.Sprintf("https://x.com/i/api/graphql/%s/%s", qid, operation)
+	return c.send(ctx, func() (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		c.setHeaders(req)
+		// Minted per attempt (see doTimelineOp): a replayed id is rejected
+		// exactly like an omitted one.
+		if retweetWithTransactionID && c.transactionID != nil {
+			transactionID, err := c.transactionID(ctx, req.Method, req.URL.Path)
+			if err != nil {
+				return nil, fmt.Errorf("generate X transaction id: %w", err)
+			}
+			req.Header.Set("X-Client-Transaction-Id", transactionID)
+		}
+		return req, nil
+	}, false, 2<<20)
+}
+
+// retweetDeleteVariable names the DeleteRetweet input. Confirmed against the
+// live endpoint: it takes the original tweet's id, and a wrong name earns a
+// GraphQL validation error naming this one.
+func retweetDeleteVariable() string {
+	return "source_tweet_id"
+}

--- a/pkg/api/retweet_live_test.go
+++ b/pkg/api/retweet_live_test.go
@@ -1,0 +1,103 @@
+package api
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/melqtx/xeet/pkg/config"
+)
+
+// The repost round trip cannot be proven by mocks: the DeleteRetweet variable
+// name is a hypothesis until the real endpoint accepts it, and only a live
+// Create/Delete pair against a known post shows both the mutation shape and
+// the legacy.retweeted flag flipping back.
+func TestRepostLive(t *testing.T) {
+	if os.Getenv("XEET_LIVE_REPOST") != "1" {
+		t.Skip("set XEET_LIVE_REPOST=1 to run")
+	}
+	mgr, err := config.NewConfigManager()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := mgr.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	client := NewWebClient(cfg)
+
+	tweetID := os.Getenv("XEET_LIVE_REPOST_TWEET_ID")
+	if tweetID == "" {
+		// Hands-free default: repost one of the account's own posts so nobody
+		// else gets a notification from the test.
+		if cfg.Handle == "" {
+			t.Skip("set XEET_LIVE_REPOST_TWEET_ID to one of your own older posts")
+		}
+		found, err := client.FetchSearchTimeline(ctx, "from:"+cfg.Handle, "", 10)
+		if err != nil {
+			t.Fatalf("search own posts: %v", err)
+		}
+		for _, post := range found.Posts {
+			if post.Handle == cfg.Handle {
+				tweetID = post.ID
+				break
+			}
+		}
+		if tweetID == "" {
+			t.Skip("no own posts found to repost; set XEET_LIVE_REPOST_TWEET_ID")
+		}
+		t.Logf("repost target: own post %s", tweetID)
+	}
+
+	reposted := func(want bool) {
+		t.Helper()
+		page, err := client.FetchTweetDetail(ctx, tweetID, "", 5)
+		if err != nil {
+			t.Fatalf("read back tweet detail: %v", err)
+		}
+		for _, post := range page.Posts {
+			if post.ID == tweetID {
+				if post.Reposted != want {
+					t.Fatalf("retweeted flag = %v, want %v", post.Reposted, want)
+				}
+				return
+			}
+		}
+		t.Fatalf("tweet %s missing from its own detail page", tweetID)
+	}
+
+	if err := client.SetTweetReposted(ctx, tweetID, true); err != nil {
+		t.Fatalf("CreateRetweet: %v", err)
+	}
+	// Even a failed verify below must attempt to undo the repost; leave nothing
+	// behind on the account.
+	t.Cleanup(func() {
+		uctx, ucancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer ucancel()
+		if err := client.SetTweetReposted(uctx, tweetID, false); err != nil {
+			t.Logf("cleanup unrepost failed (remove it by hand): %v", err)
+		}
+	})
+	reposted(true)
+
+	if err := client.SetTweetReposted(ctx, tweetID, false); err != nil {
+		t.Fatalf("DeleteRetweet: %v", err)
+	}
+	reposted(false)
+
+	if cfg.CreateRetweetQID == "" {
+		if !client.ApplyRefreshedQueryIDs(cfg) || cfg.CreateRetweetQID == "" {
+			t.Fatal("discovered a CreateRetweet id but nothing was staged for persistence")
+		}
+		t.Logf("discovered CreateRetweet query id staged for persistence (len=%d)", len(cfg.CreateRetweetQID))
+	}
+	if cfg.DeleteRetweetQID == "" {
+		if !client.ApplyRefreshedQueryIDs(cfg) || cfg.DeleteRetweetQID == "" {
+			t.Fatal("discovered a DeleteRetweet id but nothing was staged for persistence")
+		}
+		t.Logf("discovered DeleteRetweet query id staged for persistence (len=%d)", len(cfg.DeleteRetweetQID))
+	}
+}

--- a/pkg/api/retweet_test.go
+++ b/pkg/api/retweet_test.go
@@ -1,0 +1,179 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/melqtx/xeet/pkg/config"
+)
+
+func configuredRetweetTestClient(t *testing.T, cfg *config.Config, handler func(*http.Request) (*http.Response, error)) *WebClient {
+	t.Helper()
+	cfg.AuthToken, cfg.CT0 = "auth", "csrf"
+	client := NewWebClient(cfg)
+	client.httpClient = &http.Client{Transport: roundTripFunc(handler)}
+	// The generator scrapes X's transaction page; tests stub the minting step
+	// and assert on the header it produces instead.
+	client.transactionID = func(context.Context, string, string) (string, error) {
+		return "tx-id", nil
+	}
+	return client
+}
+
+func TestSetTweetRepostedPostsTweetIDToCreateRetweet(t *testing.T) {
+	var path, body string
+	client := configuredRetweetTestClient(t, &config.Config{CreateRetweetQID: "rt-qid"}, func(req *http.Request) (*http.Response, error) {
+		path = req.URL.Path
+		data, _ := io.ReadAll(req.Body)
+		body = string(data)
+		return response(http.StatusOK, `{"data":{"create_retweet":{"retweet_results":{}}}}`), nil
+	})
+
+	if err := client.SetTweetReposted(context.Background(), "123", true); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(path, "/rt-qid/CreateRetweet") || !strings.Contains(body, `"tweet_id":"123"`) {
+		t.Fatalf("path=%q body=%s", path, body)
+	}
+}
+
+func TestSetTweetRepostedSendsTransactionHeader(t *testing.T) {
+	var header string
+	client := configuredRetweetTestClient(t, &config.Config{CreateRetweetQID: "rt-qid"}, func(req *http.Request) (*http.Response, error) {
+		header = req.Header.Get("X-Client-Transaction-Id")
+		return response(http.StatusOK, `{"data":{"create_retweet":{"retweet_results":{}}}}`), nil
+	})
+
+	if err := client.SetTweetReposted(context.Background(), "123", true); err != nil {
+		t.Fatal(err)
+	}
+	if header != "tx-id" {
+		t.Fatalf("X-Client-Transaction-Id = %q, want tx-id", header)
+	}
+}
+
+func TestSetTweetUnrepostedPostsSourceTweetIDToDeleteRetweet(t *testing.T) {
+	var path, body string
+	client := configuredRetweetTestClient(t, &config.Config{DeleteRetweetQID: "drt-qid"}, func(req *http.Request) (*http.Response, error) {
+		path = req.URL.Path
+		data, _ := io.ReadAll(req.Body)
+		body = string(data)
+		return response(http.StatusOK, `{"data":{"unretweet":{}}}`), nil
+	})
+
+	if err := client.SetTweetReposted(context.Background(), "123", false); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(path, "/drt-qid/DeleteRetweet") || !strings.Contains(body, `"source_tweet_id":"123"`) {
+		t.Fatalf("path=%q body=%s", path, body)
+	}
+}
+
+func TestSetTweetRepostedDiscoversMissingQueryIDBeforeFirstRequestAndExposesItForPersistence(t *testing.T) {
+	var path string
+	client := configuredRetweetTestClient(t, &config.Config{}, func(req *http.Request) (*http.Response, error) {
+		path = req.URL.Path
+		return response(http.StatusOK, `{"data":{"create_retweet":{"retweet_results":{}}}}`), nil
+	})
+	client.discover = func(_ context.Context, auth, ct0, operation string) (string, error) {
+		if auth != "auth" || ct0 != "csrf" || operation != createRetweetOperation {
+			t.Fatalf("discovery args = auth:%q ct0:%q operation:%q", auth, ct0, operation)
+		}
+		return "fresh-rt", nil
+	}
+
+	if err := client.SetTweetReposted(context.Background(), "123", true); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(path, "/fresh-rt/CreateRetweet") {
+		t.Fatalf("path=%q", path)
+	}
+	cfg := &config.Config{}
+	if !client.ApplyRefreshedQueryIDs(cfg) || cfg.CreateRetweetQID != "fresh-rt" {
+		t.Fatalf("config=%+v", cfg)
+	}
+}
+
+func TestSetTweetRepostedRotatesQueryIDOnceOnPersistedQueryMiss(t *testing.T) {
+	var paths []string
+	client := configuredRetweetTestClient(t, &config.Config{CreateRetweetQID: "stale"}, func(req *http.Request) (*http.Response, error) {
+		paths = append(paths, req.URL.Path)
+		if len(paths) == 1 {
+			return response(http.StatusNotFound, ``), nil
+		}
+		return response(http.StatusOK, `{"data":{"create_retweet":{"retweet_results":{}}}}`), nil
+	})
+	discoveries := 0
+	client.discover = func(_ context.Context, _, _, operation string) (string, error) {
+		discoveries++
+		return "fresh-rt", nil
+	}
+
+	if err := client.SetTweetReposted(context.Background(), "123", true); err != nil {
+		t.Fatal(err)
+	}
+	if discoveries != 1 || len(paths) != 2 ||
+		!strings.Contains(paths[0], "/stale/CreateRetweet") || !strings.Contains(paths[1], "/fresh-rt/CreateRetweet") {
+		t.Fatalf("discoveries=%d paths=%v", discoveries, paths)
+	}
+}
+
+// Retweets are not idempotent — a replayed request errors as "already
+// retweeted" — so a transient 503 must surface after exactly one attempt and
+// leave the retry to the user, unlike the like path's transparent retry.
+func TestSetTweetRepostedDoesNotRetryTransientStatus(t *testing.T) {
+	attempts := 0
+	client := configuredRetweetTestClient(t, &config.Config{CreateRetweetQID: "rt-qid"}, func(req *http.Request) (*http.Response, error) {
+		attempts++
+		return response(http.StatusServiceUnavailable, ``), nil
+	})
+
+	err := client.SetTweetReposted(context.Background(), "123", true)
+	var unavailable *ServiceUnavailableError
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("err = %v, want ServiceUnavailableError", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1 (no transient retry for retweets)", attempts)
+	}
+}
+
+func TestSetTweetRepostedHonorsEnvironmentQueryIDOverride(t *testing.T) {
+	t.Setenv("XEET_CREATERETWEET_QID", "env-rt")
+	var path string
+	client := configuredRetweetTestClient(t, &config.Config{CreateRetweetQID: "cfg-rt"}, func(req *http.Request) (*http.Response, error) {
+		path = req.URL.Path
+		return response(http.StatusOK, `{"data":{"create_retweet":{"retweet_results":{}}}}`), nil
+	})
+
+	if err := client.SetTweetReposted(context.Background(), "123", true); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(path, "/env-rt/CreateRetweet") {
+		t.Fatalf("path=%q", path)
+	}
+}
+
+func TestSetTweetRepostedRejectsMissingSessionAndEmptyIDBeforeAnyRequest(t *testing.T) {
+	requests := 0
+	client := configuredRetweetTestClient(t, &config.Config{CreateRetweetQID: "rt-qid"}, func(req *http.Request) (*http.Response, error) {
+		requests++
+		return response(http.StatusOK, `{}`), nil
+	})
+	client.authToken, client.ct0 = "", ""
+
+	if err := client.SetTweetReposted(context.Background(), "123", true); err == nil {
+		t.Fatal("SetTweetReposted succeeded without a session")
+	}
+	client.authToken, client.ct0 = "auth", "csrf"
+	if err := client.SetTweetReposted(context.Background(), "", true); err == nil {
+		t.Fatal("SetTweetReposted succeeded with an empty tweet id")
+	}
+	if requests != 0 {
+		t.Fatalf("requests = %d, want 0", requests)
+	}
+}

--- a/pkg/api/timeline.go
+++ b/pkg/api/timeline.go
@@ -40,6 +40,7 @@ type TimelinePost struct {
 	Media          []TimelineMedia
 	Liked          bool
 	Reposted       bool
+	Bookmarked     bool
 	InReplyToID    string
 	ConversationID string
 }
@@ -343,6 +344,7 @@ func parseTimelineItem(item map[string]any) (TimelinePost, bool) {
 	post.LikeCount = intValue(legacy["favorite_count"])
 	post.Liked, _ = legacy["favorited"].(bool)
 	post.Reposted, _ = legacy["retweeted"].(bool)
+	post.Bookmarked, _ = legacy["bookmarked"].(bool)
 	post.InReplyToID, _ = legacy["in_reply_to_status_id_str"].(string)
 	post.ConversationID, _ = legacy["conversation_id_str"].(string)
 	if created, _ := legacy["created_at"].(string); created != "" {

--- a/pkg/api/timeline.go
+++ b/pkg/api/timeline.go
@@ -26,6 +26,14 @@ type TimelineMedia struct {
 	Height  int
 }
 
+// TimelineArticle carries an X long-form article's plain-text body. Kept off
+// Text because an article tweet's legacy text is just a preview card blurb —
+// callers that flatten it into Text would lose the boundary between the two.
+type TimelineArticle struct {
+	Title string
+	Text  string
+}
+
 type TimelinePost struct {
 	ID             string
 	Text           string
@@ -43,6 +51,7 @@ type TimelinePost struct {
 	Bookmarked     bool
 	InReplyToID    string
 	ConversationID string
+	Article        *TimelineArticle
 }
 
 type TimelinePage struct {
@@ -339,6 +348,19 @@ func parseTimelineItem(item map[string]any) (TimelinePost, bool) {
 	text = html.UnescapeString(text)
 
 	post := TimelinePost{ID: id, Text: text}
+	if article, ok := result["article"].(map[string]any); ok {
+		if articleResults, ok := article["article_results"].(map[string]any); ok {
+			if articleResult, ok := articleResults["result"].(map[string]any); ok {
+				// plain_text is only present when the request opts in via
+				// withArticlePlainText; without it the article node is just a
+				// preview card and not worth surfacing as an article.
+				if plainText, ok := articleResult["plain_text"].(string); ok && plainText != "" {
+					post.Article = &TimelineArticle{Text: html.UnescapeString(plainText)}
+					post.Article.Title, _ = articleResult["title"].(string)
+				}
+			}
+		}
+	}
 	post.ReplyCount = intValue(legacy["reply_count"])
 	post.RepostCount = intValue(legacy["retweet_count"])
 	post.LikeCount = intValue(legacy["favorite_count"])

--- a/pkg/api/timeline.go
+++ b/pkg/api/timeline.go
@@ -39,6 +39,7 @@ type TimelinePost struct {
 	MediaCount     int
 	Media          []TimelineMedia
 	Liked          bool
+	Reposted       bool
 	InReplyToID    string
 	ConversationID string
 }
@@ -341,6 +342,7 @@ func parseTimelineItem(item map[string]any) (TimelinePost, bool) {
 	post.RepostCount = intValue(legacy["retweet_count"])
 	post.LikeCount = intValue(legacy["favorite_count"])
 	post.Liked, _ = legacy["favorited"].(bool)
+	post.Reposted, _ = legacy["retweeted"].(bool)
 	post.InReplyToID, _ = legacy["in_reply_to_status_id_str"].(string)
 	post.ConversationID, _ = legacy["conversation_id_str"].(string)
 	if created, _ := legacy["created_at"].(string); created != "" {

--- a/pkg/api/timeline_test.go
+++ b/pkg/api/timeline_test.go
@@ -44,6 +44,40 @@ func TestParseTimeline(t *testing.T) {
 	}
 }
 
+func TestParseTimelineItemReadsArticlePlainText(t *testing.T) {
+	item := map[string]any{"tweet_results": map[string]any{"result": map[string]any{
+		"rest_id": "1", "legacy": map[string]any{"full_text": "preview blurb"},
+		"article": map[string]any{"article_results": map[string]any{"result": map[string]any{
+			"title":      "My Article",
+			"plain_text": "the full article body &amp; more",
+		}}},
+	}}}
+	post, ok := parseTimelineItem(item)
+	if !ok || post.Article == nil {
+		t.Fatalf("article not parsed: %+v", post)
+	}
+	if post.Article.Title != "My Article" || post.Article.Text != "the full article body & more" {
+		t.Fatalf("unexpected article: %+v", post.Article)
+	}
+	// The preview blurb stays on Text; the article body does not overwrite it.
+	if post.Text != "preview blurb" {
+		t.Fatalf("text=%q", post.Text)
+	}
+}
+
+func TestParseTimelineItemIgnoresArticlePreviewWithoutPlainText(t *testing.T) {
+	item := map[string]any{"tweet_results": map[string]any{"result": map[string]any{
+		"rest_id": "1", "legacy": map[string]any{"full_text": "preview blurb"},
+		"article": map[string]any{"article_results": map[string]any{"result": map[string]any{
+			"title": "My Article",
+		}}},
+	}}}
+	post, ok := parseTimelineItem(item)
+	if !ok || post.Article != nil {
+		t.Fatalf("preview-only article should not surface: %+v", post.Article)
+	}
+}
+
 func TestParseTimelineUnescapesText(t *testing.T) {
 	item := map[string]any{"tweet_results": map[string]any{"result": map[string]any{
 		"rest_id": "1", "legacy": map[string]any{"full_text": "&gt; hello &amp; goodbye"},

--- a/pkg/api/timeline_test.go
+++ b/pkg/api/timeline_test.go
@@ -9,7 +9,7 @@ func TestParseTimeline(t *testing.T) {
 	fixture := `{"entries":[
 	  {"itemContent":{"tweet_results":{"result":{
 	    "rest_id":"1",
-	    "legacy":{"full_text":"hello timeline","reply_count":2,"retweet_count":3,"favorite_count":4,"favorited":true,"created_at":"Mon Jul 20 10:00:00 +0000 2026","extended_entities":{"media":[{"type":"photo","media_url_https":"https://pbs.twimg.com/media/abc","ext_alt_text":"a cat","original_info":{"width":1200,"height":800}}]}},
+	    "legacy":{"full_text":"hello timeline","reply_count":2,"retweet_count":3,"favorite_count":4,"favorited":true,"retweeted":true,"created_at":"Mon Jul 20 10:00:00 +0000 2026","extended_entities":{"media":[{"type":"photo","media_url_https":"https://pbs.twimg.com/media/abc","ext_alt_text":"a cat","original_info":{"width":1200,"height":800}}]}},
 	    "views":{"count":"55"},
 	    "core":{"user_results":{"result":{"is_blue_verified":true,"core":{"name":"Alice","screen_name":"alice"}}}}
 	  }}}},
@@ -31,6 +31,9 @@ func TestParseTimeline(t *testing.T) {
 	first := page.Posts[0]
 	if first.Handle != "alice" || first.AuthorName != "Alice" || first.LikeCount != 4 || first.MediaCount != 1 || !first.Liked {
 		t.Fatalf("unexpected first post: %+v", first)
+	}
+	if !first.Reposted || first.RepostCount != 3 {
+		t.Fatalf("repost state lost: %+v", first)
 	}
 	if len(first.Media) != 1 || first.Media[0].URL != "https://pbs.twimg.com/media/abc" ||
 		first.Media[0].AltText != "a cat" || first.Media[0].Width != 1200 || first.Media[0].Height != 800 {

--- a/pkg/api/upload_test.go
+++ b/pkg/api/upload_test.go
@@ -96,7 +96,7 @@ func TestPostTweetChunkedVideo(t *testing.T) {
 	})}
 
 	var events []PostEvent
-	id, err := client.PostTweet(context.Background(), "clip", "", []Upload{
+	id, err := client.PostTweet(context.Background(), "clip", "", "", []Upload{
 		{Filename: "clip.mp4", ContentType: "video/mp4", Path: path},
 	}, func(event PostEvent) { events = append(events, event) })
 	if err != nil {

--- a/pkg/api/web.go
+++ b/pkg/api/web.go
@@ -185,6 +185,8 @@ func NewWebClient(cfg *config.Config) *WebClient {
 		"Viewer":                      cfg.ViewerQID,
 		"TweetDetail":                 cfg.TweetDetailQID,
 		"NotificationsTimeline":       cfg.NotificationsTimelineQID,
+		"CreateRetweet":               cfg.CreateRetweetQID,
+		"DeleteRetweet":               cfg.DeleteRetweetQID,
 	}
 	qid := operationQIDs["CreateTweet"]
 	if qid == "" {
@@ -270,6 +272,10 @@ func (c *WebClient) ApplyRefreshedQueryIDs(cfg *config.Config) bool {
 			cfg.TweetDetailQID = qid
 		case "NotificationsTimeline":
 			cfg.NotificationsTimelineQID = qid
+		case "CreateRetweet":
+			cfg.CreateRetweetQID = qid
+		case "DeleteRetweet":
+			cfg.DeleteRetweetQID = qid
 		}
 	}
 	return true

--- a/pkg/api/web.go
+++ b/pkg/api/web.go
@@ -173,15 +173,17 @@ func needsQueryIDRefresh(res *httpResult) bool {
 
 func NewWebClient(cfg *config.Config) *WebClient {
 	operationQIDs := map[string]string{
-		"CreateTweet":        cfg.CreateTweetQID,
-		"HomeTimeline":       cfg.HomeTimelineQID,
-		"HomeLatestTimeline": cfg.HomeLatestTimelineQID,
-		"Bookmarks":          cfg.BookmarksQID,
-		"SearchTimeline":     cfg.SearchTimelineQID,
-		"FavoriteTweet":      cfg.FavoriteTweetQID,
-		"UnfavoriteTweet":    cfg.UnfavoriteTweetQID,
-		"Viewer":             cfg.ViewerQID,
-		"TweetDetail":        cfg.TweetDetailQID,
+		"CreateTweet":                 cfg.CreateTweetQID,
+		"HomeTimeline":                cfg.HomeTimelineQID,
+		"HomeLatestTimeline":          cfg.HomeLatestTimelineQID,
+		"Bookmarks":                   cfg.BookmarksQID,
+		"SearchTimeline":              cfg.SearchTimelineQID,
+		"ListLatestTweetsTimeline":    cfg.ListLatestTweetsTimelineQID,
+		"ListsManagementPageTimeline": cfg.ListsManagementPageTimelineQID,
+		"FavoriteTweet":               cfg.FavoriteTweetQID,
+		"UnfavoriteTweet":             cfg.UnfavoriteTweetQID,
+		"Viewer":                      cfg.ViewerQID,
+		"TweetDetail":                 cfg.TweetDetailQID,
 	}
 	qid := operationQIDs["CreateTweet"]
 	if qid == "" {
@@ -253,6 +255,10 @@ func (c *WebClient) ApplyRefreshedQueryIDs(cfg *config.Config) bool {
 			cfg.BookmarksQID = qid
 		case "SearchTimeline":
 			cfg.SearchTimelineQID = qid
+		case "ListLatestTweetsTimeline":
+			cfg.ListLatestTweetsTimelineQID = qid
+		case "ListsManagementPageTimeline":
+			cfg.ListsManagementPageTimelineQID = qid
 		case "FavoriteTweet":
 			cfg.FavoriteTweetQID = qid
 		case "UnfavoriteTweet":

--- a/pkg/api/web.go
+++ b/pkg/api/web.go
@@ -431,6 +431,7 @@ type createTweetVariables struct {
 	DisallowedReplyOptions    []string                    `json:"disallowed_reply_options"`
 	SemanticAnnotationOptions ctSemanticAnnotationOptions `json:"semantic_annotation_options"`
 	Reply                     *ctReply                    `json:"reply,omitempty"`
+	AttachmentURL             string                      `json:"attachment_url,omitempty"`
 }
 
 type ctSemanticAnnotationOptions struct {
@@ -462,9 +463,18 @@ func newCreateTweetVariables(text string) createTweetVariables {
 	}
 }
 
+// quoteAttachmentURL builds the attachment_url CreateTweet expects for a
+// quote. The /i/status/ form is what the web composer sends; if a live run
+// ever posts without the quoted_status attached, this one function is the
+// place to try the public status URL instead.
+func quoteAttachmentURL(tweetID string) string {
+	return "https://x.com/i/status/" + tweetID
+}
+
 // PostTweet posts through the web GraphQL endpoint and returns the created id.
-// Media is uploaded first and attached to the same CreateTweet operation.
-func (c *WebClient) PostTweet(ctx context.Context, text, replyToID string, uploads []Upload, progress ProgressFunc) (string, error) {
+// Media is uploaded first and attached to the same CreateTweet operation; a
+// quoteID attaches that post as a quote.
+func (c *WebClient) PostTweet(ctx context.Context, text, replyToID, quoteID string, uploads []Upload, progress ProgressFunc) (string, error) {
 	c.lastDiagnostic = ""
 	if c.authToken == "" || c.ct0 == "" {
 		return "", fmt.Errorf("no session; run 'xeet auth' first")
@@ -514,6 +524,9 @@ func (c *WebClient) PostTweet(ctx context.Context, text, replyToID string, uploa
 	}
 	if replyToID != "" {
 		vars.Reply = &ctReply{InReplyToTweetID: replyToID, ExcludeReplyUserIDs: []string{}}
+	}
+	if quoteID != "" {
+		vars.AttachmentURL = quoteAttachmentURL(quoteID)
 	}
 
 	emitProgress(progress, PostEvent{Stage: PostStagePublishing})

--- a/pkg/api/web.go
+++ b/pkg/api/web.go
@@ -184,6 +184,7 @@ func NewWebClient(cfg *config.Config) *WebClient {
 		"UnfavoriteTweet":             cfg.UnfavoriteTweetQID,
 		"Viewer":                      cfg.ViewerQID,
 		"TweetDetail":                 cfg.TweetDetailQID,
+		"NotificationsTimeline":       cfg.NotificationsTimelineQID,
 	}
 	qid := operationQIDs["CreateTweet"]
 	if qid == "" {
@@ -267,6 +268,8 @@ func (c *WebClient) ApplyRefreshedQueryIDs(cfg *config.Config) bool {
 			cfg.ViewerQID = qid
 		case "TweetDetail":
 			cfg.TweetDetailQID = qid
+		case "NotificationsTimeline":
+			cfg.NotificationsTimelineQID = qid
 		}
 	}
 	return true

--- a/pkg/api/web.go
+++ b/pkg/api/web.go
@@ -189,6 +189,8 @@ func NewWebClient(cfg *config.Config) *WebClient {
 		"DeleteRetweet":               cfg.DeleteRetweetQID,
 		"UserByScreenName":            cfg.UserByScreenNameQID,
 		"UserTweets":                  cfg.UserTweetsQID,
+		"CreateBookmark":              cfg.CreateBookmarkQID,
+		"DeleteBookmark":              cfg.DeleteBookmarkQID,
 	}
 	qid := operationQIDs["CreateTweet"]
 	if qid == "" {
@@ -282,6 +284,10 @@ func (c *WebClient) ApplyRefreshedQueryIDs(cfg *config.Config) bool {
 			cfg.UserByScreenNameQID = qid
 		case "UserTweets":
 			cfg.UserTweetsQID = qid
+		case "CreateBookmark":
+			cfg.CreateBookmarkQID = qid
+		case "DeleteBookmark":
+			cfg.DeleteBookmarkQID = qid
 		}
 	}
 	return true

--- a/pkg/api/web.go
+++ b/pkg/api/web.go
@@ -187,6 +187,8 @@ func NewWebClient(cfg *config.Config) *WebClient {
 		"NotificationsTimeline":       cfg.NotificationsTimelineQID,
 		"CreateRetweet":               cfg.CreateRetweetQID,
 		"DeleteRetweet":               cfg.DeleteRetweetQID,
+		"UserByScreenName":            cfg.UserByScreenNameQID,
+		"UserTweets":                  cfg.UserTweetsQID,
 	}
 	qid := operationQIDs["CreateTweet"]
 	if qid == "" {
@@ -276,6 +278,10 @@ func (c *WebClient) ApplyRefreshedQueryIDs(cfg *config.Config) bool {
 			cfg.CreateRetweetQID = qid
 		case "DeleteRetweet":
 			cfg.DeleteRetweetQID = qid
+		case "UserByScreenName":
+			cfg.UserByScreenNameQID = qid
+		case "UserTweets":
+			cfg.UserTweetsQID = qid
 		}
 	}
 	return true

--- a/pkg/api/web_test.go
+++ b/pkg/api/web_test.go
@@ -71,7 +71,7 @@ func TestPostTweetUploadsMultipleImages(t *testing.T) {
 	})}
 
 	var events []PostEvent
-	id, err := client.PostTweet(context.Background(), "album", "", []Upload{
+	id, err := client.PostTweet(context.Background(), "album", "", "", []Upload{
 		{Filename: "one.png", ContentType: "image/png", Data: []byte("one")},
 		{Filename: "two.png", ContentType: "image/png", Data: []byte("two")},
 	}, func(event PostEvent) { events = append(events, event) })
@@ -91,14 +91,14 @@ func TestPostTweetUploadsMultipleImages(t *testing.T) {
 
 func TestPostTweetValidatesContent(t *testing.T) {
 	client := &WebClient{authToken: "auth", ct0: "csrf"}
-	if _, err := client.PostTweet(context.Background(), "", "", nil, nil); err == nil {
+	if _, err := client.PostTweet(context.Background(), "", "", "", nil, nil); err == nil {
 		t.Fatal("empty post should fail")
 	}
 	uploads := make([]Upload, 5)
 	for i := range uploads {
 		uploads[i] = Upload{Data: []byte("x")}
 	}
-	if _, err := client.PostTweet(context.Background(), "x", "", uploads, nil); err == nil {
+	if _, err := client.PostTweet(context.Background(), "x", "", "", uploads, nil); err == nil {
 		t.Fatal("five images should fail")
 	}
 }
@@ -112,8 +112,44 @@ func TestPostTweetRejectsMixedVideoAndImages(t *testing.T) {
 		{ContentType: "video/mp4", Data: []byte("v")},
 		{ContentType: "image/png", Data: []byte("i")},
 	}
-	if _, err := client.PostTweet(context.Background(), "x", "", uploads, nil); err == nil {
+	if _, err := client.PostTweet(context.Background(), "x", "", "", uploads, nil); err == nil {
 		t.Fatal("video mixed with an image should fail")
+	}
+}
+
+func TestPostTweetQuoteAttachesStatusURL(t *testing.T) {
+	var graphQLBody []byte
+	client := &WebClient{authToken: "auth", ct0: "csrf", operationQIDs: map[string]string{"CreateTweet": "qid"}}
+	client.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		graphQLBody, _ = io.ReadAll(req.Body)
+		return response(http.StatusOK, `{"data":{"create_tweet":{"tweet_results":{"result":{"rest_id":"99"}}}}}`), nil
+	})}
+
+	id, err := client.PostTweet(context.Background(), "so true", "", "42", nil, nil)
+	if err != nil || id != "99" {
+		t.Fatalf("id=%q err=%v", id, err)
+	}
+	if !strings.Contains(string(graphQLBody), `"attachment_url":"https://x.com/i/status/42"`) {
+		t.Fatalf("quote attachment missing: %s", graphQLBody)
+	}
+	if strings.Contains(string(graphQLBody), "in_reply_to_tweet_id") {
+		t.Fatalf("quote must not double as a reply: %s", graphQLBody)
+	}
+}
+
+func TestPostTweetWithoutQuoteOmitsAttachmentURL(t *testing.T) {
+	var graphQLBody []byte
+	client := &WebClient{authToken: "auth", ct0: "csrf", operationQIDs: map[string]string{"CreateTweet": "qid"}}
+	client.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		graphQLBody, _ = io.ReadAll(req.Body)
+		return response(http.StatusOK, `{"data":{"create_tweet":{"tweet_results":{"result":{"rest_id":"99"}}}}}`), nil
+	})}
+
+	if _, err := client.PostTweet(context.Background(), "plain", "", "", nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(graphQLBody), "attachment_url") {
+		t.Fatalf("plain post carried an attachment_url: %s", graphQLBody)
 	}
 }
 

--- a/pkg/config/accounts.go
+++ b/pkg/config/accounts.go
@@ -16,6 +16,7 @@ type AccountInfo struct {
 	SessionBrowser  string
 	SessionProfile  string
 	SessionImported time.Time
+	Active          bool
 }
 
 func configFromFile(fc *fileConfig) *Config {
@@ -155,6 +156,7 @@ func (cm *ConfigManager) Accounts() ([]AccountInfo, error) {
 			SessionBrowser:  account.SessionBrowser,
 			SessionProfile:  account.SessionProfile,
 			SessionImported: parseTime(account.SessionImported),
+			Active:          userID == fc.Active,
 		})
 	}
 	return accounts, nil

--- a/pkg/config/accounts.go
+++ b/pkg/config/accounts.go
@@ -1,0 +1,547 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"time"
+)
+
+// AccountInfo is non-secret account metadata available without opening the
+// keyring or contacting X.
+type AccountInfo struct {
+	UserID          string
+	Handle          string
+	SessionBrowser  string
+	SessionProfile  string
+	SessionImported time.Time
+}
+
+func configFromFile(fc *fileConfig) *Config {
+	return &Config{
+		CreateTweetQID:                 fc.CreateTweetQID,
+		HomeTimelineQID:                fc.HomeTimelineQID,
+		HomeLatestTimelineQID:          fc.HomeLatestTimelineQID,
+		BookmarksQID:                   fc.BookmarksQID,
+		SearchTimelineQID:              fc.SearchTimelineQID,
+		ListLatestTweetsTimelineQID:    fc.ListLatestTweetsTimelineQID,
+		ListsManagementPageTimelineQID: fc.ListsManagementPageTimelineQID,
+		FavoriteTweetQID:               fc.FavoriteTweetQID,
+		UnfavoriteTweetQID:             fc.UnfavoriteTweetQID,
+		ViewerQID:                      fc.ViewerQID,
+		TweetDetailQID:                 fc.TweetDetailQID,
+		Theme:                          fc.Theme,
+		Columns:                        append([]string(nil), fc.Columns...),
+		SessionBrowser:                 fc.SessionBrowser,
+		SessionProfile:                 fc.SessionProfile,
+		SessionDomain:                  fc.SessionDomain,
+		SessionExpires:                 parseTime(fc.SessionExpires),
+		SessionImported:                parseTime(fc.SessionImported),
+	}
+}
+
+func fileAccountFor(cfg *Config) fileAccount {
+	account := fileAccount{
+		Handle:          cfg.Handle,
+		SessionBrowser:  cfg.SessionBrowser,
+		SessionProfile:  cfg.SessionProfile,
+		SessionDomain:   cfg.SessionDomain,
+		SessionExpires:  formatTime(cfg.SessionExpires),
+		SessionImported: formatTime(cfg.SessionImported),
+	}
+	return account
+}
+
+func applyFileAccount(cfg *Config, userID string, account fileAccount) {
+	cfg.UserID = userID
+	cfg.Handle = account.Handle
+	cfg.SessionBrowser = account.SessionBrowser
+	cfg.SessionProfile = account.SessionProfile
+	cfg.SessionDomain = account.SessionDomain
+	cfg.SessionExpires = parseTime(account.SessionExpires)
+	cfg.SessionImported = parseTime(account.SessionImported)
+}
+
+func parseTime(value string) time.Time {
+	parsed, _ := time.Parse(time.RFC3339, value)
+	return parsed
+}
+
+func formatTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339)
+}
+
+func writableVersion(fc *fileConfig) error {
+	if fc.Version > currentConfigVersion {
+		return fmt.Errorf("config written by a newer xeet (version %d)", fc.Version)
+	}
+	return nil
+}
+
+func (cm *ConfigManager) loadAccount(fc *fileConfig, userID string) (*Config, error) {
+	account, ok := fc.Accounts[userID]
+	if !ok {
+		return nil, fmt.Errorf("saved account %q does not exist", userID)
+	}
+	authToken, ct0, err := cm.loadSecretPair(userID)
+	if err != nil {
+		return nil, err
+	}
+	cfg := configFromFile(fc)
+	applyFileAccount(cfg, userID, account)
+	cfg.AuthToken = authToken
+	cfg.CT0 = ct0
+	return cfg, nil
+}
+
+func (cm *ConfigManager) loadSecretPair(userID string) (string, string, error) {
+	authToken, authErr := cm.secrets.Get(authTokenKey(userID))
+	ct0, ct0Err := cm.secrets.Get(ct0Key(userID))
+	if authErr != nil && !errors.Is(authErr, ErrSecretNotFound) {
+		return "", "", authErr
+	}
+	if ct0Err != nil && !errors.Is(ct0Err, ErrSecretNotFound) {
+		return "", "", ct0Err
+	}
+	if authErr != nil || ct0Err != nil || authToken == "" || ct0 == "" {
+		return "", "", ErrSessionIncomplete
+	}
+	return authToken, ct0, nil
+}
+
+// LoadAccount resolves one saved account without changing which account is
+// active.
+func (cm *ConfigManager) LoadAccount(userID string) (*Config, error) {
+	fc, err := cm.readFile()
+	if err != nil {
+		return nil, err
+	}
+	if fc.Version == 0 {
+		migrated, migrateErr := cm.migrateV1(fc)
+		if migrateErr != nil {
+			return nil, migrateErr
+		}
+		if migrated {
+			fc, err = cm.readFile()
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	return cm.loadAccount(fc, userID)
+}
+
+// Accounts lists saved account metadata without reading the keyring.
+func (cm *ConfigManager) Accounts() ([]AccountInfo, error) {
+	fc, err := cm.readFile()
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(fc.Accounts))
+	for userID := range fc.Accounts {
+		ids = append(ids, userID)
+	}
+	sort.Strings(ids)
+	accounts := make([]AccountInfo, 0, len(ids))
+	for _, userID := range ids {
+		account := fc.Accounts[userID]
+		accounts = append(accounts, AccountInfo{
+			UserID:          userID,
+			Handle:          account.Handle,
+			SessionBrowser:  account.SessionBrowser,
+			SessionProfile:  account.SessionProfile,
+			SessionImported: parseTime(account.SessionImported),
+		})
+	}
+	return accounts, nil
+}
+
+// Version reads the on-disk schema version without touching the keyring.
+func (cm *ConfigManager) Version() (int, error) {
+	fc, err := cm.readFile()
+	if err != nil {
+		return 0, err
+	}
+	return fc.Version, nil
+}
+
+// SetActive selects an existing account without reading or rewriting secrets.
+func (cm *ConfigManager) SetActive(userID string) error {
+	fc, err := cm.readFile()
+	if err != nil {
+		return err
+	}
+	if err := writableVersion(fc); err != nil {
+		return err
+	}
+	if _, ok := fc.Accounts[userID]; !ok {
+		return fmt.Errorf("saved account %q does not exist", userID)
+	}
+	fc.Active = userID
+	return cm.writeFile(fc)
+}
+
+// SaveAccount upserts one stable user-id-keyed session while preserving every
+// other account and all global settings.
+func (cm *ConfigManager) SaveAccount(cfg *Config) error {
+	if cfg == nil {
+		return errors.New("config is nil")
+	}
+	if cfg.UserID == "" {
+		return errors.New("account user id is required")
+	}
+	if cfg.AuthToken == "" || cfg.CT0 == "" {
+		return ErrSessionIncomplete
+	}
+
+	fc, err := cm.readFile()
+	if err != nil {
+		return err
+	}
+	if fc.Version == 0 {
+		migrated, migrateErr := cm.migrateV1(fc)
+		if migrateErr != nil {
+			return migrateErr
+		}
+		if migrated {
+			fc, err = cm.readFile()
+			if err != nil {
+				return err
+			}
+		}
+	}
+	if err := writableVersion(fc); err != nil {
+		return err
+	}
+	upgradeFile(fc)
+
+	rollback, err := cm.setSecretPair(cfg.UserID, cfg.AuthToken, cfg.CT0)
+	if err != nil {
+		return err
+	}
+	if fc.Accounts == nil {
+		fc.Accounts = make(map[string]fileAccount)
+	}
+	fc.Accounts[cfg.UserID] = fileAccountFor(cfg)
+	fc.Active = cfg.UserID
+	if err := cm.writeFile(fc); err != nil {
+		return rollbackUncommitted(err, rollback)
+	}
+	_ = cm.secrets.Delete(keyLegacySessionCookies)
+	return nil
+}
+
+func (cm *ConfigManager) saveAccountReplacingFile(cfg *Config) error {
+	if cfg.AuthToken == "" || cfg.CT0 == "" {
+		return ErrSessionIncomplete
+	}
+	rollback, err := cm.setSecretPair(cfg.UserID, cfg.AuthToken, cfg.CT0)
+	if err != nil {
+		return err
+	}
+	if err := cm.writeFile(fileConfigFor(cfg)); err != nil {
+		return rollbackUncommitted(err, rollback)
+	}
+	return nil
+}
+
+func (cm *ConfigManager) setSecretPair(userID, authToken, ct0 string) (func(error) error, error) {
+	authKey := authTokenKey(userID)
+	ct0KeyName := ct0Key(userID)
+	oldAuth, err := cm.snapshotSecret(authKey)
+	if err != nil {
+		return nil, err
+	}
+	oldCT0, err := cm.snapshotSecret(ct0KeyName)
+	if err != nil {
+		return nil, err
+	}
+	rollback := func(cause error) error {
+		return errors.Join(cause, cm.restoreSecret(authKey, oldAuth), cm.restoreSecret(ct0KeyName, oldCT0))
+	}
+	if err := cm.secrets.Set(authKey, authToken); err != nil {
+		return nil, err
+	}
+	if err := cm.secrets.Set(ct0KeyName, ct0); err != nil {
+		return nil, rollback(err)
+	}
+	return rollback, nil
+}
+
+func upgradeFile(fc *fileConfig) {
+	fc.Version = currentConfigVersion
+	fc.AuthToken = ""
+	fc.CT0 = ""
+	fc.SessionBrowser = ""
+	fc.SessionProfile = ""
+	fc.SessionDomain = ""
+	fc.SessionExpires = ""
+	fc.SessionImported = ""
+	if fc.Accounts == nil {
+		fc.Accounts = make(map[string]fileAccount)
+	}
+}
+
+// SaveQueryIDs re-reads the file so a client holding a stale Config cannot
+// resurrect or remove accounts while caching freshly discovered operations.
+func (cm *ConfigManager) SaveQueryIDs(cfg *Config) error {
+	if cfg == nil {
+		return errors.New("config is nil")
+	}
+	fc, err := cm.readFile()
+	if err != nil {
+		return err
+	}
+	if err := writableVersion(fc); err != nil {
+		return err
+	}
+	fc.CreateTweetQID = cfg.CreateTweetQID
+	fc.HomeTimelineQID = cfg.HomeTimelineQID
+	fc.HomeLatestTimelineQID = cfg.HomeLatestTimelineQID
+	fc.BookmarksQID = cfg.BookmarksQID
+	fc.SearchTimelineQID = cfg.SearchTimelineQID
+	fc.ListLatestTweetsTimelineQID = cfg.ListLatestTweetsTimelineQID
+	fc.ListsManagementPageTimelineQID = cfg.ListsManagementPageTimelineQID
+	fc.FavoriteTweetQID = cfg.FavoriteTweetQID
+	fc.UnfavoriteTweetQID = cfg.UnfavoriteTweetQID
+	fc.ViewerQID = cfg.ViewerQID
+	fc.TweetDetailQID = cfg.TweetDetailQID
+	return cm.writeFile(fc)
+}
+
+// SaveTheme patches only the global palette selection.
+func (cm *ConfigManager) SaveTheme(name string) error {
+	fc, err := cm.readFile()
+	if err != nil {
+		return err
+	}
+	if err := writableVersion(fc); err != nil {
+		return err
+	}
+	fc.Theme = name
+	return cm.writeFile(fc)
+}
+
+// RekeyAccount promotes a provisional account to a stable X user id. The old
+// pair is deleted only after both the new pair and the rewritten file exist.
+func (cm *ConfigManager) RekeyAccount(oldID, newID string) error {
+	if oldID == "" || newID == "" {
+		return errors.New("old and new account user ids are required")
+	}
+	if oldID == newID {
+		return nil
+	}
+	fc, err := cm.readFile()
+	if err != nil {
+		return err
+	}
+	if err := writableVersion(fc); err != nil {
+		return err
+	}
+	oldAccount, oldExists := fc.Accounts[oldID]
+	newAccount, newExists := fc.Accounts[newID]
+	if !oldExists {
+		if newExists {
+			return errors.Join(
+				cm.secrets.Delete(authTokenKey(oldID)),
+				cm.secrets.Delete(ct0Key(oldID)),
+			)
+		}
+		return fmt.Errorf("saved account %q does not exist", oldID)
+	}
+
+	winnerAccount := oldAccount
+	winnerAuth, winnerCT0, err := cm.loadSecretPair(oldID)
+	if err != nil {
+		return err
+	}
+	if newExists && !parseTime(oldAccount.SessionImported).After(parseTime(newAccount.SessionImported)) {
+		winnerAccount = newAccount
+		winnerAuth, winnerCT0, err = cm.loadSecretPair(newID)
+		if err != nil {
+			return err
+		}
+	}
+
+	rollback, err := cm.setSecretPair(newID, winnerAuth, winnerCT0)
+	if err != nil {
+		return err
+	}
+	fc.Accounts[newID] = winnerAccount
+	delete(fc.Accounts, oldID)
+	if fc.Active == oldID {
+		fc.Active = newID
+	}
+	if err := cm.writeFile(fc); err != nil {
+		return rollbackUncommitted(err, rollback)
+	}
+	return errors.Join(
+		cm.secrets.Delete(authTokenKey(oldID)),
+		cm.secrets.Delete(ct0Key(oldID)),
+	)
+}
+
+// RecordViewer is the single promotion path used after a successful viewer
+// fetch. Cookie fingerprints are diagnostics only; the stable X user id is
+// the account key.
+func (cm *ConfigManager) RecordViewer(userID, handle string) error {
+	if userID == "" {
+		return errors.New("viewer user id is empty")
+	}
+	fc, err := cm.readFile()
+	if err != nil {
+		return err
+	}
+	if fc.Active == legacyAccountID {
+		if err := cm.RekeyAccount(legacyAccountID, userID); err != nil {
+			return err
+		}
+		fc, err = cm.readFile()
+		if err != nil {
+			return err
+		}
+	}
+	if err := writableVersion(fc); err != nil {
+		return err
+	}
+	account, ok := fc.Accounts[userID]
+	if !ok {
+		return nil
+	}
+	if account.Handle == handle {
+		return nil
+	}
+	account.Handle = handle
+	fc.Accounts[userID] = account
+	return cm.writeFile(fc)
+}
+
+// EraseAccount removes one session while preserving global query ids, theme,
+// columns, and every other account.
+func (cm *ConfigManager) EraseAccount(userID string) error {
+	fc, err := cm.readFile()
+	if err != nil {
+		return err
+	}
+	if err := writableVersion(fc); err != nil {
+		return err
+	}
+	if _, ok := fc.Accounts[userID]; !ok {
+		return fmt.Errorf("saved account %q does not exist", userID)
+	}
+	authKey := authTokenKey(userID)
+	ct0KeyName := ct0Key(userID)
+	oldAuth, err := cm.snapshotSecret(authKey)
+	if err != nil {
+		return err
+	}
+	oldCT0, err := cm.snapshotSecret(ct0KeyName)
+	if err != nil {
+		return err
+	}
+	rollback := func(cause error) error {
+		return errors.Join(cause, cm.restoreSecret(authKey, oldAuth), cm.restoreSecret(ct0KeyName, oldCT0))
+	}
+	if err := cm.secrets.Delete(authKey); err != nil {
+		return err
+	}
+	if err := cm.secrets.Delete(ct0KeyName); err != nil {
+		return rollback(err)
+	}
+
+	delete(fc.Accounts, userID)
+	if fc.Active == userID {
+		fc.Active = ""
+		ids := make([]string, 0, len(fc.Accounts))
+		for id := range fc.Accounts {
+			ids = append(ids, id)
+		}
+		sort.Strings(ids)
+		if len(ids) > 0 {
+			fc.Active = ids[0]
+		}
+	}
+	if err := cm.writeFile(fc); err != nil {
+		return rollbackUncommitted(err, rollback)
+	}
+	return nil
+}
+
+func (cm *ConfigManager) migrateV1(fc *fileConfig) (bool, error) {
+	authToken, ct0, found, err := cm.legacySession(fc)
+	if err != nil || !found {
+		return false, err
+	}
+
+	rollback, err := cm.setSecretPair(legacyAccountID, authToken, ct0)
+	if err != nil {
+		return false, fmt.Errorf("migrating legacy session: %w", err)
+	}
+	upgraded := *fc
+	legacyAccount := fileAccount{
+		SessionBrowser:  fc.SessionBrowser,
+		SessionProfile:  fc.SessionProfile,
+		SessionDomain:   fc.SessionDomain,
+		SessionExpires:  fc.SessionExpires,
+		SessionImported: fc.SessionImported,
+	}
+	upgradeFile(&upgraded)
+	upgraded.Active = legacyAccountID
+	upgraded.Accounts[legacyAccountID] = legacyAccount
+	if err := cm.writeFile(&upgraded); err != nil {
+		wrapped := fmt.Errorf("migrating legacy session: %w", err)
+		return false, rollbackUncommitted(wrapped, rollback)
+	}
+
+	cleanupErr := errors.Join(
+		cm.secrets.Delete(keyLegacyAuthToken),
+		cm.secrets.Delete(keyLegacyCT0),
+		cm.secrets.Delete(keyLegacySessionCookies),
+	)
+	if err := os.Remove(cm.legacyKeyPath); err != nil && !os.IsNotExist(err) {
+		cleanupErr = errors.Join(cleanupErr, err)
+	}
+	if cleanupErr != nil {
+		return false, fmt.Errorf("cleaning up migrated legacy session: %w", cleanupErr)
+	}
+	return true, nil
+}
+
+func (cm *ConfigManager) legacySession(fc *fileConfig) (string, string, bool, error) {
+	authToken, authErr := cm.secrets.Get(keyLegacyAuthToken)
+	ct0, ct0Err := cm.secrets.Get(keyLegacyCT0)
+	if authErr != nil && !errors.Is(authErr, ErrSecretNotFound) {
+		return "", "", false, authErr
+	}
+	if ct0Err != nil && !errors.Is(ct0Err, ErrSecretNotFound) {
+		return "", "", false, ct0Err
+	}
+	if authErr == nil || ct0Err == nil {
+		if authErr != nil || ct0Err != nil || authToken == "" || ct0 == "" {
+			return "", "", false, ErrSessionIncomplete
+		}
+		return authToken, ct0, true, nil
+	}
+
+	if fc.AuthToken == "" && fc.CT0 == "" {
+		return "", "", false, nil
+	}
+	if fc.AuthToken == "" || fc.CT0 == "" {
+		return "", "", false, ErrSessionIncomplete
+	}
+	authToken = fc.AuthToken
+	if key, err := secureReadFile(cm.legacyKeyPath); err == nil {
+		decrypted, decryptErr := legacyDecrypt(authToken, key)
+		if decryptErr != nil {
+			return "", "", false, fmt.Errorf("migrating legacy session: %w (run 'xeet auth' to reconnect)", decryptErr)
+		}
+		authToken = decrypted
+	} else if !os.IsNotExist(err) {
+		return "", "", false, fmt.Errorf("migrating legacy session key: %w", err)
+	}
+	return authToken, fc.CT0, true, nil
+}

--- a/pkg/config/accounts.go
+++ b/pkg/config/accounts.go
@@ -37,6 +37,8 @@ func configFromFile(fc *fileConfig) *Config {
 		DeleteRetweetQID:               fc.DeleteRetweetQID,
 		UserByScreenNameQID:            fc.UserByScreenNameQID,
 		UserTweetsQID:                  fc.UserTweetsQID,
+		CreateBookmarkQID:              fc.CreateBookmarkQID,
+		DeleteBookmarkQID:              fc.DeleteBookmarkQID,
 		Theme:                          fc.Theme,
 		Columns:                        append([]string(nil), fc.Columns...),
 		RefreshInterval:                fc.RefreshInterval,
@@ -323,6 +325,8 @@ func (cm *ConfigManager) SaveQueryIDs(cfg *Config) error {
 	fc.DeleteRetweetQID = cfg.DeleteRetweetQID
 	fc.UserByScreenNameQID = cfg.UserByScreenNameQID
 	fc.UserTweetsQID = cfg.UserTweetsQID
+	fc.CreateBookmarkQID = cfg.CreateBookmarkQID
+	fc.DeleteBookmarkQID = cfg.DeleteBookmarkQID
 	return cm.writeFile(fc)
 }
 

--- a/pkg/config/accounts.go
+++ b/pkg/config/accounts.go
@@ -34,6 +34,7 @@ func configFromFile(fc *fileConfig) *Config {
 		TweetDetailQID:                 fc.TweetDetailQID,
 		Theme:                          fc.Theme,
 		Columns:                        append([]string(nil), fc.Columns...),
+		RefreshInterval:                fc.RefreshInterval,
 		SessionBrowser:                 fc.SessionBrowser,
 		SessionProfile:                 fc.SessionProfile,
 		SessionDomain:                  fc.SessionDomain,

--- a/pkg/config/accounts.go
+++ b/pkg/config/accounts.go
@@ -35,6 +35,8 @@ func configFromFile(fc *fileConfig) *Config {
 		NotificationsTimelineQID:       fc.NotificationsTimelineQID,
 		CreateRetweetQID:               fc.CreateRetweetQID,
 		DeleteRetweetQID:               fc.DeleteRetweetQID,
+		UserByScreenNameQID:            fc.UserByScreenNameQID,
+		UserTweetsQID:                  fc.UserTweetsQID,
 		Theme:                          fc.Theme,
 		Columns:                        append([]string(nil), fc.Columns...),
 		RefreshInterval:                fc.RefreshInterval,
@@ -319,6 +321,8 @@ func (cm *ConfigManager) SaveQueryIDs(cfg *Config) error {
 	fc.NotificationsTimelineQID = cfg.NotificationsTimelineQID
 	fc.CreateRetweetQID = cfg.CreateRetweetQID
 	fc.DeleteRetweetQID = cfg.DeleteRetweetQID
+	fc.UserByScreenNameQID = cfg.UserByScreenNameQID
+	fc.UserTweetsQID = cfg.UserTweetsQID
 	return cm.writeFile(fc)
 }
 

--- a/pkg/config/accounts.go
+++ b/pkg/config/accounts.go
@@ -33,6 +33,8 @@ func configFromFile(fc *fileConfig) *Config {
 		ViewerQID:                      fc.ViewerQID,
 		TweetDetailQID:                 fc.TweetDetailQID,
 		NotificationsTimelineQID:       fc.NotificationsTimelineQID,
+		CreateRetweetQID:               fc.CreateRetweetQID,
+		DeleteRetweetQID:               fc.DeleteRetweetQID,
 		Theme:                          fc.Theme,
 		Columns:                        append([]string(nil), fc.Columns...),
 		RefreshInterval:                fc.RefreshInterval,
@@ -315,6 +317,8 @@ func (cm *ConfigManager) SaveQueryIDs(cfg *Config) error {
 	fc.ViewerQID = cfg.ViewerQID
 	fc.TweetDetailQID = cfg.TweetDetailQID
 	fc.NotificationsTimelineQID = cfg.NotificationsTimelineQID
+	fc.CreateRetweetQID = cfg.CreateRetweetQID
+	fc.DeleteRetweetQID = cfg.DeleteRetweetQID
 	return cm.writeFile(fc)
 }
 

--- a/pkg/config/accounts.go
+++ b/pkg/config/accounts.go
@@ -32,6 +32,7 @@ func configFromFile(fc *fileConfig) *Config {
 		UnfavoriteTweetQID:             fc.UnfavoriteTweetQID,
 		ViewerQID:                      fc.ViewerQID,
 		TweetDetailQID:                 fc.TweetDetailQID,
+		NotificationsTimelineQID:       fc.NotificationsTimelineQID,
 		Theme:                          fc.Theme,
 		Columns:                        append([]string(nil), fc.Columns...),
 		RefreshInterval:                fc.RefreshInterval,
@@ -313,6 +314,7 @@ func (cm *ConfigManager) SaveQueryIDs(cfg *Config) error {
 	fc.UnfavoriteTweetQID = cfg.UnfavoriteTweetQID
 	fc.ViewerQID = cfg.ViewerQID
 	fc.TweetDetailQID = cfg.TweetDetailQID
+	fc.NotificationsTimelineQID = cfg.NotificationsTimelineQID
 	return cm.writeFile(fc)
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,6 +36,8 @@ type Config struct {
 	NotificationsTimelineQID       string    `yaml:"notifications_timeline_qid,omitempty"`
 	CreateRetweetQID               string    `yaml:"create_retweet_qid,omitempty"`
 	DeleteRetweetQID               string    `yaml:"delete_retweet_qid,omitempty"`
+	UserByScreenNameQID            string    `yaml:"user_by_screen_name_qid,omitempty"`
+	UserTweetsQID                  string    `yaml:"user_tweets_qid,omitempty"`
 	Theme                          string    `yaml:"theme,omitempty"`
 	Columns                        []string  `yaml:"columns,omitempty"`
 	RefreshInterval                string    `yaml:"refresh_interval,omitempty"`
@@ -124,6 +126,8 @@ type fileConfig struct {
 	NotificationsTimelineQID       string                 `yaml:"notifications_timeline_qid,omitempty"`
 	CreateRetweetQID               string                 `yaml:"create_retweet_qid,omitempty"`
 	DeleteRetweetQID               string                 `yaml:"delete_retweet_qid,omitempty"`
+	UserByScreenNameQID            string                 `yaml:"user_by_screen_name_qid,omitempty"`
+	UserTweetsQID                  string                 `yaml:"user_tweets_qid,omitempty"`
 	Theme                          string                 `yaml:"theme,omitempty"`
 	Columns                        []string               `yaml:"columns,omitempty"`
 	RefreshInterval                string                 `yaml:"refresh_interval,omitempty"`
@@ -288,6 +292,8 @@ func fileConfigFor(config *Config) *fileConfig {
 		NotificationsTimelineQID:       config.NotificationsTimelineQID,
 		CreateRetweetQID:               config.CreateRetweetQID,
 		DeleteRetweetQID:               config.DeleteRetweetQID,
+		UserByScreenNameQID:            config.UserByScreenNameQID,
+		UserTweetsQID:                  config.UserTweetsQID,
 		Theme:                          config.Theme,
 		Columns:                        append([]string(nil), config.Columns...),
 		RefreshInterval:                config.RefreshInterval,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,6 +38,8 @@ type Config struct {
 	DeleteRetweetQID               string    `yaml:"delete_retweet_qid,omitempty"`
 	UserByScreenNameQID            string    `yaml:"user_by_screen_name_qid,omitempty"`
 	UserTweetsQID                  string    `yaml:"user_tweets_qid,omitempty"`
+	CreateBookmarkQID              string    `yaml:"create_bookmark_qid,omitempty"`
+	DeleteBookmarkQID              string    `yaml:"delete_bookmark_qid,omitempty"`
 	Theme                          string    `yaml:"theme,omitempty"`
 	Columns                        []string  `yaml:"columns,omitempty"`
 	RefreshInterval                string    `yaml:"refresh_interval,omitempty"`
@@ -128,6 +130,8 @@ type fileConfig struct {
 	DeleteRetweetQID               string                 `yaml:"delete_retweet_qid,omitempty"`
 	UserByScreenNameQID            string                 `yaml:"user_by_screen_name_qid,omitempty"`
 	UserTweetsQID                  string                 `yaml:"user_tweets_qid,omitempty"`
+	CreateBookmarkQID              string                 `yaml:"create_bookmark_qid,omitempty"`
+	DeleteBookmarkQID              string                 `yaml:"delete_bookmark_qid,omitempty"`
 	Theme                          string                 `yaml:"theme,omitempty"`
 	Columns                        []string               `yaml:"columns,omitempty"`
 	RefreshInterval                string                 `yaml:"refresh_interval,omitempty"`
@@ -294,6 +298,8 @@ func fileConfigFor(config *Config) *fileConfig {
 		DeleteRetweetQID:               config.DeleteRetweetQID,
 		UserByScreenNameQID:            config.UserByScreenNameQID,
 		UserTweetsQID:                  config.UserTweetsQID,
+		CreateBookmarkQID:              config.CreateBookmarkQID,
+		DeleteBookmarkQID:              config.DeleteBookmarkQID,
 		Theme:                          config.Theme,
 		Columns:                        append([]string(nil), config.Columns...),
 		RefreshInterval:                config.RefreshInterval,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	TweetDetailQID                 string    `yaml:"tweet_detail_qid,omitempty"`
 	Theme                          string    `yaml:"theme,omitempty"`
 	Columns                        []string  `yaml:"columns,omitempty"`
+	RefreshInterval                string    `yaml:"refresh_interval,omitempty"`
 	SessionBrowser                 string    `yaml:"session_browser,omitempty"`
 	SessionProfile                 string    `yaml:"session_profile,omitempty"`
 	SessionDomain                  string    `yaml:"session_domain,omitempty"`
@@ -119,6 +120,7 @@ type fileConfig struct {
 	TweetDetailQID                 string                 `yaml:"tweet_detail_qid,omitempty"`
 	Theme                          string                 `yaml:"theme,omitempty"`
 	Columns                        []string               `yaml:"columns,omitempty"`
+	RefreshInterval                string                 `yaml:"refresh_interval,omitempty"`
 	SessionBrowser                 string                 `yaml:"session_browser,omitempty"`
 	SessionProfile                 string                 `yaml:"session_profile,omitempty"`
 	SessionDomain                  string                 `yaml:"session_domain,omitempty"`
@@ -208,6 +210,24 @@ func (cm *ConfigManager) Columns() ([]string, error) {
 	return append([]string(nil), fc.Columns...), nil
 }
 
+// RefreshInterval reads the saved auto-refresh interval as a Go duration
+// ("60s", "5m"), or 0 when unset — polling stays opt-in. Like Theme and
+// Columns it reads the file only, so startup never provokes a keychain prompt.
+func (cm *ConfigManager) RefreshInterval() (time.Duration, error) {
+	fc, err := cm.readFile()
+	if err != nil {
+		return 0, err
+	}
+	if fc.RefreshInterval == "" {
+		return 0, nil
+	}
+	interval, err := time.ParseDuration(fc.RefreshInterval)
+	if err != nil {
+		return 0, fmt.Errorf("invalid refresh_interval %q (use a duration like 60s or 5m)", fc.RefreshInterval)
+	}
+	return interval, nil
+}
+
 // SaveColumns patches only the explicit layout setting. Loading and saving a
 // full Config here could overwrite session metadata changed by another command.
 func (cm *ConfigManager) SaveColumns(columns []string) error {
@@ -261,6 +281,7 @@ func fileConfigFor(config *Config) *fileConfig {
 		TweetDetailQID:                 config.TweetDetailQID,
 		Theme:                          config.Theme,
 		Columns:                        append([]string(nil), config.Columns...),
+		RefreshInterval:                config.RefreshInterval,
 	}
 	if config.UserID != "" {
 		result.Accounts = map[string]fileAccount{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	UnfavoriteTweetQID             string    `yaml:"unfavorite_tweet_qid,omitempty"`
 	ViewerQID                      string    `yaml:"viewer_qid,omitempty"`
 	TweetDetailQID                 string    `yaml:"tweet_detail_qid,omitempty"`
+	NotificationsTimelineQID       string    `yaml:"notifications_timeline_qid,omitempty"`
 	Theme                          string    `yaml:"theme,omitempty"`
 	Columns                        []string  `yaml:"columns,omitempty"`
 	RefreshInterval                string    `yaml:"refresh_interval,omitempty"`
@@ -118,6 +119,7 @@ type fileConfig struct {
 	UnfavoriteTweetQID             string                 `yaml:"unfavorite_tweet_qid,omitempty"`
 	ViewerQID                      string                 `yaml:"viewer_qid,omitempty"`
 	TweetDetailQID                 string                 `yaml:"tweet_detail_qid,omitempty"`
+	NotificationsTimelineQID       string                 `yaml:"notifications_timeline_qid,omitempty"`
 	Theme                          string                 `yaml:"theme,omitempty"`
 	Columns                        []string               `yaml:"columns,omitempty"`
 	RefreshInterval                string                 `yaml:"refresh_interval,omitempty"`
@@ -279,6 +281,7 @@ func fileConfigFor(config *Config) *fileConfig {
 		UnfavoriteTweetQID:             config.UnfavoriteTweetQID,
 		ViewerQID:                      config.ViewerQID,
 		TweetDetailQID:                 config.TweetDetailQID,
+		NotificationsTimelineQID:       config.NotificationsTimelineQID,
 		Theme:                          config.Theme,
 		Columns:                        append([]string(nil), config.Columns...),
 		RefreshInterval:                config.RefreshInterval,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -150,6 +150,12 @@ func NewConfigManager() (*ConfigManager, error) {
 	return newConfigManagerAt(homeDir, systemKeyring{}), nil
 }
 
+// NewConfigManagerAt keeps callers that provide storage off the process home
+// directory and OS keyring.
+func NewConfigManagerAt(dir string, secrets SecretStore) *ConfigManager {
+	return newConfigManagerAt(dir, secrets)
+}
+
 func newConfigManagerAt(dir string, secrets SecretStore) *ConfigManager {
 	return &ConfigManager{
 		configPath:    filepath.Join(dir, ".xeet.yaml"),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	ViewerQID                      string    `yaml:"viewer_qid,omitempty"`
 	TweetDetailQID                 string    `yaml:"tweet_detail_qid,omitempty"`
 	Theme                          string    `yaml:"theme,omitempty"`
+	Columns                        []string  `yaml:"columns,omitempty"`
 	SessionBrowser                 string    `yaml:"session_browser,omitempty"`
 	SessionProfile                 string    `yaml:"session_profile,omitempty"`
 	SessionDomain                  string    `yaml:"session_domain,omitempty"`
@@ -97,25 +98,26 @@ func (systemKeyring) Delete(key string) error {
 // fileConfig is the on-disk shape. auth_token and ct0 are only read for
 // migration from the pre-keyring layout and are never written back.
 type fileConfig struct {
-	AuthToken                      string `yaml:"auth_token,omitempty"`
-	CT0                            string `yaml:"ct0,omitempty"`
-	CreateTweetQID                 string `yaml:"create_tweet_qid,omitempty"`
-	HomeTimelineQID                string `yaml:"home_timeline_qid,omitempty"`
-	HomeLatestTimelineQID          string `yaml:"home_latest_timeline_qid,omitempty"`
-	BookmarksQID                   string `yaml:"bookmarks_qid,omitempty"`
-	SearchTimelineQID              string `yaml:"search_timeline_qid,omitempty"`
-	ListLatestTweetsTimelineQID    string `yaml:"list_latest_tweets_timeline_qid,omitempty"`
-	ListsManagementPageTimelineQID string `yaml:"lists_management_page_timeline_qid,omitempty"`
-	FavoriteTweetQID               string `yaml:"favorite_tweet_qid,omitempty"`
-	UnfavoriteTweetQID             string `yaml:"unfavorite_tweet_qid,omitempty"`
-	ViewerQID                      string `yaml:"viewer_qid,omitempty"`
-	TweetDetailQID                 string `yaml:"tweet_detail_qid,omitempty"`
-	Theme                          string `yaml:"theme,omitempty"`
-	SessionBrowser                 string `yaml:"session_browser,omitempty"`
-	SessionProfile                 string `yaml:"session_profile,omitempty"`
-	SessionDomain                  string `yaml:"session_domain,omitempty"`
-	SessionExpires                 string `yaml:"session_expires,omitempty"`
-	SessionImported                string `yaml:"session_imported,omitempty"`
+	AuthToken                      string   `yaml:"auth_token,omitempty"`
+	CT0                            string   `yaml:"ct0,omitempty"`
+	CreateTweetQID                 string   `yaml:"create_tweet_qid,omitempty"`
+	HomeTimelineQID                string   `yaml:"home_timeline_qid,omitempty"`
+	HomeLatestTimelineQID          string   `yaml:"home_latest_timeline_qid,omitempty"`
+	BookmarksQID                   string   `yaml:"bookmarks_qid,omitempty"`
+	SearchTimelineQID              string   `yaml:"search_timeline_qid,omitempty"`
+	ListLatestTweetsTimelineQID    string   `yaml:"list_latest_tweets_timeline_qid,omitempty"`
+	ListsManagementPageTimelineQID string   `yaml:"lists_management_page_timeline_qid,omitempty"`
+	FavoriteTweetQID               string   `yaml:"favorite_tweet_qid,omitempty"`
+	UnfavoriteTweetQID             string   `yaml:"unfavorite_tweet_qid,omitempty"`
+	ViewerQID                      string   `yaml:"viewer_qid,omitempty"`
+	TweetDetailQID                 string   `yaml:"tweet_detail_qid,omitempty"`
+	Theme                          string   `yaml:"theme,omitempty"`
+	Columns                        []string `yaml:"columns,omitempty"`
+	SessionBrowser                 string   `yaml:"session_browser,omitempty"`
+	SessionProfile                 string   `yaml:"session_profile,omitempty"`
+	SessionDomain                  string   `yaml:"session_domain,omitempty"`
+	SessionExpires                 string   `yaml:"session_expires,omitempty"`
+	SessionImported                string   `yaml:"session_imported,omitempty"`
 }
 
 type ConfigManager struct {
@@ -159,6 +161,7 @@ func (cm *ConfigManager) Load() (*Config, error) {
 		ViewerQID:                      fc.ViewerQID,
 		TweetDetailQID:                 fc.TweetDetailQID,
 		Theme:                          fc.Theme,
+		Columns:                        append([]string(nil), fc.Columns...),
 		SessionBrowser:                 fc.SessionBrowser,
 		SessionProfile:                 fc.SessionProfile,
 		SessionDomain:                  fc.SessionDomain,
@@ -218,6 +221,27 @@ func (cm *ConfigManager) Theme() (string, error) {
 	return fc.Theme, nil
 }
 
+// Columns reads only the persisted layout. It skips the keyring so startup
+// layout resolution cannot provoke a keychain prompt before the TUI starts.
+func (cm *ConfigManager) Columns() ([]string, error) {
+	fc, err := cm.readFile()
+	if err != nil {
+		return nil, err
+	}
+	return append([]string(nil), fc.Columns...), nil
+}
+
+// SaveColumns patches only the explicit layout setting. Loading and saving a
+// full Config here could overwrite session metadata changed by another command.
+func (cm *ConfigManager) SaveColumns(columns []string) error {
+	fc, err := cm.readFile()
+	if err != nil {
+		return err
+	}
+	fc.Columns = append([]string(nil), columns...)
+	return cm.writeFile(fc)
+}
+
 // migrateLegacy moves tokens from the pre-keyring on-disk layout (AES-GCM
 // encrypted auth_token with the key sitting next to it in ~/.xeet.key, ct0 in
 // plaintext) into the OS keyring, rewrites the config file without them, and
@@ -261,7 +285,7 @@ func (cm *ConfigManager) Save(config *Config) error {
 			ListsManagementPageTimelineQID: config.ListsManagementPageTimelineQID,
 			FavoriteTweetQID:               config.FavoriteTweetQID, UnfavoriteTweetQID: config.UnfavoriteTweetQID,
 			ViewerQID: config.ViewerQID, TweetDetailQID: config.TweetDetailQID,
-			Theme: config.Theme,
+			Theme: config.Theme, Columns: append([]string(nil), config.Columns...),
 		})
 	}
 
@@ -306,6 +330,7 @@ func fileConfigFor(config *Config) *fileConfig {
 		ViewerQID:                      config.ViewerQID,
 		TweetDetailQID:                 config.TweetDetailQID,
 		Theme:                          config.Theme,
+		Columns:                        append([]string(nil), config.Columns...),
 		SessionBrowser:                 config.SessionBrowser,
 		SessionProfile:                 config.SessionProfile,
 		SessionDomain:                  config.SessionDomain,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,6 +34,8 @@ type Config struct {
 	ViewerQID                      string    `yaml:"viewer_qid,omitempty"`
 	TweetDetailQID                 string    `yaml:"tweet_detail_qid,omitempty"`
 	NotificationsTimelineQID       string    `yaml:"notifications_timeline_qid,omitempty"`
+	CreateRetweetQID               string    `yaml:"create_retweet_qid,omitempty"`
+	DeleteRetweetQID               string    `yaml:"delete_retweet_qid,omitempty"`
 	Theme                          string    `yaml:"theme,omitempty"`
 	Columns                        []string  `yaml:"columns,omitempty"`
 	RefreshInterval                string    `yaml:"refresh_interval,omitempty"`
@@ -120,6 +122,8 @@ type fileConfig struct {
 	ViewerQID                      string                 `yaml:"viewer_qid,omitempty"`
 	TweetDetailQID                 string                 `yaml:"tweet_detail_qid,omitempty"`
 	NotificationsTimelineQID       string                 `yaml:"notifications_timeline_qid,omitempty"`
+	CreateRetweetQID               string                 `yaml:"create_retweet_qid,omitempty"`
+	DeleteRetweetQID               string                 `yaml:"delete_retweet_qid,omitempty"`
 	Theme                          string                 `yaml:"theme,omitempty"`
 	Columns                        []string               `yaml:"columns,omitempty"`
 	RefreshInterval                string                 `yaml:"refresh_interval,omitempty"`
@@ -282,6 +286,8 @@ func fileConfigFor(config *Config) *fileConfig {
 		ViewerQID:                      config.ViewerQID,
 		TweetDetailQID:                 config.TweetDetailQID,
 		NotificationsTimelineQID:       config.NotificationsTimelineQID,
+		CreateRetweetQID:               config.CreateRetweetQID,
+		DeleteRetweetQID:               config.DeleteRetweetQID,
 		Theme:                          config.Theme,
 		Columns:                        append([]string(nil), config.Columns...),
 		RefreshInterval:                config.RefreshInterval,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,15 +14,14 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Config is the whole of xeet's saved state: your x.com browser session plus
-// cached, non-secret operation ids and session metadata. AuthToken is the
-// session cookie and CT0 is the matching CSRF token; both live in the OS keyring (macOS Keychain, Linux
-// Secret Service), never on disk. The config file contains only non-secret
-// state: X's rotating GraphQL query ids and browser-session source metadata used
-// by `xeet doctor`.
+// Config resolves one account's x.com browser session together with global,
+// non-secret operation ids and settings. AuthToken and CT0 live in the OS
+// keyring, never on disk.
 type Config struct {
 	AuthToken                      string    `yaml:"-"`
 	CT0                            string    `yaml:"-"`
+	UserID                         string    `yaml:"-"`
+	Handle                         string    `yaml:"-"`
 	CreateTweetQID                 string    `yaml:"create_tweet_qid"`
 	HomeTimelineQID                string    `yaml:"home_timeline_qid,omitempty"`
 	HomeLatestTimelineQID          string    `yaml:"home_latest_timeline_qid,omitempty"`
@@ -47,10 +46,15 @@ type Config struct {
 const keyringService = "xeet"
 
 const (
-	keyAuthToken            = "auth_token"
-	keyCT0                  = "ct0"
+	currentConfigVersion    = 2
+	legacyAccountID         = "legacy"
+	keyLegacyAuthToken      = "auth_token"
+	keyLegacyCT0            = "ct0"
 	keyLegacySessionCookies = "session_cookies"
 )
+
+func authTokenKey(userID string) string { return "auth_token:" + userID }
+func ct0Key(userID string) string       { return "ct0:" + userID }
 
 // ErrSecretNotFound is returned by a SecretStore when a key has no value.
 var ErrSecretNotFound = errors.New("secret not found")
@@ -98,26 +102,38 @@ func (systemKeyring) Delete(key string) error {
 // fileConfig is the on-disk shape. auth_token and ct0 are only read for
 // migration from the pre-keyring layout and are never written back.
 type fileConfig struct {
-	AuthToken                      string   `yaml:"auth_token,omitempty"`
-	CT0                            string   `yaml:"ct0,omitempty"`
-	CreateTweetQID                 string   `yaml:"create_tweet_qid,omitempty"`
-	HomeTimelineQID                string   `yaml:"home_timeline_qid,omitempty"`
-	HomeLatestTimelineQID          string   `yaml:"home_latest_timeline_qid,omitempty"`
-	BookmarksQID                   string   `yaml:"bookmarks_qid,omitempty"`
-	SearchTimelineQID              string   `yaml:"search_timeline_qid,omitempty"`
-	ListLatestTweetsTimelineQID    string   `yaml:"list_latest_tweets_timeline_qid,omitempty"`
-	ListsManagementPageTimelineQID string   `yaml:"lists_management_page_timeline_qid,omitempty"`
-	FavoriteTweetQID               string   `yaml:"favorite_tweet_qid,omitempty"`
-	UnfavoriteTweetQID             string   `yaml:"unfavorite_tweet_qid,omitempty"`
-	ViewerQID                      string   `yaml:"viewer_qid,omitempty"`
-	TweetDetailQID                 string   `yaml:"tweet_detail_qid,omitempty"`
-	Theme                          string   `yaml:"theme,omitempty"`
-	Columns                        []string `yaml:"columns,omitempty"`
-	SessionBrowser                 string   `yaml:"session_browser,omitempty"`
-	SessionProfile                 string   `yaml:"session_profile,omitempty"`
-	SessionDomain                  string   `yaml:"session_domain,omitempty"`
-	SessionExpires                 string   `yaml:"session_expires,omitempty"`
-	SessionImported                string   `yaml:"session_imported,omitempty"`
+	Version                        int                    `yaml:"version,omitempty"`
+	Active                         string                 `yaml:"active,omitempty"`
+	AuthToken                      string                 `yaml:"auth_token,omitempty"`
+	CT0                            string                 `yaml:"ct0,omitempty"`
+	CreateTweetQID                 string                 `yaml:"create_tweet_qid,omitempty"`
+	HomeTimelineQID                string                 `yaml:"home_timeline_qid,omitempty"`
+	HomeLatestTimelineQID          string                 `yaml:"home_latest_timeline_qid,omitempty"`
+	BookmarksQID                   string                 `yaml:"bookmarks_qid,omitempty"`
+	SearchTimelineQID              string                 `yaml:"search_timeline_qid,omitempty"`
+	ListLatestTweetsTimelineQID    string                 `yaml:"list_latest_tweets_timeline_qid,omitempty"`
+	ListsManagementPageTimelineQID string                 `yaml:"lists_management_page_timeline_qid,omitempty"`
+	FavoriteTweetQID               string                 `yaml:"favorite_tweet_qid,omitempty"`
+	UnfavoriteTweetQID             string                 `yaml:"unfavorite_tweet_qid,omitempty"`
+	ViewerQID                      string                 `yaml:"viewer_qid,omitempty"`
+	TweetDetailQID                 string                 `yaml:"tweet_detail_qid,omitempty"`
+	Theme                          string                 `yaml:"theme,omitempty"`
+	Columns                        []string               `yaml:"columns,omitempty"`
+	SessionBrowser                 string                 `yaml:"session_browser,omitempty"`
+	SessionProfile                 string                 `yaml:"session_profile,omitempty"`
+	SessionDomain                  string                 `yaml:"session_domain,omitempty"`
+	SessionExpires                 string                 `yaml:"session_expires,omitempty"`
+	SessionImported                string                 `yaml:"session_imported,omitempty"`
+	Accounts                       map[string]fileAccount `yaml:"accounts,omitempty"`
+}
+
+type fileAccount struct {
+	Handle          string `yaml:"handle,omitempty"`
+	SessionBrowser  string `yaml:"session_browser,omitempty"`
+	SessionProfile  string `yaml:"session_profile,omitempty"`
+	SessionDomain   string `yaml:"session_domain,omitempty"`
+	SessionExpires  string `yaml:"session_expires,omitempty"`
+	SessionImported string `yaml:"session_imported,omitempty"`
 }
 
 type ConfigManager struct {
@@ -147,67 +163,22 @@ func (cm *ConfigManager) Load() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	config := &Config{
-		CreateTweetQID:                 fc.CreateTweetQID,
-		HomeTimelineQID:                fc.HomeTimelineQID,
-		HomeLatestTimelineQID:          fc.HomeLatestTimelineQID,
-		BookmarksQID:                   fc.BookmarksQID,
-		SearchTimelineQID:              fc.SearchTimelineQID,
-		ListLatestTweetsTimelineQID:    fc.ListLatestTweetsTimelineQID,
-		ListsManagementPageTimelineQID: fc.ListsManagementPageTimelineQID,
-		FavoriteTweetQID:               fc.FavoriteTweetQID,
-		UnfavoriteTweetQID:             fc.UnfavoriteTweetQID,
-		ViewerQID:                      fc.ViewerQID,
-		TweetDetailQID:                 fc.TweetDetailQID,
-		Theme:                          fc.Theme,
-		Columns:                        append([]string(nil), fc.Columns...),
-		SessionBrowser:                 fc.SessionBrowser,
-		SessionProfile:                 fc.SessionProfile,
-		SessionDomain:                  fc.SessionDomain,
-	}
-	if fc.SessionExpires != "" {
-		if parsed, parseErr := time.Parse(time.RFC3339, fc.SessionExpires); parseErr == nil {
-			config.SessionExpires = parsed
+	if fc.Version == 0 {
+		migrated, migrateErr := cm.migrateV1(fc)
+		if migrateErr != nil {
+			return nil, migrateErr
 		}
-	}
-	if fc.SessionImported != "" {
-		if parsed, parseErr := time.Parse(time.RFC3339, fc.SessionImported); parseErr == nil {
-			config.SessionImported = parsed
-		}
-	}
-
-	token, err := cm.secrets.Get(keyAuthToken)
-	switch {
-	case err == nil:
-		ct0, ct0Err := cm.secrets.Get(keyCT0)
-		if errors.Is(ct0Err, ErrSecretNotFound) || token == "" || ct0 == "" {
-			return nil, ErrSessionIncomplete
-		}
-		if ct0Err != nil {
-			return nil, ct0Err
-		}
-		config.AuthToken = token
-		config.CT0 = ct0
-	case errors.Is(err, ErrSecretNotFound):
-		// A leftover ct0 without auth_token is also corruption.
-		if ct0, ct0Err := cm.secrets.Get(keyCT0); ct0Err == nil && ct0 != "" {
-			return nil, ErrSessionIncomplete
-		} else if ct0Err != nil && !errors.Is(ct0Err, ErrSecretNotFound) {
-			return nil, ct0Err
-		}
-		// Nothing in the keyring. If the config file still holds tokens from
-		// the old layout, migrate them into the keyring now.
-		if fc.AuthToken != "" {
-			if err := cm.migrateLegacy(fc, config); err != nil {
+		if migrated {
+			fc, err = cm.readFile()
+			if err != nil {
 				return nil, err
 			}
 		}
-	default:
-		return nil, err
 	}
-
-	return config, nil
+	if fc.Active == "" {
+		return configFromFile(fc), nil
+	}
+	return cm.loadAccount(fc, fc.Active)
 }
 
 // Theme reads the saved theme name from the config file, or "" when none is
@@ -238,86 +209,39 @@ func (cm *ConfigManager) SaveColumns(columns []string) error {
 	if err != nil {
 		return err
 	}
+	if err := writableVersion(fc); err != nil {
+		return err
+	}
 	fc.Columns = append([]string(nil), columns...)
 	return cm.writeFile(fc)
 }
 
-// migrateLegacy moves tokens from the pre-keyring on-disk layout (AES-GCM
-// encrypted auth_token with the key sitting next to it in ~/.xeet.key, ct0 in
-// plaintext) into the OS keyring, rewrites the config file without them, and
-// deletes the now-useless key file.
-func (cm *ConfigManager) migrateLegacy(fc *fileConfig, config *Config) error {
-	token := fc.AuthToken
-	if key, err := secureReadFile(cm.legacyKeyPath); err == nil {
-		decrypted, err := legacyDecrypt(token, key)
-		if err != nil {
-			return fmt.Errorf("migrating legacy session: %w (run 'xeet auth' to reconnect)", err)
-		}
-		token = decrypted
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("migrating legacy session key: %w", err)
-	}
-
-	config.AuthToken = token
-	config.CT0 = fc.CT0
-
-	if err := cm.Save(config); err != nil {
-		return fmt.Errorf("migrating legacy session: %w", err)
-	}
-	_ = os.Remove(cm.legacyKeyPath)
-	return nil
-}
-
+// Save is the version-gated full-replacement path. Commands that change one
+// concern use SaveAccount, SaveQueryIDs, SaveTheme, or SaveColumns instead.
 func (cm *ConfigManager) Save(config *Config) error {
 	if config == nil {
 		return errors.New("config is nil")
 	}
-	if (config.AuthToken == "") != (config.CT0 == "") {
-		return ErrSessionIncomplete
-	}
-	if config.AuthToken == "" {
-		return cm.writeFile(&fileConfig{
-			CreateTweetQID: config.CreateTweetQID, HomeTimelineQID: config.HomeTimelineQID,
-			HomeLatestTimelineQID:          config.HomeLatestTimelineQID,
-			BookmarksQID:                   config.BookmarksQID,
-			SearchTimelineQID:              config.SearchTimelineQID,
-			ListLatestTweetsTimelineQID:    config.ListLatestTweetsTimelineQID,
-			ListsManagementPageTimelineQID: config.ListsManagementPageTimelineQID,
-			FavoriteTweetQID:               config.FavoriteTweetQID, UnfavoriteTweetQID: config.UnfavoriteTweetQID,
-			ViewerQID: config.ViewerQID, TweetDetailQID: config.TweetDetailQID,
-			Theme: config.Theme, Columns: append([]string(nil), config.Columns...),
-		})
-	}
-
-	oldAuth, err := cm.snapshotSecret(keyAuthToken)
+	fc, err := cm.readFile()
 	if err != nil {
 		return err
 	}
-	oldCT0, err := cm.snapshotSecret(keyCT0)
-	if err != nil {
+	if err := writableVersion(fc); err != nil {
 		return err
 	}
-	rollback := func(cause error) error {
-		return errors.Join(cause, cm.restoreSecret(keyAuthToken, oldAuth), cm.restoreSecret(keyCT0, oldCT0))
+	if config.UserID == "" {
+		if config.AuthToken != "" || config.CT0 != "" {
+			return errors.New("account user id is required")
+		}
+		return cm.writeFile(fileConfigFor(config))
 	}
-
-	if err := cm.secrets.Set(keyAuthToken, config.AuthToken); err != nil {
-		return err
-	}
-	if err := cm.secrets.Set(keyCT0, config.CT0); err != nil {
-		return rollback(err)
-	}
-	// Clean up the short-lived full-cookie experiment. Requests intentionally
-	// use only auth_token and ct0, matching the previously working behavior.
-	_ = cm.secrets.Delete(keyLegacySessionCookies)
-	if err := cm.writeFile(fileConfigFor(config)); err != nil {
-		return rollback(err)
-	}
-	return nil
+	return cm.saveAccountReplacingFile(config)
 }
 
 func fileConfigFor(config *Config) *fileConfig {
 	result := &fileConfig{
+		Version:                        currentConfigVersion,
+		Active:                         config.UserID,
 		CreateTweetQID:                 config.CreateTweetQID,
 		HomeTimelineQID:                config.HomeTimelineQID,
 		HomeLatestTimelineQID:          config.HomeLatestTimelineQID,
@@ -331,15 +255,11 @@ func fileConfigFor(config *Config) *fileConfig {
 		TweetDetailQID:                 config.TweetDetailQID,
 		Theme:                          config.Theme,
 		Columns:                        append([]string(nil), config.Columns...),
-		SessionBrowser:                 config.SessionBrowser,
-		SessionProfile:                 config.SessionProfile,
-		SessionDomain:                  config.SessionDomain,
 	}
-	if !config.SessionExpires.IsZero() {
-		result.SessionExpires = config.SessionExpires.UTC().Format(time.RFC3339)
-	}
-	if !config.SessionImported.IsZero() {
-		result.SessionImported = config.SessionImported.UTC().Format(time.RFC3339)
+	if config.UserID != "" {
+		result.Accounts = map[string]fileAccount{
+			config.UserID: fileAccountFor(config),
+		}
 	}
 	return result
 }
@@ -347,6 +267,19 @@ func fileConfigFor(config *Config) *fileConfig {
 type secretSnapshot struct {
 	value  string
 	exists bool
+}
+
+type committedWriteError struct{ err error }
+
+func (e *committedWriteError) Error() string { return e.err.Error() }
+func (e *committedWriteError) Unwrap() error { return e.err }
+
+func rollbackUncommitted(err error, rollback func(error) error) error {
+	var committed *committedWriteError
+	if errors.As(err, &committed) {
+		return err
+	}
+	return rollback(err)
 }
 
 func (cm *ConfigManager) snapshotSecret(key string) (secretSnapshot, error) {
@@ -367,18 +300,26 @@ func (cm *ConfigManager) restoreSecret(key string, snapshot secretSnapshot) erro
 	return cm.secrets.Delete(key)
 }
 
-// Erase deletes the saved session: keyring entries, config file, and any
-// legacy key file. It keeps going on individual failures and reports the
-// first one, so a partial logout still removes as much as possible.
-func (cm *ConfigManager) Erase() error {
+// EraseAll deletes every saved session, the config file, and any legacy key
+// file. It keeps going on individual failures so a partial logout removes as
+// much as possible.
+func (cm *ConfigManager) EraseAll() error {
 	var firstErr error
 	keep := func(err error) {
 		if err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
-	keep(cm.secrets.Delete(keyAuthToken))
-	keep(cm.secrets.Delete(keyCT0))
+	if fc, err := cm.readFile(); err == nil {
+		for userID := range fc.Accounts {
+			keep(cm.secrets.Delete(authTokenKey(userID)))
+			keep(cm.secrets.Delete(ct0Key(userID)))
+		}
+	} else {
+		keep(err)
+	}
+	keep(cm.secrets.Delete(keyLegacyAuthToken))
+	keep(cm.secrets.Delete(keyLegacyCT0))
 	keep(cm.secrets.Delete(keyLegacySessionCookies))
 	if err := os.Remove(cm.configPath); err != nil && !os.IsNotExist(err) {
 		keep(err)
@@ -388,6 +329,10 @@ func (cm *ConfigManager) Erase() error {
 	}
 	return firstErr
 }
+
+// Erase retains the pre-v2 API for callers that explicitly want a complete
+// reset. Normal logout uses EraseAccount so global preferences survive.
+func (cm *ConfigManager) Erase() error { return cm.EraseAll() }
 
 func (cm *ConfigManager) readFile() (*fileConfig, error) {
 	data, err := secureReadFile(cm.configPath)
@@ -443,7 +388,12 @@ func (cm *ConfigManager) writeFile(fc *fileConfig) error {
 	if err := os.Rename(tmpPath, cm.configPath); err != nil {
 		return err
 	}
-	return syncDirectory(dir)
+	if err := syncDirectory(dir); err != nil {
+		// Rename already published the new file; rolling back its matching
+		// keyring pair here would create an account entry with no session.
+		return &committedWriteError{err: err}
+	}
+	return nil
 }
 
 // legacyDecrypt undoes the old AES-GCM-with-key-on-disk scheme, used only to

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,23 +21,25 @@ import (
 // state: X's rotating GraphQL query ids and browser-session source metadata used
 // by `xeet doctor`.
 type Config struct {
-	AuthToken             string    `yaml:"-"`
-	CT0                   string    `yaml:"-"`
-	CreateTweetQID        string    `yaml:"create_tweet_qid"`
-	HomeTimelineQID       string    `yaml:"home_timeline_qid,omitempty"`
-	HomeLatestTimelineQID string    `yaml:"home_latest_timeline_qid,omitempty"`
-	BookmarksQID          string    `yaml:"bookmarks_qid,omitempty"`
-	SearchTimelineQID     string    `yaml:"search_timeline_qid,omitempty"`
-	FavoriteTweetQID      string    `yaml:"favorite_tweet_qid,omitempty"`
-	UnfavoriteTweetQID    string    `yaml:"unfavorite_tweet_qid,omitempty"`
-	ViewerQID             string    `yaml:"viewer_qid,omitempty"`
-	TweetDetailQID        string    `yaml:"tweet_detail_qid,omitempty"`
-	Theme                 string    `yaml:"theme,omitempty"`
-	SessionBrowser        string    `yaml:"session_browser,omitempty"`
-	SessionProfile        string    `yaml:"session_profile,omitempty"`
-	SessionDomain         string    `yaml:"session_domain,omitempty"`
-	SessionExpires        time.Time `yaml:"session_expires,omitempty"`
-	SessionImported       time.Time `yaml:"session_imported,omitempty"`
+	AuthToken                      string    `yaml:"-"`
+	CT0                            string    `yaml:"-"`
+	CreateTweetQID                 string    `yaml:"create_tweet_qid"`
+	HomeTimelineQID                string    `yaml:"home_timeline_qid,omitempty"`
+	HomeLatestTimelineQID          string    `yaml:"home_latest_timeline_qid,omitempty"`
+	BookmarksQID                   string    `yaml:"bookmarks_qid,omitempty"`
+	SearchTimelineQID              string    `yaml:"search_timeline_qid,omitempty"`
+	ListLatestTweetsTimelineQID    string    `yaml:"list_latest_tweets_timeline_qid,omitempty"`
+	ListsManagementPageTimelineQID string    `yaml:"lists_management_page_timeline_qid,omitempty"`
+	FavoriteTweetQID               string    `yaml:"favorite_tweet_qid,omitempty"`
+	UnfavoriteTweetQID             string    `yaml:"unfavorite_tweet_qid,omitempty"`
+	ViewerQID                      string    `yaml:"viewer_qid,omitempty"`
+	TweetDetailQID                 string    `yaml:"tweet_detail_qid,omitempty"`
+	Theme                          string    `yaml:"theme,omitempty"`
+	SessionBrowser                 string    `yaml:"session_browser,omitempty"`
+	SessionProfile                 string    `yaml:"session_profile,omitempty"`
+	SessionDomain                  string    `yaml:"session_domain,omitempty"`
+	SessionExpires                 time.Time `yaml:"session_expires,omitempty"`
+	SessionImported                time.Time `yaml:"session_imported,omitempty"`
 }
 
 // keyringService is the service name xeet registers its secrets under.
@@ -95,23 +97,25 @@ func (systemKeyring) Delete(key string) error {
 // fileConfig is the on-disk shape. auth_token and ct0 are only read for
 // migration from the pre-keyring layout and are never written back.
 type fileConfig struct {
-	AuthToken             string `yaml:"auth_token,omitempty"`
-	CT0                   string `yaml:"ct0,omitempty"`
-	CreateTweetQID        string `yaml:"create_tweet_qid,omitempty"`
-	HomeTimelineQID       string `yaml:"home_timeline_qid,omitempty"`
-	HomeLatestTimelineQID string `yaml:"home_latest_timeline_qid,omitempty"`
-	BookmarksQID          string `yaml:"bookmarks_qid,omitempty"`
-	SearchTimelineQID     string `yaml:"search_timeline_qid,omitempty"`
-	FavoriteTweetQID      string `yaml:"favorite_tweet_qid,omitempty"`
-	UnfavoriteTweetQID    string `yaml:"unfavorite_tweet_qid,omitempty"`
-	ViewerQID             string `yaml:"viewer_qid,omitempty"`
-	TweetDetailQID        string `yaml:"tweet_detail_qid,omitempty"`
-	Theme                 string `yaml:"theme,omitempty"`
-	SessionBrowser        string `yaml:"session_browser,omitempty"`
-	SessionProfile        string `yaml:"session_profile,omitempty"`
-	SessionDomain         string `yaml:"session_domain,omitempty"`
-	SessionExpires        string `yaml:"session_expires,omitempty"`
-	SessionImported       string `yaml:"session_imported,omitempty"`
+	AuthToken                      string `yaml:"auth_token,omitempty"`
+	CT0                            string `yaml:"ct0,omitempty"`
+	CreateTweetQID                 string `yaml:"create_tweet_qid,omitempty"`
+	HomeTimelineQID                string `yaml:"home_timeline_qid,omitempty"`
+	HomeLatestTimelineQID          string `yaml:"home_latest_timeline_qid,omitempty"`
+	BookmarksQID                   string `yaml:"bookmarks_qid,omitempty"`
+	SearchTimelineQID              string `yaml:"search_timeline_qid,omitempty"`
+	ListLatestTweetsTimelineQID    string `yaml:"list_latest_tweets_timeline_qid,omitempty"`
+	ListsManagementPageTimelineQID string `yaml:"lists_management_page_timeline_qid,omitempty"`
+	FavoriteTweetQID               string `yaml:"favorite_tweet_qid,omitempty"`
+	UnfavoriteTweetQID             string `yaml:"unfavorite_tweet_qid,omitempty"`
+	ViewerQID                      string `yaml:"viewer_qid,omitempty"`
+	TweetDetailQID                 string `yaml:"tweet_detail_qid,omitempty"`
+	Theme                          string `yaml:"theme,omitempty"`
+	SessionBrowser                 string `yaml:"session_browser,omitempty"`
+	SessionProfile                 string `yaml:"session_profile,omitempty"`
+	SessionDomain                  string `yaml:"session_domain,omitempty"`
+	SessionExpires                 string `yaml:"session_expires,omitempty"`
+	SessionImported                string `yaml:"session_imported,omitempty"`
 }
 
 type ConfigManager struct {
@@ -143,19 +147,21 @@ func (cm *ConfigManager) Load() (*Config, error) {
 	}
 
 	config := &Config{
-		CreateTweetQID:        fc.CreateTweetQID,
-		HomeTimelineQID:       fc.HomeTimelineQID,
-		HomeLatestTimelineQID: fc.HomeLatestTimelineQID,
-		BookmarksQID:          fc.BookmarksQID,
-		SearchTimelineQID:     fc.SearchTimelineQID,
-		FavoriteTweetQID:      fc.FavoriteTweetQID,
-		UnfavoriteTweetQID:    fc.UnfavoriteTweetQID,
-		ViewerQID:             fc.ViewerQID,
-		TweetDetailQID:        fc.TweetDetailQID,
-		Theme:                 fc.Theme,
-		SessionBrowser:        fc.SessionBrowser,
-		SessionProfile:        fc.SessionProfile,
-		SessionDomain:         fc.SessionDomain,
+		CreateTweetQID:                 fc.CreateTweetQID,
+		HomeTimelineQID:                fc.HomeTimelineQID,
+		HomeLatestTimelineQID:          fc.HomeLatestTimelineQID,
+		BookmarksQID:                   fc.BookmarksQID,
+		SearchTimelineQID:              fc.SearchTimelineQID,
+		ListLatestTweetsTimelineQID:    fc.ListLatestTweetsTimelineQID,
+		ListsManagementPageTimelineQID: fc.ListsManagementPageTimelineQID,
+		FavoriteTweetQID:               fc.FavoriteTweetQID,
+		UnfavoriteTweetQID:             fc.UnfavoriteTweetQID,
+		ViewerQID:                      fc.ViewerQID,
+		TweetDetailQID:                 fc.TweetDetailQID,
+		Theme:                          fc.Theme,
+		SessionBrowser:                 fc.SessionBrowser,
+		SessionProfile:                 fc.SessionProfile,
+		SessionDomain:                  fc.SessionDomain,
 	}
 	if fc.SessionExpires != "" {
 		if parsed, parseErr := time.Parse(time.RFC3339, fc.SessionExpires); parseErr == nil {
@@ -248,10 +254,12 @@ func (cm *ConfigManager) Save(config *Config) error {
 	if config.AuthToken == "" {
 		return cm.writeFile(&fileConfig{
 			CreateTweetQID: config.CreateTweetQID, HomeTimelineQID: config.HomeTimelineQID,
-			HomeLatestTimelineQID: config.HomeLatestTimelineQID,
-			BookmarksQID:          config.BookmarksQID,
-			SearchTimelineQID:     config.SearchTimelineQID,
-			FavoriteTweetQID:      config.FavoriteTweetQID, UnfavoriteTweetQID: config.UnfavoriteTweetQID,
+			HomeLatestTimelineQID:          config.HomeLatestTimelineQID,
+			BookmarksQID:                   config.BookmarksQID,
+			SearchTimelineQID:              config.SearchTimelineQID,
+			ListLatestTweetsTimelineQID:    config.ListLatestTweetsTimelineQID,
+			ListsManagementPageTimelineQID: config.ListsManagementPageTimelineQID,
+			FavoriteTweetQID:               config.FavoriteTweetQID, UnfavoriteTweetQID: config.UnfavoriteTweetQID,
 			ViewerQID: config.ViewerQID, TweetDetailQID: config.TweetDetailQID,
 			Theme: config.Theme,
 		})
@@ -286,19 +294,21 @@ func (cm *ConfigManager) Save(config *Config) error {
 
 func fileConfigFor(config *Config) *fileConfig {
 	result := &fileConfig{
-		CreateTweetQID:        config.CreateTweetQID,
-		HomeTimelineQID:       config.HomeTimelineQID,
-		HomeLatestTimelineQID: config.HomeLatestTimelineQID,
-		BookmarksQID:          config.BookmarksQID,
-		SearchTimelineQID:     config.SearchTimelineQID,
-		FavoriteTweetQID:      config.FavoriteTweetQID,
-		UnfavoriteTweetQID:    config.UnfavoriteTweetQID,
-		ViewerQID:             config.ViewerQID,
-		TweetDetailQID:        config.TweetDetailQID,
-		Theme:                 config.Theme,
-		SessionBrowser:        config.SessionBrowser,
-		SessionProfile:        config.SessionProfile,
-		SessionDomain:         config.SessionDomain,
+		CreateTweetQID:                 config.CreateTweetQID,
+		HomeTimelineQID:                config.HomeTimelineQID,
+		HomeLatestTimelineQID:          config.HomeLatestTimelineQID,
+		BookmarksQID:                   config.BookmarksQID,
+		SearchTimelineQID:              config.SearchTimelineQID,
+		ListLatestTweetsTimelineQID:    config.ListLatestTweetsTimelineQID,
+		ListsManagementPageTimelineQID: config.ListsManagementPageTimelineQID,
+		FavoriteTweetQID:               config.FavoriteTweetQID,
+		UnfavoriteTweetQID:             config.UnfavoriteTweetQID,
+		ViewerQID:                      config.ViewerQID,
+		TweetDetailQID:                 config.TweetDetailQID,
+		Theme:                          config.Theme,
+		SessionBrowser:                 config.SessionBrowser,
+		SessionProfile:                 config.SessionProfile,
+		SessionDomain:                  config.SessionDomain,
 	}
 	if !config.SessionExpires.IsZero() {
 		result.SessionExpires = config.SessionExpires.UTC().Format(time.RFC3339)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -49,6 +50,7 @@ func TestSaveLoadRoundtrip(t *testing.T) {
 		ListLatestTweetsTimelineQID: "listtimeline123", ListsManagementPageTimelineQID: "listsmanagement123",
 		FavoriteTweetQID: "like123", UnfavoriteTweetQID: "unlike123", ViewerQID: "viewer123",
 		TweetDetailQID: "detail123",
+		Columns:        []string{"foryou", "bookmarks"},
 		SessionBrowser: "Firefox", SessionProfile: "default-release", SessionDomain: "x.com",
 		SessionExpires:  time.Date(2027, 1, 2, 3, 4, 5, 0, time.UTC),
 		SessionImported: time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC),
@@ -61,7 +63,7 @@ func TestSaveLoadRoundtrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if *out != *in {
+	if !reflect.DeepEqual(out, in) {
 		t.Fatalf("roundtrip mismatch: got %+v want %+v", out, in)
 	}
 }
@@ -167,7 +169,7 @@ func TestLoadMissingFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if *cfg != (Config{}) {
+	if !reflect.DeepEqual(cfg, &Config{}) {
 		t.Fatalf("expected zero config, got %+v", cfg)
 	}
 }
@@ -441,5 +443,63 @@ func TestThemeIsEmptyWithoutAConfigFile(t *testing.T) {
 	}
 	if name != "" {
 		t.Fatalf("Theme() = %q, want empty", name)
+	}
+}
+
+func TestColumnsReadTheFileWithoutTouchingTheKeyring(t *testing.T) {
+	dir := t.TempDir()
+	store := &countingStore{fakeStore: newFakeStore()}
+	cm := newConfigManagerAt(dir, store)
+	if err := cm.Save(&Config{
+		AuthToken: "auth",
+		CT0:       "ct0",
+		Columns:   []string{"foryou", "bookmarks"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	store.gets = 0
+
+	columns, err := cm.Columns()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(columns, []string{"foryou", "bookmarks"}) {
+		t.Fatalf("Columns() = %v", columns)
+	}
+	if store.gets != 0 {
+		t.Fatalf("Columns() made %d keyring reads", store.gets)
+	}
+}
+
+func TestSaveColumnsPatchesOnlyTheLayout(t *testing.T) {
+	dir := t.TempDir()
+	store := &countingStore{fakeStore: newFakeStore()}
+	cm := newConfigManagerAt(dir, store)
+	if err := cm.Save(&Config{
+		AuthToken:      "auth",
+		CT0:            "ct0",
+		CreateTweetQID: "qid",
+		Theme:          "nord",
+		Columns:        []string{"foryou"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	store.gets = 0
+
+	if err := cm.SaveColumns([]string{"following", "search:golang"}); err != nil {
+		t.Fatal(err)
+	}
+	if store.gets != 0 {
+		t.Fatalf("SaveColumns made %d keyring reads", store.gets)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, ".xeet.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(data)
+	for _, want := range []string{"create_tweet_qid: qid", "theme: nord", "following", "search:golang"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("SaveColumns dropped %q:\n%s", want, body)
+		}
 	}
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -508,6 +508,47 @@ func TestColumnsReadTheFileWithoutTouchingTheKeyring(t *testing.T) {
 	}
 }
 
+func TestRefreshIntervalRoundTripsWithoutTouchingTheKeyring(t *testing.T) {
+	dir := t.TempDir()
+	store := &countingStore{fakeStore: newFakeStore()}
+	cm := newConfigManagerAt(dir, store)
+	if err := cm.Save(&Config{RefreshInterval: "90s"}); err != nil {
+		t.Fatal(err)
+	}
+	store.gets = 0
+
+	interval, err := cm.RefreshInterval()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if interval != 90*time.Second {
+		t.Fatalf("RefreshInterval() = %v, want 90s", interval)
+	}
+	if store.gets != 0 {
+		t.Fatalf("RefreshInterval() made %d keyring reads; resolving a display setting must not prompt for secrets", store.gets)
+	}
+}
+
+func TestRefreshIntervalDefaultsToOff(t *testing.T) {
+	interval, err := newConfigManagerAt(t.TempDir(), newFakeStore()).RefreshInterval()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if interval != 0 {
+		t.Fatalf("RefreshInterval() = %v, want 0 so polling stays opt-in", interval)
+	}
+}
+
+func TestRefreshIntervalRejectsGarbage(t *testing.T) {
+	cm := newConfigManagerAt(t.TempDir(), newFakeStore())
+	if err := cm.Save(&Config{RefreshInterval: "abc"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cm.RefreshInterval(); err == nil {
+		t.Fatal("RefreshInterval() accepted an unparseable duration")
+	}
+}
+
 func TestSaveColumnsPatchesOnlyTheLayout(t *testing.T) {
 	dir := t.TempDir()
 	store := &countingStore{fakeStore: newFakeStore()}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -46,6 +46,7 @@ func TestSaveLoadRoundtrip(t *testing.T) {
 
 	in := &Config{
 		AuthToken: "tok123", CT0: "csrf456", CreateTweetQID: "qid789",
+		UserID: "42", Handle: "alice",
 		HomeTimelineQID: "home123", BookmarksQID: "bookmarks123", SearchTimelineQID: "search123",
 		ListLatestTweetsTimelineQID: "listtimeline123", ListsManagementPageTimelineQID: "listsmanagement123",
 		FavoriteTweetQID: "like123", UnfavoriteTweetQID: "unlike123", ViewerQID: "viewer123",
@@ -57,6 +58,13 @@ func TestSaveLoadRoundtrip(t *testing.T) {
 	}
 	if err := cm.Save(in); err != nil {
 		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, ".xeet.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "\"42\":") {
+		t.Fatalf("numeric user id was not quoted as a YAML string:\n%s", data)
 	}
 
 	out, err := cm.Load()
@@ -74,6 +82,7 @@ func TestTokensNeverTouchDisk(t *testing.T) {
 
 	if err := cm.Save(&Config{
 		AuthToken: "supersecret", CT0: "alsosecret", CreateTweetQID: "qid",
+		UserID: "42", Handle: "alice",
 		SessionBrowser: "Firefox", SessionProfile: "default-release",
 	}); err != nil {
 		t.Fatal(err)
@@ -182,13 +191,14 @@ func TestMalformedSessionMetadataDoesNotBreakSavedSession(t *testing.T) {
 		t.Fatal(err)
 	}
 	store := newFakeStore()
-	store.data[keyAuthToken] = "auth"
-	store.data[keyCT0] = "ct0"
+	store.data[keyLegacyAuthToken] = "auth"
+	store.data[keyLegacyCT0] = "ct0"
 	cfg, err := newConfigManagerAt(dir, store).Load()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.AuthToken != "auth" || cfg.SessionBrowser != "Chrome" || !cfg.SessionExpires.IsZero() {
+	if cfg.AuthToken != "auth" || cfg.UserID != legacyAccountID ||
+		cfg.SessionBrowser != "Chrome" || !cfg.SessionExpires.IsZero() {
 		t.Fatalf("config=%+v", cfg)
 	}
 }
@@ -242,8 +252,15 @@ func TestLegacyMigration(t *testing.T) {
 	}
 
 	// Tokens must now be in the keyring.
-	if store.data["auth_token"] != "oldtoken" || store.data["ct0"] != "oldct0" {
+	if store.data[authTokenKey(legacyAccountID)] != "oldtoken" ||
+		store.data[ct0Key(legacyAccountID)] != "oldct0" {
 		t.Fatalf("keyring after migration: %+v", store.data)
+	}
+	if _, ok := store.data[keyLegacyAuthToken]; ok {
+		t.Fatalf("legacy auth key survived migration: %+v", store.data)
+	}
+	if _, ok := store.data[keyLegacyCT0]; ok {
+		t.Fatalf("legacy ct0 key survived migration: %+v", store.data)
 	}
 
 	// The key file must be gone and the config file scrubbed of tokens.
@@ -264,7 +281,9 @@ func TestErase(t *testing.T) {
 	store := newFakeStore()
 	cm := newConfigManagerAt(dir, store)
 
-	if err := cm.Save(&Config{AuthToken: "tok", CT0: "ct", CreateTweetQID: "qid"}); err != nil {
+	if err := cm.Save(&Config{
+		UserID: "42", AuthToken: "tok", CT0: "ct", CreateTweetQID: "qid",
+	}); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(dir, ".xeet.key"), []byte("junk"), 0600); err != nil {
@@ -322,16 +341,18 @@ func (f *failingStore) Set(key, value string) error {
 
 func TestSaveRollsBackPartialKeyringWrite(t *testing.T) {
 	base := newFakeStore()
-	base.data[keyAuthToken] = "old-auth"
-	base.data[keyCT0] = "old-ct0"
-	store := &failingStore{fakeStore: base, failKey: keyCT0, failValue: "new-ct0"}
+	base.data[authTokenKey("42")] = "old-auth"
+	base.data[ct0Key("42")] = "old-ct0"
+	store := &failingStore{fakeStore: base, failKey: ct0Key("42"), failValue: "new-ct0"}
 	cm := newConfigManagerAt(t.TempDir(), store)
 
-	err := cm.Save(&Config{AuthToken: "new-auth", CT0: "new-ct0", CreateTweetQID: "qid"})
+	err := cm.Save(&Config{
+		UserID: "42", AuthToken: "new-auth", CT0: "new-ct0", CreateTweetQID: "qid",
+	})
 	if err == nil {
 		t.Fatal("expected injected keyring error")
 	}
-	if base.data[keyAuthToken] != "old-auth" || base.data[keyCT0] != "old-ct0" {
+	if base.data[authTokenKey("42")] != "old-auth" || base.data[ct0Key("42")] != "old-ct0" {
 		t.Fatalf("partial save was not rolled back: %+v", base.data)
 	}
 }
@@ -339,8 +360,8 @@ func TestSaveRollsBackPartialKeyringWrite(t *testing.T) {
 func TestSaveRollsBackWhenConfigWriteFails(t *testing.T) {
 	dir := t.TempDir()
 	store := newFakeStore()
-	store.data[keyAuthToken] = "old-auth"
-	store.data[keyCT0] = "old-ct0"
+	store.data[authTokenKey("42")] = "old-auth"
+	store.data[ct0Key("42")] = "old-ct0"
 	cm := newConfigManagerAt(dir, store)
 
 	target := filepath.Join(dir, "target")
@@ -351,20 +372,31 @@ func TestSaveRollsBackWhenConfigWriteFails(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := cm.Save(&Config{AuthToken: "new-auth", CT0: "new-ct0", CreateTweetQID: "qid"})
+	err := cm.Save(&Config{
+		UserID: "42", AuthToken: "new-auth", CT0: "new-ct0", CreateTweetQID: "qid",
+	})
 	if err == nil {
 		t.Fatal("expected config write error")
 	}
-	if store.data[keyAuthToken] != "old-auth" || store.data[keyCT0] != "old-ct0" {
+	if store.data[authTokenKey("42")] != "old-auth" || store.data[ct0Key("42")] != "old-ct0" {
 		t.Fatalf("keyring was not rolled back: %+v", store.data)
 	}
 }
 
 func TestIncompleteKeyringSessionIsRejected(t *testing.T) {
-	for key, value := range map[string]string{keyAuthToken: "auth-only", keyCT0: "ct0-only"} {
+	for key, value := range map[string]string{
+		authTokenKey("42"): "auth-only",
+		ct0Key("42"):       "ct0-only",
+	} {
+		dir := t.TempDir()
 		store := newFakeStore()
 		store.data[key] = value
-		cm := newConfigManagerAt(t.TempDir(), store)
+		if err := os.WriteFile(filepath.Join(dir, ".xeet.yaml"), []byte(
+			"version: 2\nactive: \"42\"\naccounts:\n  \"42\":\n    handle: alice\n",
+		), 0600); err != nil {
+			t.Fatal(err)
+		}
+		cm := newConfigManagerAt(dir, store)
 		_, err := cm.Load()
 		if !errors.Is(err, ErrSessionIncomplete) {
 			t.Errorf("key %s: got %v, want ErrSessionIncomplete", key, err)
@@ -375,7 +407,11 @@ func TestIncompleteKeyringSessionIsRejected(t *testing.T) {
 func TestSaveRejectsIncompleteSession(t *testing.T) {
 	store := newFakeStore()
 	cm := newConfigManagerAt(t.TempDir(), store)
-	for _, cfg := range []*Config{{AuthToken: "auth"}, {CT0: "ct0"}, nil} {
+	for _, cfg := range []*Config{
+		{UserID: "42", AuthToken: "auth"},
+		{UserID: "42", CT0: "ct0"},
+		nil,
+	} {
 		if err := cm.Save(cfg); err == nil {
 			t.Fatalf("Save(%+v) succeeded", cfg)
 		}
@@ -451,6 +487,7 @@ func TestColumnsReadTheFileWithoutTouchingTheKeyring(t *testing.T) {
 	store := &countingStore{fakeStore: newFakeStore()}
 	cm := newConfigManagerAt(dir, store)
 	if err := cm.Save(&Config{
+		UserID:    "42",
 		AuthToken: "auth",
 		CT0:       "ct0",
 		Columns:   []string{"foryou", "bookmarks"},
@@ -476,6 +513,7 @@ func TestSaveColumnsPatchesOnlyTheLayout(t *testing.T) {
 	store := &countingStore{fakeStore: newFakeStore()}
 	cm := newConfigManagerAt(dir, store)
 	if err := cm.Save(&Config{
+		UserID:         "42",
 		AuthToken:      "auth",
 		CT0:            "ct0",
 		CreateTweetQID: "qid",
@@ -501,5 +539,479 @@ func TestSaveColumnsPatchesOnlyTheLayout(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Fatalf("SaveColumns dropped %q:\n%s", want, body)
 		}
+	}
+}
+
+type operationStore struct {
+	*fakeStore
+	operations           []string
+	failDelete           string
+	configPath           string
+	completeBeforeDelete bool
+}
+
+func (s *operationStore) Get(key string) (string, error) {
+	s.operations = append(s.operations, "get "+key)
+	return s.fakeStore.Get(key)
+}
+
+func (s *operationStore) Set(key, value string) error {
+	s.operations = append(s.operations, "set "+key)
+	return s.fakeStore.Set(key, value)
+}
+
+func (s *operationStore) Delete(key string) error {
+	s.operations = append(s.operations, "delete "+key)
+	if key == s.failDelete {
+		body, err := os.ReadFile(s.configPath)
+		if err == nil &&
+			strings.Contains(string(body), "version: 2") &&
+			strings.Contains(string(body), "active:") &&
+			s.data[authTokenKey(accountIDForDelete(key))] != "" &&
+			s.data[ct0Key(accountIDForDelete(key))] != "" {
+			s.completeBeforeDelete = true
+		}
+		return errors.New("injected delete failure")
+	}
+	return s.fakeStore.Delete(key)
+}
+
+func accountIDForDelete(key string) string {
+	if key == keyLegacyAuthToken {
+		return legacyAccountID
+	}
+	return strings.TrimPrefix(key, "auth_token:")
+}
+
+func TestLoadMigratesV1KeyringSessionToV2UnderProvisionalKey(t *testing.T) {
+	dir := t.TempDir()
+	body := strings.Join([]string{
+		"bookmarks_qid: bookmarks-v1",
+		"search_timeline_qid: search-v1",
+		"list_latest_tweets_timeline_qid: list-v1",
+		"session_browser: Chrome",
+		"session_profile: Default",
+		"session_domain: .x.com",
+		"session_expires: 2027-01-01T00:00:00Z",
+		"session_imported: 2026-07-27T00:00:00Z",
+		"columns:",
+		"  - foryou",
+		"  - following",
+		"",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(dir, ".xeet.yaml"), []byte(body), 0600); err != nil {
+		t.Fatal(err)
+	}
+	store := newFakeStore()
+	store.data[keyLegacyAuthToken] = "legacy-auth"
+	store.data[keyLegacyCT0] = "legacy-ct0"
+
+	cfg, err := newConfigManagerAt(dir, store).Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.UserID != legacyAccountID || cfg.AuthToken != "legacy-auth" || cfg.CT0 != "legacy-ct0" {
+		t.Fatalf("migrated active config = %+v", cfg)
+	}
+	if cfg.BookmarksQID != "bookmarks-v1" || cfg.SearchTimelineQID != "search-v1" ||
+		cfg.ListLatestTweetsTimelineQID != "list-v1" {
+		t.Fatalf("migration lost query ids: %+v", cfg)
+	}
+	if !reflect.DeepEqual(cfg.Columns, []string{"foryou", "following"}) {
+		t.Fatalf("migration lost columns: %v", cfg.Columns)
+	}
+	if store.data[authTokenKey(legacyAccountID)] != "legacy-auth" ||
+		store.data[ct0Key(legacyAccountID)] != "legacy-ct0" {
+		t.Fatalf("provisional keyring pair = %+v", store.data)
+	}
+	if _, ok := store.data[keyLegacyAuthToken]; ok {
+		t.Fatalf("unsuffixed auth token survived: %+v", store.data)
+	}
+	if _, ok := store.data[keyLegacyCT0]; ok {
+		t.Fatalf("unsuffixed ct0 survived: %+v", store.data)
+	}
+	written, err := os.ReadFile(filepath.Join(dir, ".xeet.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"version: 2", "active: legacy", "accounts:", "legacy:",
+		"bookmarks_qid: bookmarks-v1", "search_timeline_qid: search-v1",
+		"list_latest_tweets_timeline_qid: list-v1", "columns:",
+	} {
+		if !strings.Contains(string(written), want) {
+			t.Fatalf("migrated file missing %q:\n%s", want, written)
+		}
+	}
+}
+
+func TestMigrationCrashBeforeLegacyDeleteIsRecoverable(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".xeet.yaml"), []byte(
+		"bookmarks_qid: preserved\nsession_browser: Chrome\n",
+	), 0600); err != nil {
+		t.Fatal(err)
+	}
+	base := newFakeStore()
+	base.data[keyLegacyAuthToken] = "old-auth"
+	base.data[keyLegacyCT0] = "old-ct0"
+	store := &operationStore{
+		fakeStore:  base,
+		failDelete: keyLegacyAuthToken,
+		configPath: filepath.Join(dir, ".xeet.yaml"),
+	}
+	cm := newConfigManagerAt(dir, store)
+
+	if _, err := cm.Load(); err == nil {
+		t.Fatal("migration unexpectedly survived the injected legacy-delete failure")
+	}
+	if !store.completeBeforeDelete {
+		t.Fatalf("legacy delete started before the v2 file and new pair were complete: %v", store.operations)
+	}
+	assertOperationOrder(t, store.operations,
+		"set "+authTokenKey(legacyAccountID),
+		"set "+ct0Key(legacyAccountID),
+		"delete "+keyLegacyAuthToken,
+	)
+
+	store.failDelete = ""
+	cfg, err := cm.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.UserID != legacyAccountID || cfg.AuthToken != "old-auth" ||
+		cfg.CT0 != "old-ct0" || cfg.BookmarksQID != "preserved" {
+		t.Fatalf("recovered config = %+v", cfg)
+	}
+}
+
+func TestRekeyAccountMovesEntryAndKeyringPairDeleteLast(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".xeet.yaml"), []byte(
+		"session_imported: 2026-07-27T00:00:00Z\n",
+	), 0600); err != nil {
+		t.Fatal(err)
+	}
+	base := newFakeStore()
+	base.data[keyLegacyAuthToken] = "legacy-auth"
+	base.data[keyLegacyCT0] = "legacy-ct0"
+	store := &operationStore{fakeStore: base, configPath: filepath.Join(dir, ".xeet.yaml")}
+	cm := newConfigManagerAt(dir, store)
+	if _, err := cm.Load(); err != nil {
+		t.Fatal(err)
+	}
+	store.operations = nil
+	store.failDelete = authTokenKey(legacyAccountID)
+
+	if err := cm.RekeyAccount(legacyAccountID, "42"); err == nil {
+		t.Fatal("rekey unexpectedly survived the injected old-key delete failure")
+	}
+	if !store.completeBeforeDelete {
+		t.Fatalf("old key deletion started before the new account was durable: %v", store.operations)
+	}
+	assertOperationOrder(t, store.operations,
+		"set "+authTokenKey("42"),
+		"set "+ct0Key("42"),
+		"delete "+authTokenKey(legacyAccountID),
+	)
+	store.failDelete = ""
+	cfg, err := cm.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.UserID != "42" || cfg.AuthToken != "legacy-auth" || cfg.CT0 != "legacy-ct0" {
+		t.Fatalf("new account did not win after interrupted cleanup: %+v", cfg)
+	}
+}
+
+func TestRekeyIntoExistingUserIDMergesKeepingNewerSession(t *testing.T) {
+	dir := t.TempDir()
+	cm := newConfigManagerAt(dir, newFakeStore())
+	older := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	newer := time.Date(2026, 7, 27, 0, 0, 0, 0, time.UTC)
+	if err := cm.SaveAccount(&Config{
+		UserID: "legacy", AuthToken: "old-auth", CT0: "old-ct0",
+		Handle: "old", SessionImported: older,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := cm.SaveAccount(&Config{
+		UserID: "42", AuthToken: "new-auth", CT0: "new-ct0",
+		Handle: "alice", SessionImported: newer,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := cm.SetActive("legacy"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cm.RekeyAccount("legacy", "42"); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := cm.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.UserID != "42" || cfg.AuthToken != "new-auth" || cfg.CT0 != "new-ct0" ||
+		cfg.Handle != "alice" || !cfg.SessionImported.Equal(newer) {
+		t.Fatalf("merge did not keep the newer destination session: %+v", cfg)
+	}
+	accounts, err := cm.Accounts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(accounts) != 1 || accounts[0].UserID != "42" {
+		t.Fatalf("merged accounts = %+v", accounts)
+	}
+}
+
+func TestSaveAccountRejectsEmptyUserID(t *testing.T) {
+	store := newFakeStore()
+	cm := newConfigManagerAt(t.TempDir(), store)
+	err := cm.SaveAccount(&Config{AuthToken: "auth", CT0: "ct0"})
+	if err == nil || !strings.Contains(err.Error(), "user id") {
+		t.Fatalf("SaveAccount error = %v", err)
+	}
+	if len(store.data) != 0 {
+		t.Fatalf("rejected account touched keyring: %+v", store.data)
+	}
+}
+
+func TestSaveQueryIDsPatchesOnlyQIDFields(t *testing.T) {
+	dir := t.TempDir()
+	cm := newConfigManagerAt(dir, newFakeStore())
+	if err := cm.Save(&Config{
+		CreateTweetQID: "old-create",
+		Theme:          "nord",
+		Columns:        []string{"foryou", "following"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := cm.SaveAccount(&Config{
+		UserID: "42", AuthToken: "auth-42", CT0: "ct0-42", Handle: "alice",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	stale, err := cm.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cm.SaveAccount(&Config{
+		UserID: "84", AuthToken: "auth-84", CT0: "ct0-84", Handle: "bob",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	stale.CreateTweetQID = "fresh-create"
+	stale.ViewerQID = "fresh-viewer"
+	if err := cm.SaveQueryIDs(stale); err != nil {
+		t.Fatal(err)
+	}
+
+	accounts, err := cm.Accounts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(accounts) != 2 {
+		t.Fatalf("SaveQueryIDs clobbered accounts: %+v", accounts)
+	}
+	active, err := cm.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if active.UserID != "84" || active.CreateTweetQID != "fresh-create" ||
+		active.ViewerQID != "fresh-viewer" || active.Theme != "nord" ||
+		!reflect.DeepEqual(active.Columns, []string{"foryou", "following"}) {
+		t.Fatalf("SaveQueryIDs changed non-QID state: %+v", active)
+	}
+}
+
+func TestSaveRefusesFileFromNewerVersion(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".xeet.yaml")
+	original := "version: 3\nactive: \"42\"\naccounts:\n  \"42\": {}\nfuture_key: keep-me\n"
+	if err := os.WriteFile(path, []byte(original), 0600); err != nil {
+		t.Fatal(err)
+	}
+	store := newFakeStore()
+	cm := newConfigManagerAt(dir, store)
+	err := cm.Save(&Config{
+		UserID: "42", AuthToken: "auth", CT0: "ct0", CreateTweetQID: "replacement",
+	})
+	if err == nil || !strings.Contains(err.Error(), "config written by a newer xeet") {
+		t.Fatalf("Save error = %v", err)
+	}
+	written, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(written) != original || len(store.data) != 0 {
+		t.Fatalf("newer config was modified:\n%s\nkeyring=%+v", written, store.data)
+	}
+}
+
+func TestEraseAccountRemovesOnlyThatAccountAndPromotesActive(t *testing.T) {
+	dir := t.TempDir()
+	store := newFakeStore()
+	cm := newConfigManagerAt(dir, store)
+	if err := cm.Save(&Config{
+		CreateTweetQID: "qid", Theme: "nord", Columns: []string{"foryou", "bookmarks"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for _, cfg := range []*Config{
+		{UserID: "42", AuthToken: "auth-42", CT0: "ct0-42", Handle: "alice"},
+		{UserID: "84", AuthToken: "auth-84", CT0: "ct0-84", Handle: "bob"},
+	} {
+		if err := cm.SaveAccount(cfg); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := cm.SetActive("42"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cm.EraseAccount("42"); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := cm.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.UserID != "84" || cfg.AuthToken != "auth-84" || cfg.CreateTweetQID != "qid" ||
+		cfg.Theme != "nord" || !reflect.DeepEqual(cfg.Columns, []string{"foryou", "bookmarks"}) {
+		t.Fatalf("promoted config = %+v", cfg)
+	}
+	if _, ok := store.data[authTokenKey("42")]; ok {
+		t.Fatalf("removed account auth token survived: %+v", store.data)
+	}
+	if _, ok := store.data[ct0Key("42")]; ok {
+		t.Fatalf("removed account ct0 survived: %+v", store.data)
+	}
+	if store.data[authTokenKey("84")] != "auth-84" || store.data[ct0Key("84")] != "ct0-84" {
+		t.Fatalf("other account secrets changed: %+v", store.data)
+	}
+}
+
+func TestLoadAccountReturnsRequestedSessionNotActive(t *testing.T) {
+	cm := newConfigManagerAt(t.TempDir(), newFakeStore())
+	for _, cfg := range []*Config{
+		{UserID: "42", AuthToken: "auth-42", CT0: "ct0-42", Handle: "alice"},
+		{UserID: "84", AuthToken: "auth-84", CT0: "ct0-84", Handle: "bob"},
+	} {
+		if err := cm.SaveAccount(cfg); err != nil {
+			t.Fatal(err)
+		}
+	}
+	requested, err := cm.LoadAccount("42")
+	if err != nil {
+		t.Fatal(err)
+	}
+	active, err := cm.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if requested.UserID != "42" || requested.AuthToken != "auth-42" || requested.Handle != "alice" {
+		t.Fatalf("requested account = %+v", requested)
+	}
+	if active.UserID != "84" {
+		t.Fatalf("LoadAccount changed active account: %+v", active)
+	}
+}
+
+func TestAccountsListsMetadataWithoutTouchingKeyring(t *testing.T) {
+	dir := t.TempDir()
+	store := &countingStore{fakeStore: newFakeStore()}
+	cm := newConfigManagerAt(dir, store)
+	if err := cm.SaveAccount(&Config{
+		UserID: "42", AuthToken: "auth", CT0: "ct0", Handle: "alice",
+		SessionBrowser: "Chrome", SessionProfile: "Default",
+		SessionImported: time.Date(2026, 7, 27, 0, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	store.gets = 0
+
+	accounts, err := cm.Accounts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if store.gets != 0 {
+		t.Fatalf("Accounts made %d keyring reads", store.gets)
+	}
+	if len(accounts) != 1 || accounts[0].UserID != "42" ||
+		accounts[0].Handle != "alice" || accounts[0].SessionBrowser != "Chrome" ||
+		accounts[0].SessionProfile != "Default" {
+		t.Fatalf("accounts = %+v", accounts)
+	}
+}
+
+func TestPreKeyringLegacyFileMigratesStraightToV2(t *testing.T) {
+	dir := t.TempDir()
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".xeet.key"), key, 0600); err != nil {
+		t.Fatal(err)
+	}
+	encrypted := legacyEncrypt(t, "file-auth", key)
+	body := "auth_token: " + encrypted + "\nct0: file-ct0\nsearch_timeline_qid: search-v1\n"
+	if err := os.WriteFile(filepath.Join(dir, ".xeet.yaml"), []byte(body), 0600); err != nil {
+		t.Fatal(err)
+	}
+	store := newFakeStore()
+	cfg, err := newConfigManagerAt(dir, store).Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.UserID != legacyAccountID || cfg.AuthToken != "file-auth" ||
+		cfg.CT0 != "file-ct0" || cfg.SearchTimelineQID != "search-v1" {
+		t.Fatalf("pre-keyring migration = %+v", cfg)
+	}
+	written, err := os.ReadFile(filepath.Join(dir, ".xeet.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(written), "version: 2") ||
+		strings.Contains(string(written), encrypted) || strings.Contains(string(written), "file-ct0") {
+		t.Fatalf("pre-keyring file was not scrubbed into v2:\n%s", written)
+	}
+}
+
+func TestRecordViewerPromotesLegacyAndSetsHandle(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".xeet.yaml"), []byte(
+		"session_imported: 2026-07-27T00:00:00Z\n",
+	), 0600); err != nil {
+		t.Fatal(err)
+	}
+	store := newFakeStore()
+	store.data[keyLegacyAuthToken] = "legacy-auth"
+	store.data[keyLegacyCT0] = "legacy-ct0"
+	cm := newConfigManagerAt(dir, store)
+	if _, err := cm.Load(); err != nil {
+		t.Fatal(err)
+	}
+	if err := cm.RecordViewer("42", "alice"); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := cm.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.UserID != "42" || cfg.Handle != "alice" || cfg.AuthToken != "legacy-auth" {
+		t.Fatalf("recorded viewer = %+v", cfg)
+	}
+}
+
+func assertOperationOrder(t *testing.T, operations []string, wants ...string) {
+	t.Helper()
+	next := 0
+	for _, operation := range operations {
+		if next < len(wants) && operation == wants[next] {
+			next++
+		}
+	}
+	if next != len(wants) {
+		t.Fatalf("operations %v do not contain ordered sequence %v", operations, wants)
 	}
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -46,6 +46,7 @@ func TestSaveLoadRoundtrip(t *testing.T) {
 	in := &Config{
 		AuthToken: "tok123", CT0: "csrf456", CreateTweetQID: "qid789",
 		HomeTimelineQID: "home123", BookmarksQID: "bookmarks123", SearchTimelineQID: "search123",
+		ListLatestTweetsTimelineQID: "listtimeline123", ListsManagementPageTimelineQID: "listsmanagement123",
 		FavoriteTweetQID: "like123", UnfavoriteTweetQID: "unlike123", ViewerQID: "viewer123",
 		TweetDetailQID: "detail123",
 		SessionBrowser: "Firefox", SessionProfile: "default-release", SessionDomain: "x.com",
@@ -120,6 +121,26 @@ func TestSaveWithoutSessionPersistsSearchTimelineQueryID(t *testing.T) {
 	}
 	if cfg.SearchTimelineQID != "search123" {
 		t.Fatalf("SearchTimelineQID = %q, want search123", cfg.SearchTimelineQID)
+	}
+}
+
+func TestSaveWithoutSessionPersistsListsQueryIDs(t *testing.T) {
+	dir := t.TempDir()
+	cm := newConfigManagerAt(dir, newFakeStore())
+
+	if err := cm.Save(&Config{
+		ListLatestTweetsTimelineQID:    "listtimeline123",
+		ListsManagementPageTimelineQID: "listsmanagement123",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := cm.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ListLatestTweetsTimelineQID != "listtimeline123" ||
+		cfg.ListsManagementPageTimelineQID != "listsmanagement123" {
+		t.Fatalf("lists query ids were not persisted: %+v", cfg)
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -939,7 +939,7 @@ func TestAccountsListsMetadataWithoutTouchingKeyring(t *testing.T) {
 	}
 	if len(accounts) != 1 || accounts[0].UserID != "42" ||
 		accounts[0].Handle != "alice" || accounts[0].SessionBrowser != "Chrome" ||
-		accounts[0].SessionProfile != "Default" {
+		accounts[0].SessionProfile != "Default" || !accounts[0].Active {
 		t.Fatalf("accounts = %+v", accounts)
 	}
 }


### PR DESCRIPTION
Three features that build on each other, in 19 commits meant to be read in order. Each one is live-tested against a real account before the next starts.

## Lists

`L` opens a picker of the lists you follow; `xeet --list <id>` and `xeet lists` skip it.

Finding the operation took a detour worth recording: the list read operations ship in a shared timeline chunk that is named for the bundles that pull it — Bookmarks, Explore, HomeTimeline — and never for List, so hinting `"List"` only finds the list *management* bundles. The hint and the chunk name are written down in `discover.go` so the next person does not repeat the search.

`ListsManagementPageTimeline` also answers `200` with the entries intact *and* a partial serialization error beside them, so the parse runs first and the error is only fatal when nothing parsed — which is still the shape an auth or rate-limit rejection takes.

## Multi-column

`xeet --columns foryou,bookmarks,list:123` renders up to four feeds side by side, `Tab` moves focus, and a window too narrow to hold them all shows what fits plus `+1 more (widen terminal)` rather than truncating mid-column.

Per-feed state moved onto a `column` struct in its own commit with no behaviour change; the rendered output is byte-identical before and after for the single-column case. Columns are deliberately equal-width because the preview cache is keyed by post id — unequal panes would need a per-column cache to avoid alternating width-based refetches, and that invariant is written at both ends.

## Multi-account

Config schema v2 keys accounts by X user id rather than anything derived from the cookies, since cookies rotate and a rotation would otherwise fork one account into two. Migration writes the new keyring pair, writes the file, and only then deletes the legacy keys, rolling back if any step fails.

`xeet accounts` / `switch` / `remove` manage them, `@` cycles inside the TUI, and `--columns @alice:foryou,@bob:following` pins a column to an account. A column resolves its session inside the fetch closure from the id captured at dispatch, so the existing feed-sequence guard already drops a page that arrives after its column changed hands — no new locking.

Likes fan out by (account, post) rather than post alone: the same post under two accounts holds two independent like states, and an optimistic rollback cannot flip a heart in a column that never made the request.

`xeet post --account <handle|id>` and `xeet whoami --account <...>` select per invocation. Switching and then acting is not equivalent — anything else on the machine can move `active` in between — and this closed a real race for a caller of mine. Two things fell out of that, both in here: an unknown selector is an error listing the accounts that exist rather than a silent fall back to active, and so is an empty one, because callers build the value from an environment variable and an unset variable produces `--account ""`.

The flag decides which account acts; it does not check that the choice was right. A caller that used to compare its expected handle against the active account was getting a wrong-account check for free, and passing that same value to `--account` turns it into the destination instead. `xeet post --help` says so, and the deny-list stays with the caller, where the policy lives.

## Rebase note

This started before #21 and #23. The last commit re-points upstream's reworked search chrome at the column being rendered rather than the model, and moves the list header to the same `list · name` shape as the new `search · “query”` so the two read alike side by side in a multi-column header. Nothing in that commit is a design decision of mine.

## Verification

`go build`, `go vet`, `staticcheck 2025.1.1`, and `go test -race ./...` are all clean on this branch — no remaining failures now that #22 has landed.

Live against real accounts: lists enumerate and page (5 lists, 96 posts), columns render three different feeds with images, two then three accounts coexist in one config, `whoami --account` reports a non-active account while `active` stays put, and both the unknown and empty selectors fail as described.

Behaviour-preserving commits were checked by hashing rendered output across worktrees rather than by reading the diff. The tests for the account-scoped paths were mutation-tested — the per-account session, the like fan-out constraint, and the unknown-selector error each fail when the guard they cover is removed.
