### PR TITLE
release: v0.1.11

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,7 +9,7 @@
 buildGoModule (finalAttrs: {
   pname = "xeet";
   # Keep in step with the latest release tag.
-  version = "0.1.10";
+  version = "0.1.11";
 
   src = lib.cleanSource ./.;
 


### PR DESCRIPTION
Bumps `default.nix` to 0.1.11 so Nix installs report the release version.

`go.mod` and `go.sum` are unchanged, so `vendorHash` remains valid.

Validated with `go test ./...`, `go vet ./...`, and `nix build .#default --print-build-logs`.