### PR TITLE
feat: resize feed bindings 

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ come back next time.
 | key | does |
 |---|---|
 | `j` / `k` / arrows | move (`ctrl+d`/`ctrl+u` jumps five) |
+| `[` / `]` | narrow / widen the feed for this session |
 | `tab` / `shift+tab` | cycle forward / backward through For You, Following, and Bookmarks |
 | `f` | switch between the for you and following feeds |
 | `b` | switch between bookmarks and the for you feed |

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"os"
 	"strings"
 	"time"
 
@@ -231,6 +232,7 @@ type previewState struct {
 	imageID    uint32
 	columns    int
 	rows       int
+	width      int
 	loading    bool
 	err        error
 }
@@ -243,6 +245,7 @@ type previewMsg struct {
 	imageID    uint32
 	columns    int
 	rows       int
+	width      int
 	err        error
 }
 
@@ -688,11 +691,23 @@ func (m *Model) applyLikeResult(msg likeMsg) tea.Cmd {
 func (m *Model) storePreview(msg previewMsg) {
 	m.previews[msg.postID] = previewState{
 		content: msg.content, nativePath: msg.nativePath, nativeData: msg.nativeData, imageID: msg.imageID,
-		columns: msg.columns, rows: msg.rows, err: msg.err,
+		columns: msg.columns, rows: msg.rows, width: msg.width, err: msg.err,
 	}
 }
 
 func (m *Model) applyPreview(msg previewMsg) tea.Cmd {
+	previous, exists := m.previews[msg.postID]
+	if !exists || previous.width != msg.width {
+		// A width change can start a replacement fetch before the old one
+		// returns. Do not let its stale dimensions replace the current preview.
+		if msg.nativePath != "" {
+			_ = os.Remove(msg.nativePath)
+		}
+		return nil
+	}
+	if previous.nativePath != "" && previous.nativePath != msg.nativePath {
+		_ = os.Remove(previous.nativePath)
+	}
 	m.storePreview(msg)
 	m.evictDistantPreviews()
 	m.syncViewport()

--- a/internal/timeline/model.go
+++ b/internal/timeline/model.go
@@ -50,6 +50,12 @@ const (
 
 type Action struct{ Kind ActionKind }
 
+const (
+	minFeedWidth     = 30
+	defaultFeedWidth = 76
+	feedWidthStep    = 8
+)
+
 // FeedKind identifies which timeline the feed pane is showing.
 type FeedKind int
 
@@ -88,6 +94,7 @@ type Model struct {
 	// instead of leaving them to run out their own timeouts.
 	ctx           context.Context
 	width, height int
+	feedWidthCap  int
 	imageMode     imageMode
 	imageNote     string
 	feed          FeedKind
@@ -259,9 +266,14 @@ func NewWithImageMode(requested string) Model {
 	search.CharLimit = 512
 	mode, note := resolveImageMode(requested)
 	return Model{
-		ctx:   context.Background(),
-		width: 80, height: 24, imageMode: mode, imageNote: note, loading: true,
-		liking: map[string]bool{}, previews: map[string]previewState{},
+		ctx:          context.Background(),
+		width:        80,
+		height:       24,
+		feedWidthCap: defaultFeedWidth,
+		imageMode:    mode,
+		imageNote:    note,
+		loading:      true,
+		liking:       map[string]bool{}, previews: map[string]previewState{},
 		spinner: s, viewport: vp, replyEditor: editor, searchInput: search,
 		notificationSeq: 1, notificationPolling: true,
 	}
@@ -564,6 +576,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case "ctrl+l":
 		m.syncViewport()
 		return m, func() tea.Msg { return tea.ClearScreen() }
+	case "[":
+		if m.adjustFeedWidth(-feedWidthStep) {
+			return m, m.imageRepaint(m.requestPreviews(), m.showToast(fmt.Sprintf("feed width: %d columns", m.contentWidth())))
+		}
+	case "]":
+		if m.adjustFeedWidth(feedWidthStep) {
+			return m, m.imageRepaint(m.requestPreviews(), m.showToast(fmt.Sprintf("feed width: %d columns", m.contentWidth())))
+		}
 	case "tab":
 		return m, m.cycleFeed(1)
 	case "shift+tab":
@@ -952,6 +972,23 @@ func (m *Model) resize() {
 	m.searchInput.SetCursor(m.searchInput.Position())
 	m.syncViewport()
 	m.ensureSelectedVisible()
+}
+
+// adjustFeedWidth changes the session-only cap without letting it exceed the
+// usable terminal width. resize reflows text and repositions native previews.
+func (m *Model) adjustFeedWidth(delta int) bool {
+	cap := m.feedWidthCap
+	if cap == 0 {
+		cap = defaultFeedWidth
+	}
+	maxCap := max(minFeedWidth, m.width-4)
+	next := max(minFeedWidth, min(maxCap, cap+delta))
+	if next == cap {
+		return false
+	}
+	m.feedWidthCap = next
+	m.resize()
+	return true
 }
 
 func (m *Model) syncViewport() {

--- a/internal/timeline/model_test.go
+++ b/internal/timeline/model_test.go
@@ -646,6 +646,47 @@ func TestHalfPageJumpAndScrolloff(t *testing.T) {
 	}
 }
 
+func TestFeedWidthBindingsReflowTheCurrentSession(t *testing.T) {
+	m := New()
+	m.loading = false
+	m.posts = posts(1)
+	m = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 24})
+	if got := m.contentWidth(); got != defaultFeedWidth {
+		t.Fatalf("default feed width=%d, want %d", got, defaultFeedWidth)
+	}
+
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{']'}})
+	if got := m.contentWidth(); got != defaultFeedWidth+feedWidthStep {
+		t.Fatalf("widened feed width=%d, want %d", got, defaultFeedWidth+feedWidthStep)
+	}
+	if m.viewport.Width != m.contentWidth() {
+		t.Fatalf("viewport width=%d, want %d", m.viewport.Width, m.contentWidth())
+	}
+	if m.toast != "feed width: 84 columns" {
+		t.Fatalf("width toast=%q", m.toast)
+	}
+
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'['}})
+	if got := m.contentWidth(); got != defaultFeedWidth {
+		t.Fatalf("narrowed feed width=%d, want %d", got, defaultFeedWidth)
+	}
+
+	m.feedWidthCap = minFeedWidth
+	m.resize()
+	m = update(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'['}})
+	if got := m.contentWidth(); got != minFeedWidth {
+		t.Fatalf("minimum feed width=%d, want %d", got, minFeedWidth)
+	}
+}
+
+func TestFeedWidthBindingIsListedInHelp(t *testing.T) {
+	m := New()
+	m.help = true
+	if view := m.View(); !strings.Contains(view, "g/G ends [/]") {
+		t.Fatalf("feed-width binding missing from help:\n%s", view)
+	}
+}
+
 func TestPaginationDeduplicates(t *testing.T) {
 	m := New()
 	m = update(t, m, pageMsg{page: &api.TimelinePage{Posts: posts(2), Cursor: "one"}})

--- a/internal/timeline/preview.go
+++ b/internal/timeline/preview.go
@@ -153,12 +153,16 @@ func (m *Model) requestPreviews() tea.Cmd {
 			// at the width it now has to fit. Both renderers cap themselves at
 			// the width they are given, so the refetch cannot repeat.
 			tooWide := !state.loading && state.err == nil && previewColumns(state) > width
+			// A preview generated for a narrower frame must also be replaced when
+			// the feed widens, even if its aspect ratio kept its displayed columns
+			// below the old cap.
+			wrongWidth := state.width > 0 && state.width != width
 			// A failed fetch retries only once its post is selected again.
-			if !tooWide && (i != m.selected || state.loading || state.err == nil) {
+			if !tooWide && !wrongWidth && (i != m.selected || state.loading || state.err == nil) {
 				continue
 			}
 		}
-		m.previews[post.ID] = previewState{loading: true}
+		m.previews[post.ID] = previewState{loading: true, width: width}
 		if i == m.selected {
 			selectedChanged = true
 		}
@@ -266,18 +270,19 @@ func abs(value int) int {
 // the rest of a compose handoff.
 func fetchPreview(parent context.Context, postID string, media api.TimelineMedia, width, maxRows int, mode imageMode) tea.Cmd {
 	return func() tea.Msg {
+		failed := func(err error) previewMsg { return previewMsg{postID: postID, width: width, err: err} }
 		parsed, err := url.Parse(previewMediaURL(media.URL, mode))
 		if err != nil {
-			return previewMsg{postID: postID, err: err}
+			return failed(err)
 		}
 		if err := validateMediaURL(parsed); err != nil {
-			return previewMsg{postID: postID, err: err}
+			return failed(err)
 		}
 		ctx, cancel := context.WithTimeout(parent, 20*time.Second)
 		defer cancel()
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
 		if err != nil {
-			return previewMsg{postID: postID, err: err}
+			return failed(err)
 		}
 		req.Header.Set("User-Agent", "github.com/melqtx/xeet/terminal-image-preview")
 		client := &http.Client{
@@ -291,53 +296,53 @@ func fetchPreview(parent context.Context, postID string, media api.TimelineMedia
 		}
 		resp, err := client.Do(req)
 		if err != nil {
-			return previewMsg{postID: postID, err: fmt.Errorf("load image: %w", err)}
+			return failed(fmt.Errorf("load image: %w", err))
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
-			return previewMsg{postID: postID, err: fmt.Errorf("load image: HTTP %d", resp.StatusCode)}
+			return failed(fmt.Errorf("load image: HTTP %d", resp.StatusCode))
 		}
 		if !strings.HasPrefix(strings.ToLower(resp.Header.Get("Content-Type")), "image/") {
-			return previewMsg{postID: postID, err: fmt.Errorf("media is not an image")}
+			return failed(fmt.Errorf("media is not an image"))
 		}
 		imageData, err := io.ReadAll(io.LimitReader(resp.Body, maxPreviewBytes+1))
 		if err != nil {
-			return previewMsg{postID: postID, err: err}
+			return failed(err)
 		}
 		if len(imageData) > maxPreviewBytes {
-			return previewMsg{postID: postID, err: fmt.Errorf("image is too large to preview")}
+			return failed(fmt.Errorf("image is too large to preview"))
 		}
 		config, _, err := image.DecodeConfig(bytes.NewReader(imageData))
 		if err != nil {
-			return previewMsg{postID: postID, err: fmt.Errorf("decode image: %w", err)}
+			return failed(fmt.Errorf("decode image: %w", err))
 		}
 		if config.Width <= 0 || config.Height <= 0 || int64(config.Width)*int64(config.Height) > 50_000_000 {
-			return previewMsg{postID: postID, err: fmt.Errorf("image dimensions are too large to preview")}
+			return failed(fmt.Errorf("image dimensions are too large to preview"))
 		}
 		decoded, _, err := image.Decode(bytes.NewReader(imageData))
 		if err != nil {
-			return previewMsg{postID: postID, err: fmt.Errorf("decode image: %w", err)}
+			return failed(fmt.Errorf("decode image: %w", err))
 		}
 		if mode == imageModeNative {
 			columns, rows := nativeCellSize(decoded.Bounds(), width, maxRows)
 			path, err := writePreviewPNG(downscaleForCells(decoded, columns, rows))
 			if err != nil {
-				return previewMsg{postID: postID, err: err}
+				return failed(err)
 			}
 			return previewMsg{
 				postID: postID, nativePath: path, imageID: previewImageID(postID),
-				columns: columns, rows: rows,
+				columns: columns, rows: rows, width: width,
 			}
 		}
 		if mode == imageModeWezTerm {
 			columns, rows := nativeCellSize(decoded.Bounds(), width, maxRows)
 			encoded, err := encodePreviewPNG(downscaleForCells(decoded, columns, rows))
 			if err != nil {
-				return previewMsg{postID: postID, err: err}
+				return failed(err)
 			}
-			return previewMsg{postID: postID, nativeData: encoded, columns: columns, rows: rows}
+			return previewMsg{postID: postID, nativeData: encoded, columns: columns, rows: rows, width: width}
 		}
-		return previewMsg{postID: postID, content: renderANSIImage(decoded, width, maxRows)}
+		return previewMsg{postID: postID, content: renderANSIImage(decoded, width, maxRows), width: width}
 	}
 }
 

--- a/internal/timeline/preview_test.go
+++ b/internal/timeline/preview_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"image"
 	"image/color"
+	"os"
 	"strings"
 	"testing"
 
@@ -405,6 +406,77 @@ func TestThreadRefetchesAPreviewTooWideForItsRail(t *testing.T) {
 	m.previews["root"] = previewState{columns: m.contentWidth() - 4 - 2*maxRailDepth}
 	if cmd := m.requestPreviews(); cmd != nil {
 		t.Fatalf("a preview that fits was refetched: %+v", m.previews["root"])
+	}
+}
+
+func TestFeedWidthChangeRefetchesCachedPreview(t *testing.T) {
+	m := New()
+	m.loading = false
+	m.width, m.height = 120, 24
+	m.posts = mediaPosts(1)
+	m.resize()
+	initialWidth := m.contentWidth() - 4
+	m.previews["p0"] = previewState{content: "preview", columns: initialWidth, width: initialWidth}
+
+	if !m.adjustFeedWidth(feedWidthStep) {
+		t.Fatal("feed width did not increase")
+	}
+	if cmd := m.requestPreviews(); cmd == nil {
+		t.Fatal("widened feed did not request a replacement preview")
+	}
+	preview := m.previews["p0"]
+	if !preview.loading || preview.width != initialWidth+feedWidthStep {
+		t.Fatalf("replacement preview=%+v", preview)
+	}
+
+	if !m.adjustFeedWidth(-feedWidthStep) {
+		t.Fatal("feed width did not decrease")
+	}
+	if cmd := m.requestPreviews(); cmd == nil {
+		t.Fatal("narrowed feed did not request a replacement preview")
+	}
+	preview = m.previews["p0"]
+	if !preview.loading || preview.width != initialWidth {
+		t.Fatalf("narrowed replacement preview=%+v", preview)
+	}
+}
+
+func TestApplyPreviewDiscardsStaleWidthAndCleansNativeFile(t *testing.T) {
+	m := New()
+	stalePath := t.TempDir() + "/stale.png"
+	if err := os.WriteFile(stalePath, []byte("preview"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	m.previews["p0"] = previewState{loading: true, width: 84}
+
+	m.applyPreview(previewMsg{postID: "p0", nativePath: stalePath, width: 76})
+	if preview := m.previews["p0"]; !preview.loading || preview.width != 84 {
+		t.Fatalf("stale preview replaced current request: %+v", preview)
+	}
+	if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
+		t.Fatalf("stale native preview was not removed: %v", err)
+	}
+}
+
+func TestApplyPreviewReplacesNativeFile(t *testing.T) {
+	m := New()
+	dir := t.TempDir()
+	oldPath := dir + "/old.png"
+	newPath := dir + "/new.png"
+	if err := os.WriteFile(oldPath, []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(newPath, []byte("new"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	m.previews["p0"] = previewState{nativePath: oldPath, width: 84}
+
+	m.applyPreview(previewMsg{postID: "p0", nativePath: newPath, width: 84})
+	if preview := m.previews["p0"]; preview.nativePath != newPath {
+		t.Fatalf("replacement preview=%+v", preview)
+	}
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Fatalf("replaced native preview was not removed: %v", err)
 	}
 }
 

--- a/internal/timeline/view.go
+++ b/internal/timeline/view.go
@@ -89,11 +89,15 @@ func (m Model) shell(center, footer string) string {
 
 func (m Model) contentWidth() int {
 	w := m.width - 4
-	if w > 76 {
-		w = 76
+	cap := m.feedWidthCap
+	if cap == 0 {
+		cap = defaultFeedWidth
 	}
-	if w < 30 {
-		w = 30
+	if w > cap {
+		w = cap
+	}
+	if w < minFeedWidth {
+		w = minFeedWidth
 	}
 	return w
 }
@@ -852,7 +856,7 @@ func (m Model) viewHelp() string {
 	if w > 54 {
 		w = 54
 	}
-	keys := "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\ntab         next feed\nshift+tab   previous feed\nf / b       quick feed toggles\nn           notifications\n/           search\nl           like / unlike\nr           reply\nR           refresh\nenter       open replies\ne / space   read full post\ni           zoom image\nv           play video (mpv)\nA           image alt text\no           open in browser\ny           copy link\nP           new post\ng / G       top / bottom\nctrl+l      redraw screen\nq           quit"
+	keys := "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\n[ / ]       narrow / widen feed\ntab         next feed\nshift+tab   previous feed\nf / b       quick feed toggles\nn           notifications\n/           search\nl           like / unlike\nr           reply\nR           refresh\nenter       open replies\ne / space   read full post\ni           zoom image\nv           play video (mpv)\nA           image alt text\no           open in browser\ny           copy link\nP           new post\ng / G       top / bottom\nctrl+l      redraw screen\nq           quit"
 	if m.mode == modeThread {
 		keys = "\n\n↑ / k       previous\n↓ / j       next\nctrl+d/u    jump five\nn           notifications\n/           search\nl           like / unlike\nr           reply to selected\nR           refresh replies\ne / space   read full post\ni           zoom image\nv           play video (mpv)\nA           image alt text\no           open in browser\ny           copy link\ng / G       top / bottom\nctrl+l      redraw screen\nesc         back to timeline\nq           quit"
 	}
@@ -860,7 +864,7 @@ func (m Model) viewHelp() string {
 		keys = "\n\n↑ / k       previous\n↓ / j       next\nr           reply\nR           refresh\nenter       open conversation\ne / space   read full post\no           open in browser\ny           copy link\nesc / n     back\nq           quit"
 	}
 	if m.height < 25 {
-		keys = "\n\nj/k move · g/G ends\ntab feeds · n inbox\nl like · r reply · y copy\nenter replies · e read\ni zoom · A alt · o browser\nR refresh · P new · / search\n^L redraw · q quit"
+		keys = "\n\nj/k move · g/G ends [/]\ntab feeds · n inbox\nl like · r reply · y copy\nenter replies · e read\ni zoom · A alt · o browser\nR refresh · P new · / search\n^L redraw · q quit"
 		if m.mode == modeThread {
 			keys = "\n\nj/k move · g/G ends\nl like · r reply · n inbox\ny copy · e read · i zoom\nA alt · R refresh · o browser\n/ search · esc back · q quit"
 		} else if m.mode == modeNotifications {


### PR DESCRIPTION
## Description 

On a wider monitor, I wanted the feed to take up more space, so this adds a couple of bindings in order to resize the feed, it will try to resize images but I have seen mixed results with how it resizes some images depending on their dimensions. 

## Changes in this pull request 
- Update `README.md` to include new bindings (also updates help window in app)
- Now tracks width as part of the model, and will resize as part of the update loop 
- Add relevant unit tests 

I have tried to keep the change small, my heart is not set on any of the keybindings so feel free to request any changes 