### PR TITLE
filter ads from terminal feeds and threads

### DIFF
--- a/pkg/api/conversation.go
+++ b/pkg/api/conversation.go
@@ -138,7 +138,7 @@ func parseConversation(payload any, focalID string) ConversationPage {
 
 	parseEntry := func(raw any) {
 		entry, ok := raw.(map[string]any)
-		if !ok {
+		if !ok || isPromotedEntry(entry) {
 			return
 		}
 		content, _ := entry["content"].(map[string]any)
@@ -154,6 +154,9 @@ func parseConversation(payload any, focalID string) ConversationPage {
 				}
 			}
 		}
+		if isPromotedEntry(content) {
+			return
+		}
 		parseCursor(content)
 		if item, ok := content["itemContent"].(map[string]any); ok {
 			parseCursor(item)
@@ -162,9 +165,15 @@ func parseConversation(payload any, focalID string) ConversationPage {
 		if items, ok := content["items"].([]any); ok {
 			for _, rawItem := range items {
 				moduleItem, _ := rawItem.(map[string]any)
+				if isPromotedEntry(moduleItem) {
+					continue
+				}
 				item, _ := moduleItem["item"].(map[string]any)
 				if item == nil {
 					item = moduleItem
+				}
+				if isPromotedEntry(item) {
+					continue
 				}
 				if itemContent, ok := item["itemContent"].(map[string]any); ok {
 					parseCursor(itemContent)

--- a/pkg/api/timeline.go
+++ b/pkg/api/timeline.go
@@ -182,7 +182,7 @@ func (c *WebClient) fetchTimelineOp(
 func timelineVariables(cursor string, count int) map[string]any {
 	variables := map[string]any{
 		"count":                  count,
-		"includePromotedContent": true,
+		"includePromotedContent": false,
 		"latestControlAvailable": true,
 		"requestContext":         "launch",
 		"seenTweetIds":           []string{},
@@ -261,12 +261,15 @@ func parseEntries(payload any) (posts []TimelinePost, bottomCursor string) {
 
 	parseEntry := func(raw any) {
 		entry, ok := raw.(map[string]any)
-		if !ok {
+		if !ok || isPromotedEntry(entry) {
 			return
 		}
 		content, _ := entry["content"].(map[string]any)
 		if content == nil {
 			content = entry
+		}
+		if isPromotedEntry(content) {
+			return
 		}
 		parseCursor(content)
 		if item, ok := content["itemContent"].(map[string]any); ok {
@@ -276,9 +279,15 @@ func parseEntries(payload any) (posts []TimelinePost, bottomCursor string) {
 		if items, ok := content["items"].([]any); ok {
 			for _, rawItem := range items {
 				moduleItem, _ := rawItem.(map[string]any)
+				if isPromotedEntry(moduleItem) {
+					continue
+				}
 				item, _ := moduleItem["item"].(map[string]any)
 				if item == nil {
 					item = moduleItem
+				}
+				if isPromotedEntry(item) {
+					continue
 				}
 				if itemContent, ok := item["itemContent"].(map[string]any); ok {
 					parseCursor(itemContent)
@@ -312,7 +321,7 @@ func parseEntries(payload any) (posts []TimelinePost, bottomCursor string) {
 }
 
 func parseTimelineItem(item map[string]any) (TimelinePost, bool) {
-	if _, promoted := item["promoted_metadata"]; promoted {
+	if isPromotedEntry(item) {
 		return TimelinePost{}, false
 	}
 	tweetResults, _ := item["tweet_results"].(map[string]any)
@@ -439,4 +448,15 @@ func intValue(value any) int {
 		return int(result)
 	}
 	return 0
+}
+
+// Inspect only placement metadata, never post text or quoted posts.
+func isPromotedEntry(item map[string]any) bool {
+	for _, key := range []string{"promotedMetadata", "promoted_metadata"} {
+		if value, exists := item[key]; exists && value != nil {
+			return true
+		}
+	}
+	id, _ := item["entryId"].(string)
+	return strings.HasPrefix(id, "promoted-")
 }

--- a/pkg/api/timeline_test.go
+++ b/pkg/api/timeline_test.go
@@ -140,3 +140,42 @@ func TestParseTimelinePreservesDirectAndModuleItemOrderAndShowMoreCursor(t *test
 		}
 	}
 }
+
+func TestPromotedPlacementsFilteredWithoutLosingOrganicPostsOrCursor(t *testing.T) {
+	fixture := `{"entries":[
+  {"entryId":"promoted-tweet-1","content":{"itemContent":{"tweet_results":{"result":{"rest_id":"1","legacy":{"full_text":"ad","in_reply_to_status_id_str":"organic"}}}}}},
+  {"content":{"itemContent":{"promotedMetadata":{},"tweet_results":{"result":{"rest_id":"2","legacy":{"full_text":"ad","in_reply_to_status_id_str":"organic"}}}}}},
+  {"content":{"items":[
+   {"entryId":"promoted-tweet-3","item":{"itemContent":{"tweet_results":{"result":{"rest_id":"3","legacy":{"full_text":"ad","in_reply_to_status_id_str":"organic"}}}}}},
+   {"item":{"itemContent":{"promotedMetadata":{},"tweet_results":{"result":{"rest_id":"4","legacy":{"full_text":"ad","in_reply_to_status_id_str":"organic"}}}}}},
+   {"item":{"itemContent":{"tweet_results":{"result":{"rest_id":"organic","legacy":{"full_text":"I am discussing ads and promotedMetadata"}}}}}}
+  ]}},
+  {"content":{"itemContent":{"promotedMetadata":null,"tweet_results":{"result":{"rest_id":"normal","legacy":{"full_text":"regular post"}}}}}},
+  {"content":{"cursorType":"Bottom","value":"next-page"}}
+ ]}`
+	var payload any
+	if err := json.Unmarshal([]byte(fixture), &payload); err != nil {
+		t.Fatal(err)
+	}
+	page := parseTimeline(payload)
+	if len(page.Posts) != 2 || page.Posts[0].ID != "organic" || page.Posts[1].ID != "normal" || page.Cursor != "next-page" {
+		t.Fatalf("page=%+v", page)
+	}
+	conversation := parseConversation(payload, "organic")
+	if conversation.Cursor != "next-page" {
+		t.Fatalf("conversation cursor=%q", conversation.Cursor)
+	}
+	// The focal post remains available after filtering module siblings.
+	if len(conversation.Posts) != 1 || conversation.Posts[0].ID != "organic" || len(conversation.Unresolved) != 0 {
+		t.Fatalf("conversation=%+v", conversation)
+	}
+}
+
+func TestTimelineRequestsExcludePromotedContent(t *testing.T) {
+	for _, cursor := range []string{"", "next-page"} {
+		variables := timelineVariables(cursor, 20)
+		if variables["includePromotedContent"] != false {
+			t.Fatal("timeline requested ads")
+		}
+	}
+}


### PR DESCRIPTION
filter promoted posts from feeds and threads while preserving regular posts and pagination; race tests, build, and vet pass.
