### PR TITLE
add WSL Firefox support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ showing 1/37 with the enter, e, r, and ? key hints](docs/timeline.png)
 
 ## get it
 
-works on macos and linux. windows isn't supported, open an issue if you
-want it.
+works on macos and linux, including wsl with a windows firefox session.
+native windows isn't supported yet.
 
 **with nix**:
 
@@ -97,6 +97,22 @@ replaces a session that already works, and a failure lets you try another
 browser without starting over.
 
 scripting it? `xeet auth --browser firefox` skips the picker entirely.
+
+**using wsl?** xeet can read the x.com session from firefox running on the
+windows side:
+
+```bash
+xeet auth --browser firefox
+```
+
+windows command interoperability must be enabled, with `cmd.exe`,
+`powershell.exe`, and `wslpath` available on `PATH`. xeet asks windows for the
+current user's firefox profile instead of assuming windows is mounted at
+`/mnt/c`. its copy of the two session values is encrypted with windows dpapi
+for that windows user; plaintext values are never written to the linux
+filesystem. windows chrome, brave, helium, zen, and edge profiles are not
+supported from wsl. browsers installed inside the linux distribution continue
+to use their normal linux profile locations.
 
 then just:
 
@@ -236,8 +252,9 @@ xeet reuses the x.com session already in your browser and speaks the same
 unsupported internal graphql endpoints the website does. the imported
 `auth_token` and `ct0` cookies grant account-level access, so treat them
 like a password. they live in the macos keychain or linux secret service, never
-in the yaml config file. `xeet logout` deletes xeet's copy (your browser
-stays logged in).
+in the yaml config file. on wsl, windows dpapi encrypts xeet's copy before the
+ciphertext reaches the linux filesystem. `xeet logout` deletes xeet's copy
+(your browser stays logged in).
 
 <details>
 <summary>details: query ids and retries</summary>

--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ windows side:
 xeet auth --browser firefox
 ```
 
-windows command interoperability must be enabled, with `cmd.exe`,
-`powershell.exe`, and `wslpath` available on `PATH`. xeet asks windows for the
+windows command interoperability must be enabled, with `powershell.exe` and
+`wslpath` available on `PATH`. xeet asks windows for the
 current user's firefox profile instead of assuming windows is mounted at
 `/mnt/c`. its copy of the two session values is encrypted with windows dpapi
 for that windows user; plaintext values are never written to the linux

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ nix profile install github:melqtx/xeet   # install
 nix run github:melqtx/xeet               # or just try it
 ```
 
-**with go** (1.26.5+, for the patched tls stack):
+**with go** (1.26.6+, for the patched tls stack):
 
 ```bash
 go install github.com/melqtx/xeet@latest
@@ -105,14 +105,17 @@ windows side:
 xeet auth --browser firefox
 ```
 
-windows command interoperability must be enabled, with `powershell.exe` and
-`wslpath` available on `PATH`. xeet asks windows for the
+to import from windows firefox, windows command interoperability must be
+enabled, with `powershell.exe` and `wslpath` available on `PATH`. xeet asks windows for the
 current user's firefox profile instead of assuming windows is mounted at
 `/mnt/c`. its copy of the two session values is encrypted with windows dpapi
 for that windows user; plaintext values are never written to the linux
 filesystem. windows chrome, brave, helium, zen, and edge profiles are not
 supported from wsl. browsers installed inside the linux distribution continue
-to use their normal linux profile locations.
+to use their normal linux profile locations and can fall back to linux secret
+service when windows interoperability is unavailable. an existing complete
+secret-service session is copied to dpapi only after both values are safely
+encrypted; `xeet logout` cleans both stores.
 
 then just:
 
@@ -262,9 +265,10 @@ xeet reuses the x.com session already in your browser and speaks the same
 unsupported internal graphql endpoints the website does. the imported
 `auth_token` and `ct0` cookies grant account-level access, so treat them
 like a password. they live in the macos keychain or linux secret service, never
-in the yaml config file. on wsl, windows dpapi encrypts xeet's copy before the
-ciphertext reaches the linux filesystem. `xeet logout` deletes xeet's copy
-(your browser stays logged in).
+in the yaml config file. on wsl, xeet prefers windows dpapi and falls back to
+linux secret service when windows interoperability is unavailable. dpapi
+encrypts xeet's copy before the ciphertext reaches the linux filesystem.
+`xeet logout` deletes xeet's copy (your browser stays logged in).
 
 <details>
 <summary>details: query ids and retries</summary>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,9 +22,11 @@ output from an account you care about; redact first.
 
 ## Scope notes
 
-- Cookies are stored in the macOS Keychain or Linux Secret Service, never in
-  the YAML config file. Anything that causes them to be written to disk,
-  logs, or terminal output is a vulnerability.
+- Cookies are stored in the macOS Keychain or Linux Secret Service. Under WSL,
+  Windows DPAPI encrypts each value for the current Windows user before the
+  ciphertext is written to the Linux filesystem. Plaintext cookies never
+  belong in the YAML config file, another file, process arguments, environment
+  variables, logs, or terminal output.
 - Xeet talks only to X-operated hosts (`x.com`, `upload.twitter.com`,
   `*.twimg.com`, `t.co`). Any request to another host, especially one
   carrying cookies, would be a vulnerability.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,8 +23,9 @@ output from an account you care about; redact first.
 ## Scope notes
 
 - Cookies are stored in the macOS Keychain or Linux Secret Service. Under WSL,
