### PR TITLE
release: v0.1.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build artifacts
 xeet
 xeet-bin
+xeet-video
 xeet.exe
 dist/
 private-dist/

--- a/default.nix
+++ b/default.nix
@@ -9,7 +9,7 @@
 buildGoModule (finalAttrs: {
   pname = "xeet";
   # Keep in step with the latest release tag.
-  version = "0.1.9";
+  version = "0.1.10";
 
   src = lib.cleanSource ./.;
 


### PR DESCRIPTION
Bumps default.nix to 0.1.10 so the flake stamps the right version, since `nix profile install github:melqtx/xeet` builds from main rather than the tag.

go.mod and go.sum haven't changed since v0.1.9, so vendorHash still matches.

Also ignores xeet-video, a build artifact the existing rules missed.