### PR TITLE
feat: render quoted post cards

### DIFF
--- a/internal/timeline/preview.go
+++ b/internal/timeline/preview.go
@@ -51,6 +51,12 @@ const (
 	imageModeOff     imageMode = "off"
 )
 
+// quotePreviewKey scopes an embedded preview to its parent. The quoted post can
+// also appear as a regular feed item at a different width in the same frame.
+func quotePreviewKey(parentID, quoteID string) string {
+	return "quote:" + parentID + ":" + quoteID
+}
+
 // resolveImageMode picks the renderer and explains any downgrade from the
 // terminal's native graphics so the help overlay can show why images look
 // the way they do.
@@ -141,28 +147,38 @@ func (m *Model) requestPreviews() tea.Cmd {
 			}
 		}
 	}
-	for i := from; i <= to; i++ {
-		post := posts[i]
-		if len(post.Media) == 0 {
-			continue
-		}
-		if state, exists := m.previews[post.ID]; exists {
+	queue := func(key string, media api.TimelineMedia, previewWidth int, selected bool) {
+		if state, exists := m.previews[key]; exists {
 			// A preview cached at a wider frame -- from the feed, before a
 			// thread indented its post behind a rail, or from before the window
 			// shrank -- would spill past the right edge, so it is fetched again
 			// at the width it now has to fit. Both renderers cap themselves at
 			// the width they are given, so the refetch cannot repeat.
-			tooWide := !state.loading && state.err == nil && previewColumns(state) > width
+			tooWide := !state.loading && state.err == nil && previewColumns(state) > previewWidth
 			// A failed fetch retries only once its post is selected again.
-			if !tooWide && (i != m.selected || state.loading || state.err == nil) {
-				continue
+			if !tooWide && (!selected || state.loading || state.err == nil) {
+				return
 			}
 		}
-		m.previews[post.ID] = previewState{loading: true}
-		if i == m.selected {
+		m.previews[key] = previewState{loading: true}
+		if selected {
 			selectedChanged = true
 		}
-		cmds = append(cmds, fetchPreview(m.requestContext(), post.ID, post.Media[0], width, rows, m.imageMode))
+		cmds = append(cmds, fetchPreview(m.requestContext(), key, media, previewWidth, rows, m.imageMode))
+	}
+	for i := from; i <= to; i++ {
+		post := posts[i]
+		selected := i == m.selected
+		if len(post.Media) > 0 {
+			queue(post.ID, post.Media[0], width, selected)
+		}
+		if post.Quote != nil && len(post.Quote.Media) > 0 {
+			quoteWidth := max(10, width-4)
+			if m.imageMode == imageModeNative {
+				quoteWidth = min(quoteWidth, len(kittyDiacritics))
+			}
+			queue(quotePreviewKey(post.ID, post.Quote.ID), post.Quote.Media[0], quoteWidth, selected)
+		}
 	}
 	if selectedChanged {
 		m.syncViewport()
@@ -216,6 +232,9 @@ func (m *Model) evictDistantPreviews() {
 	index := make(map[string]int, len(posts))
 	for i := range posts {
 		index[posts[i].ID] = i
+		if posts[i].Quote != nil {
+			index[quotePreviewKey(posts[i].ID, posts[i].Quote.ID)] = i
+		}
 	}
 	activeZoom := ""
 	if post, ok := m.currentPost(); ok && m.zoom {

--- a/internal/timeline/preview_test.go
+++ b/internal/timeline/preview_test.go
@@ -385,6 +385,23 @@ func TestPreviewsPrefetchAroundSelection(t *testing.T) {
 	}
 }
 
+func TestPreviewsFetchQuotedMediaAtCardWidth(t *testing.T) {
+	m := NewWithImageMode("ansi")
+	m.loading = false
+	quote := mediaPosts(1)[0]
+	quote.ID = "quoted"
+	m.posts = []api.TimelinePost{{ID: "outer", Text: "quote", Quote: &quote}}
+	m.syncViewport()
+
+	if cmd := m.requestPreviews(); cmd == nil {
+		t.Fatal("quoted image was not requested")
+	}
+	preview, ok := m.previews[quotePreviewKey("outer", "quoted")]
+	if !ok || !preview.loading {
+		t.Fatalf("quoted preview state=%+v", preview)
+	}
+}
+
 func TestThreadRefetchesAPreviewTooWideForItsRail(t *testing.T) {
 	m := NewWithImageMode("ansi")
 	m.loading = false

--- a/internal/timeline/view.go
+++ b/internal/timeline/view.go
@@ -485,9 +485,62 @@ func (m Model) renderPost(post api.TimelinePost, selected, nearSelection bool, d
 		}
 		parts = append(parts, indent+lipgloss.NewStyle().Foreground(muted).Render(chip))
 	}
+	if post.Quote != nil {
+		parts = append(parts, m.renderQuoteCard(post.ID, *post.Quote, indent, width, nearSelection))
+	}
 
 	parts = append(parts, indent+m.actionLine(post))
 	return lipgloss.JoinVertical(lipgloss.Left, parts...)
+}
+
+// renderQuoteCard keeps an embedded quote visually separate from its authoring
+// post while using the same preview formats as the main timeline.
+func (m Model) renderQuoteCard(parentID string, quote api.TimelinePost, indent string, width int, showPreview bool) string {
+	cardWidth := max(10, width-lipgloss.Width(indent)-2)
+	handle := quote.Handle
+	if handle == "" {
+		handle = "unknown"
+	}
+	name := quote.AuthorName
+	if name == "" {
+		name = "someone"
+	}
+	header := ansi.Truncate(name+"  @"+handle, max(8, cardWidth-1), "…")
+	lines := []string{
+		indent + lipgloss.NewStyle().Foreground(muted).Render("╭─ "+header),
+	}
+	text := strings.Split(lipgloss.NewStyle().Width(cardWidth).Render(cleanText(quote.Text)), "\n")
+	if len(text) > 3 {
+		text = text[:3]
+		text[2] = ansi.Truncate(text[2], max(2, cardWidth-1), "…")
+	}
+	for _, line := range text {
+		lines = append(lines, indent+"│ "+lipgloss.NewStyle().Foreground(muted).Render(line))
+	}
+
+	preview, hasPreview := m.previews[quotePreviewKey(parentID, quote.ID)]
+	imageShown := false
+	if len(quote.Media) > 0 && showPreview && hasPreview {
+		imageBlock := ""
+		switch {
+		case preview.nativePath != "":
+			imageBlock = m.nativePreviewBlock(preview)
+		case preview.nativeData != "":
+			imageBlock = m.wezTermPreviewBlock(preview)
+		case preview.content != "":
+			imageBlock = preview.content
+		}
+		if imageBlock != "" {
+			lines = append(lines, indent+"│")
+			lines = append(lines, prefixLines(imageBlock, indent+"│ "))
+			imageShown = true
+		}
+	}
+	if len(quote.Media) > 0 && !imageShown {
+		lines = append(lines, indent+"│ "+lipgloss.NewStyle().Foreground(muted).Render(mediaChip(quote)))
+	}
+	lines = append(lines, indent+lipgloss.NewStyle().Foreground(muted).Render("╰─"))
+	return strings.Join(lines, "\n")
 }
 
 // imagePrefix keeps a preview inside the frame. Previews are cached per post at

--- a/internal/timeline/view_test.go
+++ b/internal/timeline/view_test.go
@@ -77,6 +77,24 @@ func TestMediaChip(t *testing.T) {
 	}
 }
 
+func TestQuoteCardRendersTextAndInlinePreview(t *testing.T) {
+	m := NewWithImageMode("off")
+	m.width = 80
+	quote := api.TimelinePost{
+		ID: "quoted", AuthorName: "Quoted Author", Handle: "quoted", Text: "the quoted post",
+		Media: []api.TimelineMedia{{URL: "https://pbs.twimg.com/media/quoted", Type: "photo"}},
+	}
+	m.posts = []api.TimelinePost{{ID: "outer", AuthorName: "Outer", Handle: "outer", Text: "my comment", Quote: &quote}}
+	m.previews[quotePreviewKey("outer", "quoted")] = previewState{content: "QUOTE-IMAGE"}
+	content, _, _ := m.renderFeedContent()
+	plain := ansi.Strip(content)
+	for _, want := range []string{"╭─ Quoted Author  @quoted", "the quoted post", "QUOTE-IMAGE", "╰─"} {
+		if !strings.Contains(plain, want) {
+			t.Fatalf("quote card is missing %q:\n%s", want, plain)
+		}
+	}
+}
+
 func TestUnselectedPostNearSelectionRendersCachedImage(t *testing.T) {
 	m := New()
 	m.loading = false

--- a/pkg/api/timeline.go
+++ b/pkg/api/timeline.go
@@ -40,6 +40,7 @@ type TimelinePost struct {
 	MediaCount     int
 	Media          []TimelineMedia
 	Liked          bool
+	Quote          *TimelinePost
 	InReplyToID    string
 	ConversationID string
 }
@@ -317,6 +318,13 @@ func parseTimelineItem(item map[string]any) (TimelinePost, bool) {
 	}
 	tweetResults, _ := item["tweet_results"].(map[string]any)
 	result, _ := tweetResults["result"].(map[string]any)
+	return parseTimelineResult(result, true)
+}
+
+// parseTimelineResult decodes a tweet result shared by timeline posts and the
+// embedded result of a quote. Quotes are decoded only one level deep so a
+// chain of quote cards cannot consume the entire frame.
+func parseTimelineResult(result map[string]any, includeQuote bool) (TimelinePost, bool) {
 	if nested, ok := result["tweet"].(map[string]any); ok {
 		result = nested
 	}
@@ -389,6 +397,15 @@ func parseTimelineItem(item map[string]any) (TimelinePost, bool) {
 	}
 	if post.Handle == "" {
 		post.Handle, _ = userLegacy["screen_name"].(string)
+	}
+	if includeQuote {
+		if quotedResult, ok := result["quoted_status_result"].(map[string]any); ok {
+			if quoted, ok := quotedResult["result"].(map[string]any); ok {
+				if quote, ok := parseTimelineResult(quoted, false); ok {
+					post.Quote = &quote
+				}
+			}
+		}
 	}
 	return post, true
 }

--- a/pkg/api/timeline_test.go
+++ b/pkg/api/timeline_test.go
@@ -90,6 +90,40 @@ func TestParseTimelineVisibilityWrapper(t *testing.T) {
 	}
 }
 
+func TestParseTimelineIncludesEmbeddedQuote(t *testing.T) {
+	quote := map[string]any{
+		"rest_id": "quoted",
+		"legacy": map[string]any{"full_text": "the quoted post", "extended_entities": map[string]any{
+			"media": []any{map[string]any{"type": "photo", "media_url_https": "https://pbs.twimg.com/media/quoted"}},
+		}},
+		"core": map[string]any{"user_results": map[string]any{"result": map[string]any{"core": map[string]any{
+			"name": "Quoted Author", "screen_name": "quoted",
+		}}}},
+	}
+	item := map[string]any{"tweet_results": map[string]any{"result": map[string]any{
+		"rest_id": "outer", "legacy": map[string]any{"full_text": "my comment"},
+		"quoted_status_result": map[string]any{"result": quote},
+	}}}
+	post, ok := parseTimelineItem(item)
+	if !ok || post.Quote == nil {
+		t.Fatalf("quote was not parsed: %+v", post)
+	}
+	if post.Quote.ID != "quoted" || post.Quote.Handle != "quoted" || post.Quote.Text != "the quoted post" || len(post.Quote.Media) != 1 {
+		t.Fatalf("quote = %+v", post.Quote)
+	}
+}
+
+func TestParseTimelineOmitsUnavailableQuote(t *testing.T) {
+	item := map[string]any{"tweet_results": map[string]any{"result": map[string]any{
+		"rest_id": "outer", "legacy": map[string]any{"full_text": "my comment"},
+		"quoted_status_result": map[string]any{"result": map[string]any{"__typename": "TweetTombstone"}},
+	}}}
+	post, ok := parseTimelineItem(item)
+	if !ok || post.Quote != nil {
+		t.Fatalf("unavailable quote = %+v", post)
+	}
+}
+
 func TestParseTimelineMultipleImages(t *testing.T) {
 	fixture := `{"entries":[{"itemContent":{"tweet_results":{"result":{
 	  "rest_id":"photos","legacy":{"full_text":"album","extended_entities":{"media":[


### PR DESCRIPTION
## Description 

Some tweets didn't make any sense and when I opened them in browser they were quoting some other tweet, this PR renders the quote tweet, it does mean that not as many tweets appear on the tl as they take up more space, so maybe we want a button to view a quote tweet 

## Changes in this pull request 
- If a quote tweet exists then render it, if it includes an image also render that 

Again small change, happy to change any of this 