-  Windows DPAPI encrypts each value for the current Windows user before the
-  ciphertext is written to the Linux filesystem. Plaintext cookies never
+  xeet prefers Windows DPAPI and retains Linux Secret Service as a fallback
+  when Windows interoperability is unavailable. DPAPI encrypts each value for
+  the current Windows user before ciphertext is written. Plaintext cookies never
   belong in the YAML config file, another file, process arguments, environment
   variables, logs, or terminal output.
 - Xeet talks only to X-operated hosts (`x.com`, `upload.twitter.com`,

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -133,7 +133,7 @@ func verifyAndSave(ctx context.Context, result *api.LoginResult, browser string)
 
 // runAuthPlain is the scripted path: no picker, no spinner, one line per step.
 func runAuthPlain(ctx context.Context, out io.Writer, browser string) error {
-	fmt.Fprintf(out, "Reading your session from %s (your OS may ask to unlock its keyring)...\n", browser)
+	fmt.Fprintf(out, "Reading your session from %s (your OS may ask to unlock secure storage)...\n", browser)
 	result, resolved, err := api.ImportBrowserSession(browser)
 	if err != nil {
 		return err

--- a/cmd/auth_ui.go
+++ b/cmd/auth_ui.go
@@ -230,7 +230,7 @@ func (p authPicker) View() string {
 	switch p.phase {
 	case authPhaseImport:
 		return head + p.renderWorking(w, "reading your x.com session from "+p.chosen+"…",
-			"your OS may ask to unlock its keyring")
+			"your OS may ask to unlock secure storage")
 	case authPhaseVerify:
 		return head + p.renderWorking(w, "asking X to verify the session…", "")
 	case authPhaseDone:

--- a/cmd/auth_ui_test.go
+++ b/cmd/auth_ui_test.go
@@ -81,8 +81,8 @@ func TestAuthPickerEnterStartsTheImport(t *testing.T) {
 	if p.chosen != p.browsers[0] {
 		t.Fatalf("chose %q, want %q", p.chosen, p.browsers[0])
 	}
-	if !strings.Contains(p.View(), "unlock its keyring") {
-		t.Error("the import step should warn about the keyring prompt")
+	if !strings.Contains(p.View(), "unlock secure storage") {
+		t.Error("the import step should warn about the secure-storage prompt")
 	}
 }
 

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -11,7 +11,7 @@ import (
 var logoutCmd = &cobra.Command{
 	Use:   "logout",
 	Short: "disconnect and erase the saved session",
-	Long: `Removes the x.com session tokens from your OS keyring and deletes xeet's
+	Long: `Removes the x.com session tokens from secure storage and deletes xeet's
 config file. Your browser session is untouched; run 'xeet auth' to reconnect.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		configMgr, err := config.NewConfigManager()
@@ -21,7 +21,7 @@ config file. Your browser session is untouched; run 'xeet auth' to reconnect.`,
 		if err := configMgr.Erase(); err != nil {
 			return fmt.Errorf("logout incomplete: %w", err)
 		}
-		fmt.Println("✓ Logged out. Session erased from keyring and config removed.")
+		fmt.Println("✓ Logged out. Session erased from secure storage and config removed.")
 		return nil
 	},
 }

--- a/default.nix
+++ b/default.nix
@@ -1,12 +1,23 @@
 { lib
 , buildGoModule
+, fetchurl
+, go_1_26
 , wl-clipboard
 , libx11
 , makeWrapper
 , stdenv
 }:
 
-buildGoModule (finalAttrs: {
+let
+  go_1_26_6 = go_1_26.overrideAttrs (_: {
+    version = "1.26.6";
+    src = fetchurl {
+      url = "https://go.dev/dl/go1.26.6.src.tar.gz";
+      hash = "sha256-oHIcVMaIkBRI13rZs+x+p8R0cwdV/4kTgukuy5P/LLE=";
+    };
+  });
+in
+(buildGoModule.override { go = go_1_26_6; }) (finalAttrs: {
   pname = "xeet";
   # Keep in step with the latest release tag.
   version = "0.1.11";
@@ -16,7 +27,7 @@ buildGoModule (finalAttrs: {
   # Regenerate whenever go.mod or go.sum changes (including on dependabot
   # bumps): set this to lib.fakeHash, run `nix build .#default`, and copy the
   # hash nix reports. CI's nix job fails when it goes stale.
-  vendorHash = "sha256-Hij56rK+qINQYCjGdLUgM/5N7e0XAfh/zvcOYDs6gek=";
+  vendorHash = "sha256-OD+Zi8PgMtYPYeCTHC3L2AO20MrL5bkHvsTkR3Hs0D0=";
 
   # main.go reads these through -X; without them the binary reports "dev".
   ldflags = [

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,10 @@
 module github.com/melqtx/xeet
 
-// The patch version is deliberate, not incidental: go1.26.5 is the release
-// that fixes GO-2026-5856 (an Encrypted Client Hello privacy leak in
-// crypto/tls) along with GO-2026-5039 and GO-2026-5037. Relaxing this to
+// The patch version is deliberate, not incidental: go1.26.6 includes the
+// latest standard-library security fixes. Relaxing this to
 // "go 1.26" lets an older toolchain build xeet against a vulnerable TLS
 // stack, and CI's govulncheck job fails when it happens.
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/browserutils/kooky v0.2.10
@@ -19,7 +18,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/zalando/go-keyring v0.2.8
 	golang.design/x/clipboard v0.8.0
-	golang.org/x/image v0.44.0
+	golang.org/x/image v0.45.0
 	golang.org/x/net v0.57.0
 	golang.org/x/sys v0.47.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -56,7 +55,7 @@ require (
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/exp/shiny v0.0.0-20250606033433-dcc06ee1d476 // indirect
 	golang.org/x/mobile v0.0.0-20250606033058-a2a15c67f36f // indirect
-	golang.org/x/text v0.40.0 // indirect
+	golang.org/x/text v0.41.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/ini.v1 v1.67.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,8 @@ golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/exp/shiny v0.0.0-20250606033433-dcc06ee1d476 h1:Wdx0vgH5Wgsw+lF//LJKmWOJBLWX6nprsMqnf99rYDE=
 golang.org/x/exp/shiny v0.0.0-20250606033433-dcc06ee1d476/go.mod h1:ygj7T6vSGhhm/9yTpOQQNvuAUFziTH7RUiH74EoE2C8=
-golang.org/x/image v0.44.0 h1:+tDekMZED9+LrtB3G5xzRggpVh9CARjZqROla3R3R+I=
-golang.org/x/image v0.44.0/go.mod h1:V8K3KE9KKKE+pLpQDOeN18w9oacNSvy1tDOirTu4xtY=
+golang.org/x/image v0.45.0 h1:FMb1nTbH5H9vF55SriQHgFw5GnNL9Jg6L25BwXKzhB0=
+golang.org/x/image v0.45.0/go.mod h1:n62x/7RqlwXDvGsSU4u6IUTUf6KghUZ9Bt7cG/T9Fx4=
 golang.org/x/mobile v0.0.0-20250606033058-a2a15c67f36f h1:/n+PL2HlfqeSiDCuhdBbRNlGS/g2fM4OHufalHaTVG8=
 golang.org/x/mobile v0.0.0-20250606033058-a2a15c67f36f/go.mod h1:ESkJ836Z6LpG6mTVAhA48LpfW/8fNR0ifStlH2axyfg=
 golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=
@@ -122,8 +122,8 @@ golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
-golang.org/x/text v0.40.0 h1:Ub2Z6/xjgF1WrYQz2nuITOEegKFtiIy+rieRJ5lHZKs=
-golang.org/x/text v0.40.0/go.mod h1:hpnzDAfGV753zIKo+wk3u1bVKCGPbrnF7+7LBF/UHVY=
+golang.org/x/text v0.41.0 h1:vz/seA0lnX87Othu2f/0L24RcgrXD9/YFTSuGjj3rH8=
+golang.org/x/text v0.41.0/go.mod h1:jvf1O8ajNzZqhSrQBPbutR/EB83Cc0CFrezNQIwbb5M=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/wsl/wsl.go
+++ b/internal/wsl/wsl.go
@@ -1,0 +1,215 @@
+package wsl
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"unicode/utf16"
+)
+
+var ErrUnavailable = errors.New("windows interoperability is unavailable")
+
+type commandRunner interface {
+	Run(ctx context.Context, name string, args []string, stdin []byte) ([]byte, error)
+}
+
+type execRunner struct{}
+
+func (execRunner) Run(ctx context.Context, name string, args []string, stdin []byte) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdin = bytes.NewReader(stdin)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		// Do not return an ExitError containing captured process output. The
+		// DPAPI process handles account-level session material.
+		return nil, errors.New("windows command failed")
+	}
+	return stdout.Bytes(), nil
+}
+
+type bridge struct {
+	goos      string
+	lookupEnv func(string) (string, bool)
+	stat      func(string) (os.FileInfo, error)
+	lookPath  func(string) (string, error)
+	runner    commandRunner
+}
+
+var systemBridge = bridge{
+	goos:      runtime.GOOS,
+	lookupEnv: os.LookupEnv,
+	stat:      os.Stat,
+	lookPath:  exec.LookPath,
+	runner:    execRunner{},
+}
+
+// Active reports whether the current Linux process is running under WSL.
+func Active() bool {
+	return systemBridge.active()
+}
+
+func (b bridge) active() bool {
+	if b.goos != "linux" {
+		return false
+	}
+	if _, ok := b.lookupEnv("WSL_DISTRO_NAME"); ok {
+		return true
+	}
+	_, err := b.stat("/proc/sys/fs/binfmt_misc/WSLInterop")
+	return err == nil
+}
+
+// AppData resolves the current Windows user's roaming AppData directory and
+// converts it to a path that the WSL process can open.
+func AppData(ctx context.Context) (string, error) {
+	return systemBridge.appData(ctx)
+}
+
+func (b bridge) appData(ctx context.Context) (string, error) {
+	if !b.active() {
+		return "", ErrUnavailable
+	}
+	cmdPath, err := b.lookPath("cmd.exe")
+	if err != nil {
+		return "", fmt.Errorf("%w: cmd.exe is not on PATH", ErrUnavailable)
+	}
+	out, err := b.runner.Run(ctx, cmdPath, []string{"/d", "/c", "echo %APPDATA%"}, nil)
+	if err != nil {
+		return "", fmt.Errorf("%w: could not query %%APPDATA%%", ErrUnavailable)
+	}
+	windowsPath := strings.TrimSpace(strings.ReplaceAll(string(out), "\r", ""))
+	if windowsPath == "" || strings.Contains(windowsPath, "%APPDATA%") {
+		return "", fmt.Errorf("%w: Windows did not return %%APPDATA%%", ErrUnavailable)
+	}
+
+	wslpath, err := b.lookPath("wslpath")
+	if err != nil {
+		return "", fmt.Errorf("%w: wslpath is not on PATH", ErrUnavailable)
+	}
+	out, err = b.runner.Run(ctx, wslpath, []string{"-u", windowsPath}, nil)
+	if err != nil {
+		return "", fmt.Errorf("%w: could not translate %%APPDATA%%", ErrUnavailable)
+	}
+	path := strings.TrimSpace(strings.ReplaceAll(string(out), "\r", ""))
+	if path == "" || !strings.HasPrefix(path, "/") {
+		return "", fmt.Errorf("%w: wslpath returned an invalid path", ErrUnavailable)
+	}
+	return path, nil
+}
+
+type dpapiRequest struct {
+	Operation string `json:"operation"`
+	Key       string `json:"key"`
+	Payload   string `json:"payload"`
+}
+
+// Protect encrypts plaintext with Windows DPAPI in the current Windows user's
+// security context. The plaintext is sent only over the child process's stdin.
+func Protect(ctx context.Context, key string, plaintext []byte) ([]byte, error) {
+	return systemBridge.dpapi(ctx, "protect", key, plaintext)
+}
+
+// Unprotect decrypts a DPAPI ciphertext in the current Windows user's security
+// context. The returned plaintext exists only in process memory.
+func Unprotect(ctx context.Context, key string, ciphertext []byte) ([]byte, error) {
+	return systemBridge.dpapi(ctx, "unprotect", key, ciphertext)
+}
+
+func (b bridge) dpapi(ctx context.Context, operation, key string, payload []byte) ([]byte, error) {
+	if !b.active() {
+		return nil, ErrUnavailable
+	}
+	if operation != "protect" && operation != "unprotect" {
+		return nil, errors.New("invalid DPAPI operation")
+	}
+	if !validKey(key) {
+		return nil, errors.New("invalid DPAPI key name")
+	}
+	powershell, err := b.lookPath("powershell.exe")
+	if err != nil {
+		return nil, fmt.Errorf("%w: powershell.exe is not on PATH", ErrUnavailable)
+	}
+	request, err := json.Marshal(dpapiRequest{
+		Operation: operation,
+		Key:       key,
+		Payload:   base64.StdEncoding.EncodeToString(payload),
+	})
+	if err != nil {
+		return nil, errors.New("could not prepare DPAPI request")
+	}
+	out, err := b.runner.Run(ctx, powershell, []string{
+		"-NoLogo", "-NoProfile", "-NonInteractive",
+		"-EncodedCommand", encodedDPAPIScript,
+	}, request)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			return nil, err
+		}
+		return nil, errors.New("windows DPAPI operation failed")
+	}
+	result, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(out)))
+	if err != nil || len(result) == 0 {
+		return nil, errors.New("windows DPAPI returned an invalid result")
+	}
+	return result, nil
+}
+
+func validKey(key string) bool {
+	if key == "" || len(key) > 64 {
+		return false
+	}
+	for _, r := range key {
+		if (r < 'a' || r > 'z') && (r < '0' || r > '9') && r != '_' {
+			return false
+		}
+	}
+	return true
+}
+
+func encodePowerShell(script string) string {
+	encoded := utf16.Encode([]rune(script))
+	raw := make([]byte, len(encoded)*2)
+	for i, value := range encoded {
+		raw[i*2] = byte(value)
+		raw[i*2+1] = byte(value >> 8)
+	}
+	return base64.StdEncoding.EncodeToString(raw)
+}
+
+var encodedDPAPIScript = encodePowerShell(`
+$ErrorActionPreference = 'Stop'
+try {
+    $request = [Console]::In.ReadToEnd() | ConvertFrom-Json
+    $payload = [Convert]::FromBase64String([string]$request.payload)
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $entropy = $sha.ComputeHash([Text.Encoding]::UTF8.GetBytes("xeet" + [char]0 + [string]$request.key))
+    } finally {
+        $sha.Dispose()
+    }
+    $scope = [System.Security.Cryptography.DataProtectionScope]::CurrentUser
+    if ([string]$request.operation -eq 'protect') {
+        $result = [System.Security.Cryptography.ProtectedData]::Protect($payload, $entropy, $scope)
+    } elseif ([string]$request.operation -eq 'unprotect') {
+        $result = [System.Security.Cryptography.ProtectedData]::Unprotect($payload, $entropy, $scope)
+    } else {
+        throw 'invalid operation'
+    }
+    [Console]::Out.Write([Convert]::ToBase64String($result))
+} catch {
+    exit 1
+}
+`)

--- a/internal/wsl/wsl.go
+++ b/internal/wsl/wsl.go
@@ -82,18 +82,22 @@ func (b bridge) appData(ctx context.Context) (string, error) {
 	if !b.active() {
 		return "", ErrUnavailable
 	}
-	cmdPath, err := b.lookPath("cmd.exe")
+	powershell, err := b.lookPath("powershell.exe")
 	if err != nil {
-		return "", fmt.Errorf("%w: cmd.exe is not on PATH", ErrUnavailable)
+		return "", fmt.Errorf("%w: powershell.exe is not on PATH", ErrUnavailable)
 	}
-	out, err := b.runner.Run(ctx, cmdPath, []string{"/d", "/c", "echo %APPDATA%"}, nil)
+	out, err := b.runner.Run(ctx, powershell, []string{
+		"-NoLogo", "-NoProfile", "-NonInteractive",
+		"-EncodedCommand", encodedAppDataScript,
+	}, nil)
 	if err != nil {
-		return "", fmt.Errorf("%w: could not query %%APPDATA%%", ErrUnavailable)
+		return "", fmt.Errorf("%w: could not query Windows AppData", ErrUnavailable)
 	}
-	windowsPath := strings.TrimSpace(strings.ReplaceAll(string(out), "\r", ""))
-	if windowsPath == "" || strings.Contains(windowsPath, "%APPDATA%") {
-		return "", fmt.Errorf("%w: Windows did not return %%APPDATA%%", ErrUnavailable)
+	windowsPathBytes, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(out)))
+	if err != nil || len(windowsPathBytes) == 0 {
+		return "", fmt.Errorf("%w: Windows returned an invalid AppData path", ErrUnavailable)
 	}
+	windowsPath := string(windowsPathBytes)
 
 	wslpath, err := b.lookPath("wslpath")
 	if err != nil {
@@ -209,6 +213,20 @@ try {
         throw 'invalid operation'
     }
     [Console]::Out.Write([Convert]::ToBase64String($result))
+} catch {
+    exit 1
+}
+`)
+
+var encodedAppDataScript = encodePowerShell(`
+$ErrorActionPreference = 'Stop'
+try {
+    $path = [Environment]::GetFolderPath([Environment+SpecialFolder]::ApplicationData)
+    if ([string]::IsNullOrWhiteSpace($path)) {
+        throw 'AppData is unavailable'
+    }
+    $bytes = [Text.Encoding]::UTF8.GetBytes($path)
+    [Console]::Out.Write([Convert]::ToBase64String($bytes))
 } catch {
     exit 1
 }

--- a/internal/wsl/wsl.go
+++ b/internal/wsl/wsl.go
@@ -196,6 +196,7 @@ func encodePowerShell(script string) string {
 var encodedDPAPIScript = encodePowerShell(`
 $ErrorActionPreference = 'Stop'
 try {
+    Add-Type -AssemblyName System.Security
     $request = [Console]::In.ReadToEnd() | ConvertFrom-Json
     $payload = [Convert]::FromBase64String([string]$request.payload)
     $sha = [System.Security.Cryptography.SHA256]::Create()

--- a/internal/wsl/wsl_test.go
+++ b/internal/wsl/wsl_test.go
@@ -1,0 +1,166 @@
+package wsl
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+)
+
+type runCall struct {
+	name  string
+	args  []string
+	stdin []byte
+}
+
+type fakeRunner struct {
+	calls []runCall
+	run   func(runCall) ([]byte, error)
+}
+
+func (f *fakeRunner) Run(_ context.Context, name string, args []string, stdin []byte) ([]byte, error) {
+	call := runCall{name: name, args: slices.Clone(args), stdin: slices.Clone(stdin)}
+	f.calls = append(f.calls, call)
+	return f.run(call)
+}
+
+func activeBridge(runner commandRunner) bridge {
+	return bridge{
+		goos:      "linux",
+		lookupEnv: func(key string) (string, bool) { return "Ubuntu", key == "WSL_DISTRO_NAME" },
+		stat:      func(string) (os.FileInfo, error) { return nil, os.ErrNotExist },
+		lookPath: func(name string) (string, error) {
+			return "/interop/" + name, nil
+		},
+		runner: runner,
+	}
+}
+
+func TestActive(t *testing.T) {
+	tests := []struct {
+		name string
+		goos string
+		env  bool
+		stat error
+		want bool
+	}{
+		{"macOS ignores WSL variables", "darwin", true, nil, false},
+		{"environment", "linux", true, os.ErrNotExist, true},
+		{"interop marker", "linux", false, nil, true},
+		{"ordinary Linux", "linux", false, os.ErrNotExist, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := bridge{
+				goos: tt.goos,
+				lookupEnv: func(string) (string, bool) {
+					return "", tt.env
+				},
+				stat: func(string) (os.FileInfo, error) {
+					return nil, tt.stat
+				},
+			}
+			if got := b.active(); got != tt.want {
+				t.Fatalf("active() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAppDataUsesWindowsAndWSLPathTools(t *testing.T) {
+	runner := &fakeRunner{}
+	runner.run = func(call runCall) ([]byte, error) {
+		switch call.name {
+		case "/interop/cmd.exe":
+			return []byte("C:\\Users\\Zoë Lovelace\\AppData\\Roaming\r\n"), nil
+		case "/interop/wslpath":
+			if !slices.Equal(call.args, []string{"-u", `C:\Users\Zoë Lovelace\AppData\Roaming`}) {
+				t.Fatalf("wslpath args = %#v", call.args)
+			}
+			return []byte("/windows/Users/Zoë Lovelace/AppData/Roaming\n"), nil
+		default:
+			t.Fatalf("unexpected command %q", call.name)
+			return nil, nil
+		}
+	}
+	got, err := activeBridge(runner).appData(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/windows/Users/Zoë Lovelace/AppData/Roaming" {
+		t.Fatalf("AppData = %q", got)
+	}
+}
+
+func TestAppDataFailsClosed(t *testing.T) {
+	runner := &fakeRunner{run: func(runCall) ([]byte, error) {
+		return []byte("%APPDATA%\r\n"), nil
+	}}
+	_, err := activeBridge(runner).appData(context.Background())
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("error = %v, want ErrUnavailable", err)
+	}
+}
+
+func TestDPAPISecretOnlyTravelsOnStdin(t *testing.T) {
+	const secret = "session-material-must-not-leak"
+	runner := &fakeRunner{}
+	runner.run = func(call runCall) ([]byte, error) {
+		for _, arg := range call.args {
+			if strings.Contains(arg, secret) {
+				t.Fatalf("secret leaked into argv: %#v", call.args)
+			}
+		}
+		var request dpapiRequest
+		if err := json.Unmarshal(call.stdin, &request); err != nil {
+			t.Fatal(err)
+		}
+		decoded, err := base64.StdEncoding.DecodeString(request.Payload)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(decoded) != secret || request.Operation != "protect" || request.Key != "auth_token" {
+			t.Fatalf("request = %+v, payload %q", request, decoded)
+		}
+		return []byte(base64.StdEncoding.EncodeToString([]byte("ciphertext"))), nil
+	}
+
+	got, err := activeBridge(runner).dpapi(context.Background(), "protect", "auth_token", []byte(secret))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "ciphertext" {
+		t.Fatalf("result = %q", got)
+	}
+}
+
+func TestDPAPIErrorsDoNotExposeProcessMaterial(t *testing.T) {
+	const secret = "private-cookie"
+	runner := &fakeRunner{run: func(runCall) ([]byte, error) {
+		return []byte(secret), errors.New(secret)
+	}}
+	_, err := activeBridge(runner).dpapi(context.Background(), "protect", "ct0", []byte(secret))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("error leaked secret: %v", err)
+	}
+}
+
+func TestDPAPIRejectsInvalidOutputAndKeys(t *testing.T) {
+	runner := &fakeRunner{run: func(runCall) ([]byte, error) {
+		return []byte("not base64"), nil
+	}}
+	b := activeBridge(runner)
+	if _, err := b.dpapi(context.Background(), "protect", "../auth", []byte("x")); err == nil {
+		t.Fatal("invalid key accepted")
+	}
+	if _, err := b.dpapi(context.Background(), "protect", "auth_token", []byte("x")); err == nil {
+		t.Fatal("invalid PowerShell output accepted")
+	}
+}

--- a/internal/wsl/wsl_test.go
+++ b/internal/wsl/wsl_test.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"unicode/utf16"
 )
 
 type runCall struct {
@@ -169,5 +170,23 @@ func TestDPAPIRejectsInvalidOutputAndKeys(t *testing.T) {
 	}
 	if _, err := b.dpapi(context.Background(), "protect", "auth_token", []byte("x")); err == nil {
 		t.Fatal("invalid PowerShell output accepted")
+	}
+}
+
+func TestDPAPIScriptLoadsProtectedDataAssembly(t *testing.T) {
+	raw, err := base64.StdEncoding.DecodeString(encodedDPAPIScript)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(raw)%2 != 0 {
+		t.Fatalf("encoded PowerShell byte length = %d, want an even number", len(raw))
+	}
+	units := make([]uint16, len(raw)/2)
+	for i := range units {
+		units[i] = uint16(raw[i*2]) | uint16(raw[i*2+1])<<8
+	}
+	script := string(utf16.Decode(units))
+	if !strings.Contains(script, "Add-Type -AssemblyName System.Security") {
+		t.Fatal("DPAPI script does not load System.Security for Windows PowerShell 5.1")
 	}
 }

--- a/internal/wsl/wsl_test.go
+++ b/internal/wsl/wsl_test.go
@@ -75,8 +75,15 @@ func TestAppDataUsesWindowsAndWSLPathTools(t *testing.T) {
 	runner := &fakeRunner{}
 	runner.run = func(call runCall) ([]byte, error) {
 		switch call.name {
-		case "/interop/cmd.exe":
-			return []byte("C:\\Users\\Zoë Lovelace\\AppData\\Roaming\r\n"), nil
+		case "/interop/powershell.exe":
+			if !slices.Equal(call.args, []string{
+				"-NoLogo", "-NoProfile", "-NonInteractive",
+				"-EncodedCommand", encodedAppDataScript,
+			}) {
+				t.Fatalf("PowerShell args = %#v", call.args)
+			}
+			path := []byte("C:\\Users\\Zoë Lovelace\\AppData\\Roaming")
+			return []byte(base64.StdEncoding.EncodeToString(path)), nil
 		case "/interop/wslpath":
 			if !slices.Equal(call.args, []string{"-u", `C:\Users\Zoë Lovelace\AppData\Roaming`}) {
 				t.Fatalf("wslpath args = %#v", call.args)
@@ -98,7 +105,7 @@ func TestAppDataUsesWindowsAndWSLPathTools(t *testing.T) {
 
 func TestAppDataFailsClosed(t *testing.T) {
 	runner := &fakeRunner{run: func(runCall) ([]byte, error) {
-		return []byte("%APPDATA%\r\n"), nil
+		return []byte("not base64"), nil
 	}}
 	_, err := activeBridge(runner).appData(context.Background())
 	if !errors.Is(err, ErrUnavailable) {

--- a/pkg/api/cookies_darwin.go
+++ b/pkg/api/cookies_darwin.go
@@ -51,8 +51,8 @@ func chromiumBrowsers(home string) []chromiumBrowser {
 func geckoBrowsers(home string) []geckoBrowser {
 	appSup := filepath.Join(home, "Library", "Application Support")
 	return []geckoBrowser{
-		{"Firefox", []string{filepath.Join(appSup, "Firefox", "Profiles")}},
-		{"Zen", []string{filepath.Join(appSup, "zen", "Profiles")}},
+		{name: "Firefox", roots: []string{filepath.Join(appSup, "Firefox", "Profiles")}},
+		{name: "Zen", roots: []string{filepath.Join(appSup, "zen", "Profiles")}},
 	}
 }
 

--- a/pkg/api/cookies_gecko.go
+++ b/pkg/api/cookies_gecko.go
@@ -17,8 +17,10 @@ import (
 // geckoBrowser describes Firefox and Firefox-derived browsers. Their cookies
 // are stored in plain SQLite files, so no browser keyring access is needed.
 type geckoBrowser struct {
-	name  string
-	roots []string
+	name        string
+	roots       []string
+	windowsRoot string
+	reader      func(string) ([]*kooky.Cookie, error)
 }
 
 func (b geckoBrowser) cookieDBs() []string {
@@ -81,13 +83,18 @@ func importGeckoSession(b geckoBrowser) (*LoginResult, string, error) {
 
 	var lastErr error
 	var best *LoginResult
+	bestBrowser := b.name
+	reader := b.reader
+	if reader == nil {
+		reader = readGeckoXCookies
+	}
 	for _, db := range dbs {
 		tmp, copied, err := copyDBAs(db, "cookies.sqlite")
 		if err != nil {
 			lastErr = err
 			continue
 		}
-		cookies, readErr := readGeckoXCookies(copied)
+		cookies, readErr := reader(copied)
 		os.RemoveAll(tmp)
 		if readErr != nil {
 			lastErr = readErr
@@ -102,17 +109,29 @@ func importGeckoSession(b geckoBrowser) (*LoginResult, string, error) {
 			}
 			if betterLoginResult(result, best) {
 				best = result
+				bestBrowser = b.name
+				if withinRoot(db, b.windowsRoot) {
+					bestBrowser += " (Windows via WSL)"
+				}
 			}
 		}
 	}
 	if best != nil {
-		return best, b.name, nil
+		return best, bestBrowser, nil
 	}
 
 	if lastErr != nil {
 		return nil, "", fmt.Errorf("couldn't read %s cookies: %w", b.name, lastErr)
 	}
 	return nil, "", fmt.Errorf("no logged-in x.com session found in %s; open x.com in it, log in, then try again", b.name)
+}
+
+func withinRoot(path, root string) bool {
+	if root == "" {
+		return false
+	}
+	rel, err := filepath.Rel(root, path)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 func sessionFromCookies(cookies []*kooky.Cookie) *LoginResult {

--- a/pkg/api/cookies_linux.go
+++ b/pkg/api/cookies_linux.go
@@ -10,11 +10,13 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/browserutils/kooky"
 	"github.com/browserutils/kooky/browser/brave"
 	"github.com/browserutils/kooky/browser/chrome"
 	"github.com/browserutils/kooky/browser/chromium"
+	"github.com/melqtx/xeet/internal/wsl"
 )
 
 type chromiumCookieReader func(context.Context, string, ...kooky.Filter) ([]*kooky.Cookie, error)
@@ -44,14 +46,36 @@ func chromiumBrowsers(home string) []chromiumBrowser {
 }
 
 func geckoBrowsers(home string) []geckoBrowser {
+	browsers, _ := geckoBrowsersForEnvironment(home)
+	return browsers
+}
+
+func geckoBrowsersForEnvironment(home string) ([]geckoBrowser, error) {
+	var windowsAppData string
+	var interopErr error
+	if wsl.Active() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		windowsAppData, interopErr = wsl.AppData(ctx)
+	}
+	return geckoBrowsersAt(home, windowsAppData), interopErr
+}
+
+func geckoBrowsersAt(home, windowsAppData string) []geckoBrowser {
 	flatpak := filepath.Join(home, ".var", "app")
+	firefoxRoots := []string{
+		filepath.Join(home, ".mozilla", "firefox"),
+		filepath.Join(home, "snap", "firefox", "common", ".mozilla", "firefox"),
+		filepath.Join(flatpak, "org.mozilla.firefox", ".mozilla", "firefox"),
+	}
+	var windowsFirefoxRoot string
+	if windowsAppData != "" {
+		windowsFirefoxRoot = filepath.Join(windowsAppData, "Mozilla", "Firefox")
+		firefoxRoots = append(firefoxRoots, windowsFirefoxRoot)
+	}
 	return []geckoBrowser{
-		{"Firefox", []string{
-			filepath.Join(home, ".mozilla", "firefox"),
-			filepath.Join(home, "snap", "firefox", "common", ".mozilla", "firefox"),
-			filepath.Join(flatpak, "org.mozilla.firefox", ".mozilla", "firefox"),
-		}},
-		{"Zen", []string{
+		{name: "Firefox", roots: firefoxRoots, windowsRoot: windowsFirefoxRoot},
+		{name: "Zen", roots: []string{
 			filepath.Join(home, ".zen"),
 			filepath.Join(flatpak, "app.zen_browser.zen", ".zen"),
 			filepath.Join(flatpak, "io.github.zen_browser.zen", ".zen"),
@@ -87,8 +111,13 @@ func ImportBrowserSession(name string) (*LoginResult, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-	if browser, ok := findGeckoBrowser(name, geckoBrowsers(home)); ok {
-		return importGeckoSession(browser)
+	gecko, interopErr := geckoBrowsersForEnvironment(home)
+	if browser, ok := findGeckoBrowser(name, gecko); ok {
+		result, resolved, err := importGeckoSession(browser)
+		if err != nil && interopErr != nil {
+			return nil, "", fmt.Errorf("%w; WSL detected but Windows Firefox could not be checked: %v", err, interopErr)
+		}
+		return result, resolved, err
 	}
 	if browser, ok := findChromiumBrowser(name, chromiumBrowsers(home)); ok {
 		return importChromiumSession(browser)

--- a/pkg/api/cookies_linux_test.go
+++ b/pkg/api/cookies_linux_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -86,5 +87,57 @@ func TestLinuxLockedKeyringErrorIsActionable(t *testing.T) {
 	_, _, err := importChromiumSession(browser)
 	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "unlock") {
 		t.Fatalf("error = %v, want unlock guidance", err)
+	}
+}
+
+func TestWSLAddsOnlyWindowsFirefoxRoot(t *testing.T) {
+	home := t.TempDir()
+	appData := filepath.Join(t.TempDir(), "Users", "Ada Lovelace", "AppData", "Roaming")
+	browsers := geckoBrowsersAt(home, appData)
+
+	firefox, ok := findGeckoBrowser("Firefox", browsers)
+	if !ok {
+		t.Fatal("Firefox missing")
+	}
+	want := filepath.Join(appData, "Mozilla", "Firefox")
+	if firefox.windowsRoot != want || !slices.Contains(firefox.roots, want) {
+		t.Fatalf("Firefox roots = %#v, windows root = %q", firefox.roots, firefox.windowsRoot)
+	}
+
+	zen, ok := findGeckoBrowser("Zen", browsers)
+	if !ok {
+		t.Fatal("Zen missing")
+	}
+	if zen.windowsRoot != "" || slices.Contains(zen.roots, filepath.Join(appData, "Zen")) {
+		t.Fatalf("Windows roots leaked into Zen: %+v", zen)
+	}
+}
+
+func TestWSLFirefoxImportRecordsWindowsSource(t *testing.T) {
+	windowsRoot := filepath.Join(t.TempDir(), "Mozilla", "Firefox")
+	profile := filepath.Join(windowsRoot, "Profiles", "default-release")
+	if err := os.MkdirAll(profile, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(profile, "cookies.sqlite"), []byte("db"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	browser := geckoBrowser{
+		name:        "Firefox",
+		roots:       []string{windowsRoot},
+		windowsRoot: windowsRoot,
+		reader: func(string) ([]*kooky.Cookie, error) {
+			return []*kooky.Cookie{
+				{Cookie: http.Cookie{Name: "auth_token", Value: "token", Domain: ".x.com"}},
+				{Cookie: http.Cookie{Name: "ct0", Value: "csrf", Domain: ".x.com"}},
+			}, nil
+		},
+	}
+	result, name, err := importGeckoSession(browser)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Profile != "default-release" || name != "Firefox (Windows via WSL)" {
+		t.Fatalf("result = %+v, browser = %q", result, name)
 	}
 }

--- a/pkg/config/atomic_file.go
+++ b/pkg/config/atomic_file.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// atomicWriteFile writes one private file using a same-directory temporary
+// file, fsync, rename, and directory fsync. It refuses to replace a symlink.
+func atomicWriteFile(path string, data []byte) error {
+	if info, err := os.Lstat(path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%s is a symlink; refusing to replace it", path)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("%s is not a regular file", path)
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".xeet-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	if err := tmp.Chmod(0600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	return syncDirectory(dir)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,16 +10,18 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/melqtx/xeet/internal/wsl"
 	"github.com/zalando/go-keyring"
 	"gopkg.in/yaml.v3"
 )
 
 // Config is the whole of xeet's saved state: your x.com browser session plus
 // cached, non-secret operation ids and session metadata. AuthToken is the
-// session cookie and CT0 is the matching CSRF token; both live in the OS keyring (macOS Keychain, Linux
-// Secret Service), never on disk. The config file contains only non-secret
-// state: X's rotating GraphQL query ids and browser-session source metadata used
-// by `xeet doctor`.
+// session cookie and CT0 is the matching CSRF token; both live in secure
+// platform storage (macOS Keychain, Linux Secret Service, or Windows DPAPI
+// while running under WSL), never in the YAML config. The config file contains
+// only non-secret state: X's rotating GraphQL query ids and browser-session
+// source metadata used by `xeet doctor`.
 type Config struct {
 	AuthToken             string    `yaml:"-"`
 	CT0                   string    `yaml:"-"`
@@ -125,7 +127,14 @@ func NewConfigManager() (*ConfigManager, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newConfigManagerAt(homeDir, systemKeyring{}), nil
+	return newConfigManagerAt(homeDir, secretStoreFor(homeDir, wsl.Active())), nil
+}
+
+func secretStoreFor(homeDir string, isWSL bool) SecretStore {
+	if isWSL {
+		return newWSLSecretStore(homeDir)
+	}
+	return systemKeyring{}
 }
 
 func newConfigManagerAt(dir string, secrets SecretStore) *ConfigManager {
@@ -382,33 +391,7 @@ func (cm *ConfigManager) writeFile(fc *fileConfig) error {
 		return err
 	}
 
-	dir := filepath.Dir(cm.configPath)
-	tmp, err := os.CreateTemp(dir, ".xeet-*.tmp")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmp.Name()
-	defer os.Remove(tmpPath) // no-op after successful rename
-
-	if err := tmp.Chmod(0600); err != nil {
-		tmp.Close()
-		return err
-	}
-	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		return err
-	}
-	if err := tmp.Sync(); err != nil {
-		tmp.Close()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	if err := os.Rename(tmpPath, cm.configPath); err != nil {
-		return err
-	}
-	return syncDirectory(dir)
+	return atomicWriteFile(cm.configPath, data)
 }
 
 // legacyDecrypt undoes the old AES-GCM-with-key-on-disk scheme, used only to

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -144,7 +144,7 @@ func NewConfigManager() (*ConfigManager, error) {
 
 func secretStoreFor(homeDir string, isWSL bool) SecretStore {
 	if isWSL {
-		return newWSLSecretStore(homeDir)
+		return newWSLCompatibleSecretStore(homeDir)
 	}
 	return systemKeyring{}
 }
@@ -205,6 +205,13 @@ func (cm *ConfigManager) Load() (*Config, error) {
 		}
 		config.AuthToken = token
 		config.CT0 = ct0
+		if promoter, ok := cm.secrets.(interface {
+			Promote(string, string) error
+		}); ok {
+			// Migration is best-effort: a WSL user without Windows
+			// interoperability must still be able to use Linux Secret Service.
+			_ = promoter.Promote(token, ct0)
+		}
 	case errors.Is(err, ErrSecretNotFound):
 		// A leftover ct0 without auth_token is also corruption.
 		if ct0, ct0Err := cm.secrets.Get(keyCT0); ct0Err == nil && ct0 != "" {

--- a/pkg/config/secrets_wsl.go
+++ b/pkg/config/secrets_wsl.go
@@ -1,0 +1,137 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/melqtx/xeet/internal/wsl"
+)
+
+const wslSecretTimeout = 10 * time.Second
+
+type dataProtector interface {
+	Protect(context.Context, string, []byte) ([]byte, error)
+	Unprotect(context.Context, string, []byte) ([]byte, error)
+}
+
+type windowsDPAPI struct{}
+
+func (windowsDPAPI) Protect(ctx context.Context, key string, plaintext []byte) ([]byte, error) {
+	return wsl.Protect(ctx, key, plaintext)
+}
+
+func (windowsDPAPI) Unprotect(ctx context.Context, key string, ciphertext []byte) ([]byte, error) {
+	return wsl.Unprotect(ctx, key, ciphertext)
+}
+
+// wslSecretStore keeps only Windows DPAPI ciphertext in the WSL filesystem.
+// Plaintext crosses the Windows boundary over stdin/stdout and exists only in
+// process memory.
+type wslSecretStore struct {
+	dir       string
+	protector dataProtector
+	timeout   time.Duration
+}
+
+func newWSLSecretStore(home string) *wslSecretStore {
+	return &wslSecretStore{
+		dir:       filepath.Join(home, ".local", "share", "xeet", "keyring"),
+		protector: windowsDPAPI{},
+		timeout:   wslSecretTimeout,
+	}
+}
+
+func (s *wslSecretStore) Get(key string) (string, error) {
+	path, err := s.path(key)
+	if err != nil {
+		return "", err
+	}
+	ciphertext, err := secureReadFile(path)
+	if os.IsNotExist(err) {
+		return "", ErrSecretNotFound
+	}
+	if err != nil {
+		return "", fmt.Errorf("reading %s from Windows-backed secure storage: %w", key, err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), s.operationTimeout())
+	defer cancel()
+	plaintext, err := s.protector.Unprotect(ctx, key, ciphertext)
+	if err != nil {
+		return "", fmt.Errorf("decrypting %s with Windows secure storage: %w", key, err)
+	}
+	if len(plaintext) == 0 {
+		return "", ErrSecretNotFound
+	}
+	return string(plaintext), nil
+}
+
+func (s *wslSecretStore) Set(key, value string) error {
+	path, err := s.path(key)
+	if err != nil {
+		return err
+	}
+	if value == "" {
+		return errors.New("refusing to store an empty secret")
+	}
+	if err := ensurePrivateDir(s.dir); err != nil {
+		return fmt.Errorf("preparing Windows-backed secure storage: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), s.operationTimeout())
+	defer cancel()
+	ciphertext, err := s.protector.Protect(ctx, key, []byte(value))
+	if err != nil {
+		return fmt.Errorf("encrypting %s with Windows secure storage: %w", key, err)
+	}
+	if len(ciphertext) == 0 {
+		return errors.New("windows secure storage returned empty ciphertext")
+	}
+	if err := atomicWriteFile(path, ciphertext); err != nil {
+		return fmt.Errorf("saving %s to Windows-backed secure storage: %w", key, err)
+	}
+	return nil
+}
+
+func (s *wslSecretStore) Delete(key string) error {
+	path, err := s.path(key)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("deleting %s from Windows-backed secure storage: %w", key, err)
+	}
+	return nil
+}
+
+func (s *wslSecretStore) path(key string) (string, error) {
+	switch key {
+	case keyAuthToken, keyCT0, keyLegacySessionCookies:
+		return filepath.Join(s.dir, key+".dpapi"), nil
+	default:
+		return "", fmt.Errorf("invalid secret key %q", key)
+	}
+}
+
+func (s *wslSecretStore) operationTimeout() time.Duration {
+	if s.timeout > 0 {
+		return s.timeout
+	}
+	return wslSecretTimeout
+}
+
+func ensurePrivateDir(path string) error {
+	if err := os.MkdirAll(path, 0700); err != nil {
+		return err
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("%s is not a private directory", path)
+	}
+	return os.Chmod(path, 0700)
+}

--- a/pkg/config/secrets_wsl.go
+++ b/pkg/config/secrets_wsl.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/melqtx/xeet/internal/wsl"
@@ -43,6 +44,181 @@ func newWSLSecretStore(home string) *wslSecretStore {
 		protector: windowsDPAPI{},
 		timeout:   wslSecretTimeout,
 	}
+}
+
+type secretBackend uint8
+
+const (
+	backendUnselected secretBackend = iota
+	backendDPAPI
+	backendSecretService
+)
+
+// wslCompatibleSecretStore prefers Windows DPAPI but retains Linux Secret
+// Service as a complete-session fallback. This keeps Linux-browser sessions
+// working when Windows interoperability is disabled and migrates an existing
+// WSL keyring session only after both values have been written to DPAPI.
+type wslCompatibleSecretStore struct {
+	dpapi         SecretStore
+	secretService SecretStore
+	mu            sync.Mutex
+	selected      secretBackend
+}
+
+func newWSLCompatibleSecretStore(home string) *wslCompatibleSecretStore {
+	return &wslCompatibleSecretStore{
+		dpapi:         newWSLSecretStore(home),
+		secretService: systemKeyring{},
+	}
+}
+
+type secretPairStatus struct {
+	complete bool
+	partial  bool
+	err      error
+}
+
+func inspectSecretPair(store SecretStore) secretPairStatus {
+	auth, authErr := store.Get(keyAuthToken)
+	ct0, ct0Err := store.Get(keyCT0)
+	authFound := authErr == nil && auth != ""
+	ct0Found := ct0Err == nil && ct0 != ""
+	var unexpected []error
+	if authErr != nil && !errors.Is(authErr, ErrSecretNotFound) {
+		unexpected = append(unexpected, authErr)
+	}
+	if ct0Err != nil && !errors.Is(ct0Err, ErrSecretNotFound) {
+		unexpected = append(unexpected, ct0Err)
+	}
+	return secretPairStatus{
+		complete: authFound && ct0Found,
+		partial:  authFound != ct0Found,
+		err:      errors.Join(unexpected...),
+	}
+}
+
+func (s *wslCompatibleSecretStore) store(backend secretBackend) SecretStore {
+	if backend == backendSecretService {
+		return s.secretService
+	}
+	return s.dpapi
+}
+
+func (s *wslCompatibleSecretStore) selectForRead() (secretBackend, error) {
+	dpapi := inspectSecretPair(s.dpapi)
+	if dpapi.complete {
+		return backendDPAPI, nil
+	}
+	service := inspectSecretPair(s.secretService)
+	if service.complete {
+		return backendSecretService, nil
+	}
+	if dpapi.partial {
+		return backendDPAPI, nil
+	}
+	if service.partial {
+		return backendSecretService, nil
+	}
+	if dpapi.err != nil {
+		return backendUnselected, dpapi.err
+	}
+	if service.err != nil {
+		// An unavailable optional fallback must not block a fresh DPAPI
+		// session on a stock WSL installation without Secret Service.
+		return backendUnselected, ErrSecretNotFound
+	}
+	return backendUnselected, ErrSecretNotFound
+}
+
+func (s *wslCompatibleSecretStore) Get(key string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.selected == backendUnselected {
+		backend, err := s.selectForRead()
+		if err != nil {
+			return "", err
+		}
+		s.selected = backend
+	}
+	return s.store(s.selected).Get(key)
+}
+
+func (s *wslCompatibleSecretStore) Set(key, value string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.selected != backendUnselected {
+		return s.store(s.selected).Set(key, value)
+	}
+	dpapiErr := s.dpapi.Set(key, value)
+	if dpapiErr == nil {
+		s.selected = backendDPAPI
+		return nil
+	}
+	if err := s.secretService.Set(key, value); err != nil {
+		return errors.Join(dpapiErr, err)
+	}
+	s.selected = backendSecretService
+	return nil
+}
+
+func (s *wslCompatibleSecretStore) Delete(key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	dpapiErr := s.dpapi.Delete(key)
+	serviceErr := s.secretService.Delete(key)
+	s.selected = backendUnselected
+	return errors.Join(dpapiErr, serviceErr)
+}
+
+// Promote moves a complete Secret Service session to DPAPI. Failure is safe:
+// the original pair remains in Secret Service and continues to be selected.
+func (s *wslCompatibleSecretStore) Promote(authToken, ct0 string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.selected != backendSecretService || authToken == "" || ct0 == "" {
+		return nil
+	}
+	oldAuth, authErr := s.dpapi.Get(keyAuthToken)
+	oldCT0, ct0Err := s.dpapi.Get(keyCT0)
+	if authErr != nil && !errors.Is(authErr, ErrSecretNotFound) {
+		return authErr
+	}
+	if ct0Err != nil && !errors.Is(ct0Err, ErrSecretNotFound) {
+		return ct0Err
+	}
+	restore := func() {
+		if authErr == nil {
+			_ = s.dpapi.Set(keyAuthToken, oldAuth)
+		} else {
+			_ = s.dpapi.Delete(keyAuthToken)
+		}
+		if ct0Err == nil {
+			_ = s.dpapi.Set(keyCT0, oldCT0)
+		} else {
+			_ = s.dpapi.Delete(keyCT0)
+		}
+	}
+	if err := s.dpapi.Set(keyAuthToken, authToken); err != nil {
+		restore()
+		return err
+	}
+	if err := s.dpapi.Set(keyCT0, ct0); err != nil {
+		restore()
+		return err
+	}
+	if err := errors.Join(
+		s.secretService.Delete(keyAuthToken),
+		s.secretService.Delete(keyCT0),
+	); err != nil {
+		// DPAPI now has the complete pair, so preserve that successful
+		// migration and restore the fallback pair for a later cleanup retry.
+		_ = s.secretService.Set(keyAuthToken, authToken)
+		_ = s.secretService.Set(keyCT0, ct0)
+		s.selected = backendDPAPI
+		return err
+	}
+	s.selected = backendDPAPI
+	return nil
 }
 
 func (s *wslSecretStore) Get(key string) (string, error) {

--- a/pkg/config/secrets_wsl.go
+++ b/pkg/config/secrets_wsl.go
@@ -165,7 +165,14 @@ func (s *wslCompatibleSecretStore) Delete(key string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	dpapiErr := s.dpapi.Delete(key)
-	serviceErr := s.secretService.Delete(key)
+	var serviceErr error
+	if _, err := s.secretService.Get(key); err == nil {
+		// Secret Service is an optional WSL fallback. Only surface a delete
+		// failure after proving that this key exists there; an unavailable
+		// service must not turn an otherwise successful logout into a partial
+		// one.
+		serviceErr = s.secretService.Delete(key)
+	}
 	s.selected = backendUnselected
 	return errors.Join(dpapiErr, serviceErr)
 }

--- a/pkg/config/secrets_wsl_test.go
+++ b/pkg/config/secrets_wsl_test.go
@@ -1,0 +1,188 @@
+package config
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+type xorProtector struct {
+	protected [][]byte
+}
+
+func (p *xorProtector) Protect(_ context.Context, _ string, plaintext []byte) ([]byte, error) {
+	p.protected = append(p.protected, bytes.Clone(plaintext))
+	return xorBytes(plaintext), nil
+}
+
+func (p *xorProtector) Unprotect(_ context.Context, _ string, ciphertext []byte) ([]byte, error) {
+	return xorBytes(ciphertext), nil
+}
+
+func xorBytes(value []byte) []byte {
+	out := bytes.Clone(value)
+	for i := range out {
+		out[i] ^= 0xa5
+	}
+	return out
+}
+
+func testWSLStore(t *testing.T, protector dataProtector) *wslSecretStore {
+	t.Helper()
+	return &wslSecretStore{
+		dir:       filepath.Join(t.TempDir(), "keyring"),
+		protector: protector,
+		timeout:   time.Second,
+	}
+}
+
+func TestWSLSecretStoreRoundTripLeavesOnlyCiphertext(t *testing.T) {
+	protector := &xorProtector{}
+	store := testWSLStore(t, protector)
+	const secret = "account-level-session-material"
+
+	if err := store.Set(keyAuthToken, secret); err != nil {
+		t.Fatal(err)
+	}
+	path, _ := store.path(keyAuthToken)
+	onDisk, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(onDisk, []byte(secret)) {
+		t.Fatal("plaintext secret reached disk")
+	}
+	if info, err := os.Stat(path); err != nil || info.Mode().Perm() != 0600 {
+		t.Fatalf("secret file info = %v, err = %v", info, err)
+	}
+	if info, err := os.Stat(store.dir); err != nil || info.Mode().Perm() != 0700 {
+		t.Fatalf("secret directory info = %v, err = %v", info, err)
+	}
+
+	got, err := store.Get(keyAuthToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != secret {
+		t.Fatalf("Get = %q", got)
+	}
+	if len(protector.protected) != 1 || string(protector.protected[0]) != secret {
+		t.Fatalf("protector inputs = %#v", protector.protected)
+	}
+}
+
+func TestWSLSecretStoreMissingAndDelete(t *testing.T) {
+	store := testWSLStore(t, &xorProtector{})
+	if _, err := store.Get(keyCT0); !errors.Is(err, ErrSecretNotFound) {
+		t.Fatalf("Get missing = %v", err)
+	}
+	if err := store.Set(keyCT0, "csrf"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Delete(keyCT0); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Delete(keyCT0); err != nil {
+		t.Fatalf("second Delete = %v", err)
+	}
+	if _, err := store.Get(keyCT0); !errors.Is(err, ErrSecretNotFound) {
+		t.Fatalf("Get after Delete = %v", err)
+	}
+}
+
+func TestWSLConfigEraseRemovesEveryCiphertext(t *testing.T) {
+	store := testWSLStore(t, &xorProtector{})
+	manager := newConfigManagerAt(t.TempDir(), store)
+	if err := manager.Save(&Config{AuthToken: "auth", CT0: "csrf"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.Erase(); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{keyAuthToken, keyCT0, keyLegacySessionCookies} {
+		path, _ := store.path(key)
+		if _, err := os.Lstat(path); !os.IsNotExist(err) {
+			t.Fatalf("%s remains after Erase: %v", key, err)
+		}
+	}
+}
+
+func TestWSLSecretStoreRefusesSymlink(t *testing.T) {
+	store := testWSLStore(t, &xorProtector{})
+	if err := ensurePrivateDir(store.dir); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(t.TempDir(), "target")
+	if err := os.WriteFile(target, []byte("safe"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	path, _ := store.path(keyAuthToken)
+	if err := os.Symlink(target, path); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set(keyAuthToken, "secret"); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("Set through symlink = %v", err)
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "safe" {
+		t.Fatalf("symlink target changed to %q", data)
+	}
+}
+
+func TestWSLSecretStoreRefusesSymlinkDirectory(t *testing.T) {
+	base := t.TempDir()
+	target := filepath.Join(base, "target")
+	if err := os.Mkdir(target, 0700); err != nil {
+		t.Fatal(err)
+	}
+	store := &wslSecretStore{
+		dir:       filepath.Join(base, "keyring"),
+		protector: &xorProtector{},
+		timeout:   time.Second,
+	}
+	if err := os.Symlink(target, store.dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set(keyAuthToken, "secret"); err == nil {
+		t.Fatal("Set accepted a symlinked keyring directory")
+	}
+}
+
+type blockingProtector struct{}
+
+func (blockingProtector) Protect(ctx context.Context, _ string, _ []byte) ([]byte, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (blockingProtector) Unprotect(ctx context.Context, _ string, _ []byte) ([]byte, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func TestWSLSecretStoreTimesOut(t *testing.T) {
+	store := testWSLStore(t, blockingProtector{})
+	store.timeout = time.Millisecond
+	err := store.Set(keyAuthToken, "secret")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Set error = %v", err)
+	}
+}
+
+func TestWSLBackendSelectionIsDeterministic(t *testing.T) {
+	home := t.TempDir()
+	if _, ok := secretStoreFor(home, true).(*wslSecretStore); !ok {
+		t.Fatal("WSL did not select DPAPI store")
+	}
+	if _, ok := secretStoreFor(home, false).(systemKeyring); !ok {
+		t.Fatal("ordinary platform did not select system keyring")
+	}
+}

--- a/pkg/config/secrets_wsl_test.go
+++ b/pkg/config/secrets_wsl_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/melqtx/xeet/internal/wsl"
 )
 
 type xorProtector struct {
@@ -179,10 +181,154 @@ func TestWSLSecretStoreTimesOut(t *testing.T) {
 
 func TestWSLBackendSelectionIsDeterministic(t *testing.T) {
 	home := t.TempDir()
-	if _, ok := secretStoreFor(home, true).(*wslSecretStore); !ok {
-		t.Fatal("WSL did not select DPAPI store")
+	if _, ok := secretStoreFor(home, true).(*wslCompatibleSecretStore); !ok {
+		t.Fatal("WSL did not select the DPAPI-compatible fallback store")
 	}
 	if _, ok := secretStoreFor(home, false).(systemKeyring); !ok {
 		t.Fatal("ordinary platform did not select system keyring")
+	}
+}
+
+type setFailStore struct {
+	*fakeStore
+	err error
+}
+
+func (s *setFailStore) Set(string, string) error { return s.err }
+
+type unavailableStore struct{ err error }
+
+func (s unavailableStore) Get(string) (string, error) { return "", s.err }
+func (s unavailableStore) Set(string, string) error   { return s.err }
+func (s unavailableStore) Delete(string) error        { return nil }
+
+func TestWSLWithoutSecretServiceUsesDPAPI(t *testing.T) {
+	dpapi := newFakeStore()
+	store := &wslCompatibleSecretStore{
+		dpapi:         dpapi,
+		secretService: unavailableStore{err: errors.New("secret service unavailable")},
+	}
+	manager := newConfigManagerAt(t.TempDir(), store)
+	if err := manager.Save(&Config{AuthToken: "auth", CT0: "csrf"}); err != nil {
+		t.Fatal(err)
+	}
+	if dpapi.data[keyAuthToken] != "auth" || dpapi.data[keyCT0] != "csrf" {
+		t.Fatalf("DPAPI session = %#v", dpapi.data)
+	}
+}
+
+func TestWSLFallsBackWhenDPAPIIsUnavailable(t *testing.T) {
+	dpapi := &setFailStore{fakeStore: newFakeStore(), err: wsl.ErrUnavailable}
+	service := newFakeStore()
+	store := &wslCompatibleSecretStore{dpapi: dpapi, secretService: service}
+	manager := newConfigManagerAt(t.TempDir(), store)
+
+	want := &Config{AuthToken: "auth", CT0: "csrf", SessionBrowser: "Firefox"}
+	if err := manager.Save(want); err != nil {
+		t.Fatal(err)
+	}
+	if service.data[keyAuthToken] != "auth" || service.data[keyCT0] != "csrf" {
+		t.Fatalf("Secret Service fallback = %#v", service.data)
+	}
+	got, err := manager.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AuthToken != want.AuthToken || got.CT0 != want.CT0 {
+		t.Fatalf("Load = %+v, want session from Secret Service", got)
+	}
+}
+
+func TestWSLPromotesExistingSecretServicePairToDPAPI(t *testing.T) {
+	dpapi := newFakeStore()
+	service := newFakeStore()
+	service.data[keyAuthToken] = "legacy-auth"
+	service.data[keyCT0] = "legacy-csrf"
+	store := &wslCompatibleSecretStore{dpapi: dpapi, secretService: service}
+	manager := newConfigManagerAt(t.TempDir(), store)
+
+	got, err := manager.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AuthToken != "legacy-auth" || got.CT0 != "legacy-csrf" {
+		t.Fatalf("Load = %+v, want existing Secret Service session", got)
+	}
+	if dpapi.data[keyAuthToken] != "legacy-auth" || dpapi.data[keyCT0] != "legacy-csrf" {
+		t.Fatalf("DPAPI migration = %#v", dpapi.data)
+	}
+	if len(service.data) != 0 {
+		t.Fatalf("Secret Service entries remain after migration: %#v", service.data)
+	}
+}
+
+func TestWSLPromotionFailureKeepsSecretServicePair(t *testing.T) {
+	dpapi := &setFailStore{fakeStore: newFakeStore(), err: wsl.ErrUnavailable}
+	service := newFakeStore()
+	service.data[keyAuthToken] = "auth"
+	service.data[keyCT0] = "csrf"
+	store := &wslCompatibleSecretStore{dpapi: dpapi, secretService: service}
+	manager := newConfigManagerAt(t.TempDir(), store)
+
+	got, err := manager.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AuthToken != "auth" || got.CT0 != "csrf" {
+		t.Fatalf("Load = %+v, want Secret Service session", got)
+	}
+	if service.data[keyAuthToken] != "auth" || service.data[keyCT0] != "csrf" {
+		t.Fatalf("failed migration damaged Secret Service: %#v", service.data)
+	}
+}
+
+type deleteFailStore struct {
+	*fakeStore
+	failKey string
+}
+
+func (s *deleteFailStore) Delete(key string) error {
+	if key == s.failKey {
+		return errors.New("delete failed")
+	}
+	return s.fakeStore.Delete(key)
+}
+
+func TestWSLPromotionCleanupFailureKeepsACompletePairInBothStores(t *testing.T) {
+	dpapi := newFakeStore()
+	base := newFakeStore()
+	base.data[keyAuthToken] = "auth"
+	base.data[keyCT0] = "csrf"
+	service := &deleteFailStore{fakeStore: base, failKey: keyCT0}
+	manager := newConfigManagerAt(t.TempDir(), &wslCompatibleSecretStore{
+		dpapi: dpapi, secretService: service,
+	})
+
+	if _, err := manager.Load(); err != nil {
+		t.Fatal(err)
+	}
+	for name, store := range map[string]*fakeStore{"DPAPI": dpapi, "SecretService": base} {
+		if store.data[keyAuthToken] != "auth" || store.data[keyCT0] != "csrf" {
+			t.Fatalf("%s pair after cleanup failure = %#v", name, store.data)
+		}
+	}
+}
+
+func TestWSLEraseDeletesBothBackends(t *testing.T) {
+	dpapi := newFakeStore()
+	service := newFakeStore()
+	for _, store := range []*fakeStore{dpapi, service} {
+		store.data[keyAuthToken] = "auth"
+		store.data[keyCT0] = "csrf"
+		store.data[keyLegacySessionCookies] = "legacy"
+	}
+	manager := newConfigManagerAt(t.TempDir(), &wslCompatibleSecretStore{
+		dpapi: dpapi, secretService: service,
+	})
+	if err := manager.Erase(); err != nil {
+		t.Fatal(err)
+	}
+	if len(dpapi.data) != 0 || len(service.data) != 0 {
+		t.Fatalf("Erase left DPAPI=%#v SecretService=%#v", dpapi.data, service.data)
 	}
 }

--- a/pkg/config/secrets_wsl_test.go
+++ b/pkg/config/secrets_wsl_test.go
@@ -200,7 +200,7 @@ type unavailableStore struct{ err error }
 
 func (s unavailableStore) Get(string) (string, error) { return "", s.err }
 func (s unavailableStore) Set(string, string) error   { return s.err }
-func (s unavailableStore) Delete(string) error        { return nil }
+func (s unavailableStore) Delete(string) error        { return s.err }
 
 func TestWSLWithoutSecretServiceUsesDPAPI(t *testing.T) {
 	dpapi := newFakeStore()
@@ -214,6 +214,26 @@ func TestWSLWithoutSecretServiceUsesDPAPI(t *testing.T) {
 	}
 	if dpapi.data[keyAuthToken] != "auth" || dpapi.data[keyCT0] != "csrf" {
 		t.Fatalf("DPAPI session = %#v", dpapi.data)
+	}
+}
+
+func TestWSLEraseIgnoresUnavailableSecretService(t *testing.T) {
+	dpapi := newFakeStore()
+	for _, key := range []string{keyAuthToken, keyCT0, keyLegacySessionCookies} {
+		dpapi.data[key] = "secret"
+	}
+	manager := newConfigManagerAt(t.TempDir(), &wslCompatibleSecretStore{
+		dpapi: dpapi,
+		secretService: unavailableStore{
+			err: errors.New("secret service unavailable"),
+		},
+	})
+
+	if err := manager.Erase(); err != nil {
+		t.Fatalf("Erase with unavailable Secret Service = %v", err)
+	}
+	if len(dpapi.data) != 0 {
+		t.Fatalf("Erase left DPAPI secrets = %#v", dpapi.data)
 	}
 }
 
@@ -330,5 +350,22 @@ func TestWSLEraseDeletesBothBackends(t *testing.T) {
 	}
 	if len(dpapi.data) != 0 || len(service.data) != 0 {
 		t.Fatalf("Erase left DPAPI=%#v SecretService=%#v", dpapi.data, service.data)
+	}
+}
+
+func TestWSLEraseReportsDeleteFailureForSecretServiceSession(t *testing.T) {
+	service := newFakeStore()
+	service.data[keyAuthToken] = "auth"
+	service.data[keyCT0] = "csrf"
+	manager := newConfigManagerAt(t.TempDir(), &wslCompatibleSecretStore{
+		dpapi: newFakeStore(),
+		secretService: &deleteFailStore{
+			fakeStore: service,
+			failKey:   keyAuthToken,
+		},
+	})
+
+	if err := manager.Erase(); err == nil {
+		t.Fatal("Erase ignored a delete failure for a Secret Service session")
 	}
 }


### PR DESCRIPTION
Adds Windows Firefox session import and secure credential storage for xeet running under WSL.

## What changed

- discovers the current Windows user’s Firefox profiles through WSL interoperability
- imports x.com cookies from Windows Firefox while preserving Linux Firefox support
- loads `System.Security` explicitly so DPAPI works with stock Windows PowerShell 5.1
- prefers Windows DPAPI storage while retaining Linux Secret Service as a complete-pair fallback
- migrates an existing Secret Service session only after both DPAPI writes succeed
- makes logout clean DPAPI and legacy Secret Service entries
- resolves Windows AppData through explicit UTF-8 PowerShell output, including non-ASCII user paths
- merges current main, including notifications, bookmarks, video work, and v0.1.11
- updates Go and image decoding dependencies to current security-fixed releases
- keeps the Nix package reproducible with a pinned Go 1.26.6 source and vendor hash

## Validation

- go test ./...
- go test -race ./...
- repeated WSL/config regression tests
- go vet ./...
- staticcheck ./...
- govulncheck ./... (no vulnerabilities found)
- Linux amd64 and arm64 cross-builds
- nix build .#default

A final smoke test on a real WSL installation is still required to exercise Windows process interoperability and DPAPI end to end.