### PR TITLE
release v0.1.12

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -20,7 +20,7 @@ in
 (buildGoModule.override { go = go_1_26_6; }) (finalAttrs: {
   pname = "xeet";
   # Keep in step with the latest release tag.
-  version = "0.1.11";
+  version = "0.1.12";
 
   src = lib.cleanSource ./.;
 


### PR DESCRIPTION
Bump the Nix package version to 0.1.12 to match the upcoming release tag. The existing vendor hash already covers the merged dependency updates and was verified by a clean Nix build and its tests.

The release will include the merged profile, quote, long-post, feed, and WSL changes since v0.1.11. Release archives and checksums are generated by the tag workflow; the Homebrew source checksum will be updated from the published tag archive.
