### PR TITLE
timeline: play videos with mpv

### DIFF
--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -544,6 +544,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.showAltText()
 	case "i":
 		return m, m.zoomSelected()
+	case "v":
+		return m, m.playSelectedVideo()
 	case "l":
 		return m, m.toggleSelectedLike()
 	case "y":
@@ -593,6 +595,18 @@ func (m *Model) applyPreview(msg previewMsg) tea.Cmd {
 	m.syncViewport()
 	m.ensureSelectedVisible()
 	return m.imageRepaint()
+}
+
+func (m *Model) playSelectedVideo() tea.Cmd {
+	post, ok := m.currentPost()
+	if !ok || len(post.Media) == 0 {
+		return nil
+	}
+	videoURL := post.Media[0].VideoURL
+	if videoURL == "" {
+		return m.showToast("selected post has no video")
+	}
+	return playVideo(videoURL)
 }
 
 func (m *Model) openSelected() tea.Cmd {

--- a/internal/timeline/open.go
+++ b/internal/timeline/open.go
@@ -1,12 +1,30 @@
 package timeline
 
 import (
+	"fmt"
 	"net/url"
 	"os/exec"
 	"runtime"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
+
+// playVideo hands the direct MP4 URL to mpv, which streams it without a full
+// download first. mpv runs detached from xeet: its own window (or terminal
+// UI, under --vo=tct/similar mpv configs) opens independently, and closing
+// the player doesn't affect the timeline underneath.
+func playVideo(videoURL string) tea.Cmd {
+	return func() tea.Msg {
+		if _, err := exec.LookPath("mpv"); err != nil {
+			return actionMsg{err: fmt.Errorf("mpv not found; install mpv to play videos")}
+		}
+		cmd := exec.Command("mpv", "--force-window=immediate", videoURL)
+		if err := cmd.Start(); err != nil {
+			return actionMsg{err: fmt.Errorf("play video: %w", err)}
+		}
+		return actionMsg{message: "playing in mpv"}
+	}
+}
 
 func openExternalURL(target string) error {
 	var cmd *exec.Cmd

--- a/internal/timeline/thread.go
+++ b/internal/timeline/thread.go
@@ -261,6 +261,8 @@ func (m Model) updateThread(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.showAltText()
 	case "i":
 		return m, m.zoomSelected()
+	case "v":
+		return m, m.playSelectedVideo()
 	case "l":
 		return m, m.toggleSelectedLike()
 	case "y":

--- a/internal/timeline/view.go
+++ b/internal/timeline/view.go
@@ -809,9 +809,9 @@ func (m Model) viewHelp() string {
 	if w > 54 {
 		w = 54
 	}
-	keys := "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nf           for you / following\nb           bookmarks / for you\n/           search\nl           like / unlike\nr           reply\nR           refresh\nenter       open replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\nP           new post\ng / G       top / bottom\nctrl+l      redraw screen\nq           quit"
+	keys := "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nf           for you / following\nb           bookmarks / for you\n/           search\nl           like / unlike\nr           reply\nR           refresh\nenter       open replies\ne / space   read full post\ni           zoom image\nv           play video (mpv)\nA           image alt text\no           open in browser\ny           copy link\nP           new post\ng / G       top / bottom\nctrl+l      redraw screen\nq           quit"
 	if m.mode == modeThread {
-		keys = "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\n/           search\nl           like / unlike\nr           reply to selected\nR           refresh replies\ne / space   read full post\ni           zoom image\nA           image alt text\no           open in browser\ny           copy link\ng / G       top / bottom\nctrl+l      redraw screen\nesc         back to timeline\nq           quit"
+		keys = "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\n/           search\nl           like / unlike\nr           reply to selected\nR           refresh replies\ne / space   read full post\ni           zoom image\nv           play video (mpv)\nA           image alt text\no           open in browser\ny           copy link\ng / G       top / bottom\nctrl+l      redraw screen\nesc         back to timeline\nq           quit"
 	}
 	if m.height < 25 {
 		keys = "\n\nj/k move · g/G ends · f feed\nl like · r reply · y copy\nenter replies · e read · i zoom · A alt text\nR refresh · o browser\nP new · / search · ^L redraw\nb bookmarks · q quit"

--- a/pkg/api/timeline.go
+++ b/pkg/api/timeline.go
@@ -19,11 +19,12 @@ const (
 )
 
 type TimelineMedia struct {
-	URL     string
-	Type    string
-	AltText string
-	Width   int
-	Height  int
+	URL      string
+	Type     string
+	AltText  string
+	Width    int
+	Height   int
+	VideoURL string
 }
 
 type TimelinePost struct {
@@ -364,6 +365,9 @@ func parseTimelineItem(item map[string]any) (TimelinePost, bool) {
 					entry.Width = intValue(original["width"])
 					entry.Height = intValue(original["height"])
 				}
+				if entry.Type == "video" || entry.Type == "animated_gif" {
+					entry.VideoURL = bestVideoVariant(item)
+				}
 				post.Media = append(post.Media, entry)
 			}
 			post.MediaCount = len(post.Media)
@@ -387,6 +391,43 @@ func parseTimelineItem(item map[string]any) (TimelinePost, bool) {
 		post.Handle, _ = userLegacy["screen_name"].(string)
 	}
 	return post, true
+}
+
+// bestVideoVariant picks the highest-bitrate MP4 variant from a media item's
+// video_info. Twitter also lists an HLS (.m3u8) variant with no bitrate
+// field; that one is skipped since mpv is pointed at a direct file so it
+// doesn't have to negotiate a manifest first.
+func bestVideoVariant(item map[string]any) string {
+	videoInfo, ok := item["video_info"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	variants, ok := videoInfo["variants"].([]any)
+	if !ok {
+		return ""
+	}
+	bestURL := ""
+	bestBitrate := -1
+	for _, raw := range variants {
+		variant, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		contentType, _ := variant["content_type"].(string)
+		if contentType != "video/mp4" {
+			continue
+		}
+		url, _ := variant["url"].(string)
+		if url == "" {
+			continue
+		}
+		bitrate := intValue(variant["bitrate"])
+		if bitrate > bestBitrate {
+			bestBitrate = bitrate
+			bestURL = url
+		}
+	}
+	return bestURL
 }
 
 func intValue(value any) int {


### PR DESCRIPTION
Adds a 'v' keybinding (feed + thread) that plays the selected post's video with mpv, since previously the only way to watch a video was opening the tweet in a browser.

- TimelineMedia gains a VideoURL field, populated from the highest- bitrate MP4 variant in video_info.variants (skips the HLS/.m3u8 variant so mpv gets a direct file to stream).
- playVideo checks mpv is on PATH and starts it detached (cmd.Start()), so xeet's own UI isn't blocked while it plays.
- Help screen documents the new key.

Requires mpv on PATH; shows a toast instead of failing silently if it's missing. Only the first media item is used, since X only allows one video per post.

resolves #26 