### PR TITLE
Remove unused sendReply wrapper

### DIFF
--- a/internal/timeline/reply.go
+++ b/internal/timeline/reply.go
@@ -18,10 +18,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-func sendReply(parent context.Context, tweetID, text string, attachments ...media.Attachment) tea.Cmd {
-	return sendReplyOrQuote(parent, tweetID, text, false, attachments...)
-}
-
 func sendReplyOrQuote(parent context.Context, tweetID, text string, quote bool, attachments ...media.Attachment) tea.Cmd {
 	attachments = append([]media.Attachment(nil), attachments...)
 	return func() tea.Msg {


### PR DESCRIPTION
Staticcheck flags the obsolete sendReply wrapper as U1000 after reply and quote posting were consolidated through sendReplyOrQuote. Remove the unused wrapper so CI passes.\n\nVerified with staticcheck, go build, go vet, and go test -race ./....